### PR TITLE
feat: Gate release PRs on bundled categories freshness

### DIFF
--- a/.github/workflows/release-freshness.yml
+++ b/.github/workflows/release-freshness.yml
@@ -1,0 +1,37 @@
+name: Release freshness
+
+# Release gate: PRs into master must ship a bundled categories.json at least
+# as new as CaskKit's latest data release. Fix is one command:
+#   ./Scripts/sync_bundled_categories.sh && git commit -am "Sync bundled categories"
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  bundled-categories:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare bundled categories.json with CaskKit's latest release
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/latest.json \
+            "https://github.com/alielsokary/CaskKit/releases/latest/download/categories.json"
+          python3 - << 'EOF'
+          import json, sys
+
+          bundled = json.load(open("CaskHub/Resources/categories.json"))
+          latest = json.load(open("/tmp/latest.json"))
+          b, l = bundled["generatedDate"], latest["generatedDate"]
+          print(f"bundled: {b} ({bundled['totalCasks']} casks)")
+          print(f"latest:  {l} ({latest['totalCasks']} casks)")
+          if b < l:
+              print("\n::error::Bundled categories.json is stale. Run "
+                    "Scripts/sync_bundled_categories.sh and commit before releasing.")
+              sys.exit(1)
+          print("bundled data is current ✓")
+          EOF


### PR DESCRIPTION
Turns the "remember to run sync_bundled_categories.sh before releasing" checklist item into a CI check that can't be forgotten: PRs targeting `master` fail when the bundled `categories.json`'s `generatedDate` is older than CaskKit's `releases/latest`. Error message names the one-command fix. No event-input interpolation in run blocks.