### PR TITLE
chore: Ignore local Claude tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Local Claude tooling and exports — not part of the app
+skills/
+.claude-plugin/
+*.txt


### PR DESCRIPTION
Follow-up to the git-filter-repo purge of `skills/`, `.claude-plugin/`, and an accidentally-committed conversation export: these stay local-only via .gitignore. Old feature branches carrying the pre-rewrite history are deleted.