### PR TITLE
feat: Original icons only: drop favicon and avatar tiers

### DIFF
--- a/CaskHub/Models/CaskIconURL.swift
+++ b/CaskHub/Models/CaskIconURL.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+/// Icon sources, all original app icons keyed by cask token — no generated
+/// fallbacks (favicons, avatars). Casks without an extracted icon show the
+/// placeholder until CaskKit's daily pipeline picks them up.
 enum CaskIconURL {
     /// Original app icons extracted by CaskKit (icons branch, keyed by token).
     /// jsDelivr edge CDN first, raw.githubusercontent.com as fallback.
@@ -17,52 +20,10 @@ enum CaskIconURL {
         ].compactMap { $0 }
     }
 
-    /// High-quality app icon from App-Fair/appcasks GitHub releases (~74% coverage of pre-2022 casks)
-    static func appIconURL(for token: String) -> URL? {
+    /// App-Fair/appcasks GitHub releases — also original icons, but frozen
+    /// pre-2022. Covers some casks CaskKit can't extract (EULA walls, dead
+    /// vendor URLs that worked back then).
+    static func appFairIconURL(for token: String) -> URL? {
         URL(string: "https://github.com/App-Fair/appcasks/releases/download/cask-\(token)/AppIcon.png")
-    }
-
-    /// GitHub owner extracted from homepage or download URL — caller should verify it's an org before using the avatar
-    static func gitHubOwner(homepage: String, downloadURL: String?) -> String? {
-        if let owner = extractGitHubOwner(from: homepage) {
-            return owner
-        }
-        if let downloadURL, let owner = extractGitHubOwner(from: downloadURL) {
-            return owner
-        }
-        return nil
-    }
-
-    /// GitHub owner avatar — only meaningful for organizations (personal accounts return developer faces)
-    static func gitHubAvatarURL(for owner: String) -> URL? {
-        URL(string: "https://github.com/\(owner).png?size=128")
-    }
-
-    /// High-quality favicon via icon.horse (returns 404 on missing favicon, unlike Google's generic globe)
-    static func faviconURL(for homepage: String) -> URL? {
-        guard let host = URL(string: homepage)?.host else { return nil }
-        // Skip shared platform domains — their favicons are generic
-        let sharedDomains: Set<String> = [
-            "github.com", "sourceforge.net", "aka.ms",
-            "bitbucket.org", "gitlab.com", "codeberg.org"
-        ]
-        guard !sharedDomains.contains(host) else { return nil }
-        return URL(string: "https://icon.horse/icon/\(host)")
-    }
-
-    // MARK: - Private
-
-    /// Extracts the GitHub owner from URLs like "https://github.com/{owner}/..."
-    private static func extractGitHubOwner(from urlString: String) -> String? {
-        guard let url = URL(string: urlString),
-              url.host == "github.com" || url.host == "www.github.com" else {
-            return nil
-        }
-        let pathComponents = url.pathComponents
-        // pathComponents[0] is "/", [1] is the owner
-        guard pathComponents.count >= 2 else { return nil }
-        let owner = pathComponents[1]
-        guard !owner.isEmpty, owner != "downloads" else { return nil }
-        return owner
     }
 }

--- a/CaskHub/Services/ImageCacheService.swift
+++ b/CaskHub/Services/ImageCacheService.swift
@@ -16,7 +16,6 @@ final class ImageCacheService {
     private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
     private var upgradeInFlight: Set<String> = []
     private let session: URLSession
-    private var ownerTypeCache: [String: Bool] = [:] // owner -> isOrg
 
     /// How long a full-chain miss suppresses re-fetching. Misses re-try daily
     /// so users pick up newly backfilled CaskKit icons without launch chatter.
@@ -29,21 +28,10 @@ final class ImageCacheService {
         return dir
     }()
 
-    private static let ownerTypeCachePath: URL = {
-        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-        return caches.appendingPathComponent("CaskHub/github_owner_types.json")
-    }()
-
-    /// Shared session that doesn't follow redirects — used to inspect github.com/orgs/{owner} status codes
-    private static let noRedirectSession: URLSession = {
-        URLSession(configuration: .ephemeral, delegate: NoRedirectDelegate.shared, delegateQueue: nil)
-    }()
-
     init(session: URLSession = .shared) {
         self.session = session
         memoryCache.countLimit = 500
-        ownerTypeCache = Self.loadOwnerTypeCache()
-        Self.migrateUntieredCacheIfNeeded()
+        Self.purgeGeneratedIconsIfNeeded()
     }
 
     func image(for cask: Cask) async -> NSImage? {
@@ -94,29 +82,16 @@ final class ImageCacheService {
                 }
             }
 
-            // Tier 1: App-Fair app icon (original icons, stale — pre-2022 coverage)
-            if let url = CaskIconURL.appIconURL(for: token),
+            // Tier 1: App-Fair app icon (also original; frozen pre-2022 —
+            // covers some casks CaskKit can't extract today)
+            if let url = CaskIconURL.appFairIconURL(for: token),
                let image = await fetch(url) {
                 cache(image: image, token: token)
                 return image
             }
 
-            // Tier 2: Homepage favicon via icon.horse (best for apps with dedicated websites)
-            if let url = CaskIconURL.faviconURL(for: cask.homepage),
-               let image = await fetch(url) {
-                cache(image: image, token: token)
-                return image
-            }
-
-            // Tier 3: GitHub org avatar only (skip personal accounts — their avatars are faces, not app icons)
-            if let owner = CaskIconURL.gitHubOwner(homepage: cask.homepage, downloadURL: cask.url),
-               await isGitHubOrganization(owner: owner),
-               let url = CaskIconURL.gitHubAvatarURL(for: owner),
-               let image = await fetch(url) {
-                cache(image: image, token: token)
-                return image
-            }
-
+            // No generated fallbacks (favicons, avatars) — by design the
+            // placeholder shows until an original icon exists.
             if sawHTTPResponse {
                 markMiss(token: token)
             }
@@ -195,24 +170,31 @@ final class ImageCacheService {
         }
     }
 
-    /// One-time migration: icons cached before tier tracking existed get a
-    /// backdated fallback marker, making them upgrade-eligible immediately.
-    private nonisolated static func migrateUntieredCacheIfNeeded() {
+    /// One-time migration: purge cached icons that predate the original-only
+    /// chain. Anything carrying a fallback marker (or unmarked from before
+    /// tier tracking) may be a favicon/avatar — delete it and let the cask
+    /// refetch through CaskKit → App-Fair. CaskKit-tier caches are unmarked
+    /// only if fetched after tier tracking, so we key off the v1 flag:
+    /// pre-tracking installs purge everything marked or migrated.
+    private nonisolated static func purgeGeneratedIconsIfNeeded() {
         Task.detached(priority: .utility) {
             let dir = await Self.cacheDirectory
-            let flag = dir.appendingPathComponent(".tier-migration-done")
+            let flag = dir.appendingPathComponent(".generated-purge-done")
             guard !FileManager.default.fileExists(atPath: flag.path) else { return }
             let files = (try? FileManager.default.contentsOfDirectory(
                 at: dir, includingPropertiesForKeys: nil)) ?? []
-            let epoch = Date(timeIntervalSince1970: 0)
-            for file in files where file.pathExtension == "png" {
-                let token = file.deletingPathExtension().lastPathComponent
-                let marker = dir.appendingPathComponent("\(token).fallback")
-                guard !FileManager.default.fileExists(atPath: marker.path) else { continue }
-                try? Data().write(to: marker, options: .atomic)
-                try? FileManager.default.setAttributes(
-                    [.modificationDate: epoch], ofItemAtPath: marker.path)
+            for marker in files where marker.pathExtension == "fallback" {
+                let token = marker.deletingPathExtension().lastPathComponent
+                try? FileManager.default.removeItem(
+                    at: dir.appendingPathComponent("\(token).png"))
+                try? FileManager.default.removeItem(at: marker)
             }
+            // Retired artifacts from the avatar tier and the v1 migration.
+            try? FileManager.default.removeItem(
+                at: dir.deletingLastPathComponent()
+                    .appendingPathComponent("github_owner_types.json"))
+            try? FileManager.default.removeItem(
+                at: dir.appendingPathComponent(".tier-migration-done"))
             try? Data().write(to: flag, options: .atomic)
         }
     }
@@ -262,70 +244,4 @@ final class ImageCacheService {
         }
     }
 
-    // MARK: - GitHub Organization Check
-
-    /// Checks if a GitHub owner is an Organization (not a personal account).
-    /// Uses HEAD request to github.com/orgs/{owner} — 302 = org, 404 = user.
-    /// No API rate limits. Only definitive results are cached, so transient network failures won't permanently blacklist an owner.
-    private func isGitHubOrganization(owner: String) async -> Bool {
-        if let cached = ownerTypeCache[owner] {
-            return cached
-        }
-
-        guard let isOrg = await checkGitHubOrgStatus(owner: owner) else {
-            // Network error or unexpected status — don't cache, retry next time
-            return false
-        }
-        ownerTypeCache[owner] = isOrg
-        persistOwnerTypeCache()
-        return isOrg
-    }
-
-    /// Returns true for org, false for user, nil for network error or unexpected status (don't cache)
-    private func checkGitHubOrgStatus(owner: String) async -> Bool? {
-        guard let url = URL(string: "https://github.com/orgs/\(owner)") else { return nil }
-        var request = URLRequest(url: url)
-        request.httpMethod = "HEAD"
-        guard let (_, response) = try? await Self.noRedirectSession.data(for: request),
-              let httpResponse = response as? HTTPURLResponse else {
-            return nil
-        }
-        switch httpResponse.statusCode {
-        case 302: return true   // organization (redirects to org page)
-        case 404: return false  // personal user
-        default:  return nil    // unexpected — don't cache
-        }
-    }
-
-    private func persistOwnerTypeCache() {
-        let cache = ownerTypeCache
-        let path = Self.ownerTypeCachePath
-        Task.detached(priority: .utility) {
-            guard let data = try? JSONEncoder().encode(cache) else { return }
-            try? data.write(to: path, options: .atomic)
-        }
-    }
-
-    private static func loadOwnerTypeCache() -> [String: Bool] {
-        guard let data = try? Data(contentsOf: ownerTypeCachePath),
-              let cache = try? JSONDecoder().decode([String: Bool].self, from: data) else {
-            return [:]
-        }
-        return cache
-    }
-}
-
-/// Prevents URLSession from following redirects so we can inspect the status code
-private final class NoRedirectDelegate: NSObject, URLSessionTaskDelegate, Sendable {
-    static let shared = NoRedirectDelegate()
-
-    func urlSession(
-        _ session: URLSession,
-        task: URLSessionTask,
-        willPerformHTTPRedirection response: HTTPURLResponse,
-        newRequest request: URLRequest,
-        completionHandler: @escaping (URLRequest?) -> Void
-    ) {
-        completionHandler(nil) // Don't follow redirect
-    }
 }


### PR DESCRIPTION
The end state the icon pipeline was built for — **no generated icons**, per the spec's CaskHub follow-up section:

- Chain is now: **CaskKit** (jsDelivr → raw fallback) → **App-Fair** (also original icons; frozen pre-2022, still covers some casks CaskKit can't extract — EULA walls, dead vendor URLs that worked back then) → **placeholder**
- Deleted: icon.horse favicon tier, GitHub org-avatar tier, and its whole apparatus (org HEAD-check with no-redirect session, persisted owner-type cache) — **−123 net lines**
- One-time migration purges disk-cached fallback-tier icons (`.fallback`-marked), so existing installs shed favicons/avatars and refetch through the new chain; retires `github_owner_types.json` and the v1 migration flag
- Kept: miss cooldown, fallback→CaskKit daily upgrade (App-Fair icons still upgrade as CaskKit coverage grows)

Behavior change to expect: casks with no original icon anywhere (~10% of main casks) now show the placeholder instead of a favicon — that's the design goal, and they self-heal as the daily pipeline extends coverage.