### PR TITLE
feat: Enhance Browse page sections, search submit flow

### DIFF
--- a/CaskHub/ContentView.swift
+++ b/CaskHub/ContentView.swift
@@ -20,6 +20,7 @@ struct ContentView: View {
     @State private var selectedSidebar: SidebarSelection = .discover(.browse)
     @State private var viewMode: ViewMode = .grid
     @FocusState private var searchFocused: Bool
+    @State private var showsResultsHeader = false
 
     // Fixed 4-column grid from the design mock (cards never reflow wider).
     private let columns = Array(
@@ -66,13 +67,28 @@ struct ContentView: View {
                     onSelectPeriod: { period in
                         Task { await viewModel.selectAnalyticsPeriod(period) }
                     },
-                    showsSort: selectedSidebar != .discover(.featured)
+                    // Sections have a fixed popularity order; sorting is a no-op there.
+                    showsSort: selectedSidebar != .discover(.featured) && !showsBrowseSections,
+                    onSubmitSearch: {
+                        searchFocused = false
+                        showsResultsHeader = !viewModel.searchText.isEmpty
+                    }
                 )
                 // Never wider than the card grid below it, centered to match.
                 .frame(maxWidth: CHSize.contentWidth)
                 .padding(.horizontal, CHSpace.s5)
                 .frame(maxWidth: .infinity)
                 .padding(.top, CHSpace.s4)
+
+                if showsResultsHeader {
+                    Text("Results for “\(viewModel.searchText)”")
+                        .font(CHType.section)
+                        .foregroundStyle(Color.chTextTitle)
+                        .frame(maxWidth: CHSize.contentWidth, alignment: .leading)
+                        .padding(.horizontal, CHSpace.s5)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, CHSpace.s4)
+                }
 
                 detailContent
             }
@@ -113,6 +129,19 @@ struct ContentView: View {
                 Task { await viewModel.selectAnalyticsPeriod(viewModel.analyticsPeriod) }
             }
         }
+        .onChange(of: viewModel.searchText) { _, newValue in
+            if newValue.isEmpty {
+                // Only drop focus when clearing a submitted search — while
+                // still composing (backspaced to empty), keep the field active.
+                if showsResultsHeader { searchFocused = false }
+                showsResultsHeader = false
+            }
+        }
+        .onAppear {
+            // AppKit hands the window's initial key focus to the first text
+            // field; take it back so the search field only activates via ⌘F.
+            DispatchQueue.main.async { searchFocused = false }
+        }
     }
 
     // MARK: - Detail Content
@@ -146,9 +175,16 @@ struct ContentView: View {
 
     /// House pick: shown on Browse when not searching.
     private var heroCask: Cask? {
-        guard case .discover(.browse) = selectedSidebar,
-              viewModel.searchText.isEmpty else { return nil }
+        guard showsBrowseSections else { return nil }
         return viewModel.filteredCasks.first
+    }
+
+    /// Browse shows titled shelves instead of the flat grid — unless searching,
+    /// where a flat result grid is more useful. List mode stays a flat list.
+    private var showsBrowseSections: Bool {
+        selectedSidebar == .discover(.browse)
+            && viewModel.searchText.isEmpty
+            && viewMode == .grid
     }
 
     private func categoryInfo(for cask: Cask) -> (id: String, name: String)? {
@@ -168,15 +204,12 @@ struct ContentView: View {
                         categoryName: categoryInfo(for: hero)?.name
                     )
                 }
-                LazyVGrid(columns: columns, alignment: .leading, spacing: CHSpace.gridGap) {
-                    ForEach(gridCasks) { cask in
-                        CaskCardView(
-                            cask: cask,
-                            downloads: viewModel.formattedDownloads(for: cask.token),
-                            category: categoryInfo(for: cask),
-                            onSelectCategory: { selectedSidebar = .category($0) }
-                        )
+                if showsBrowseSections {
+                    ForEach(viewModel.browseSections) { section in
+                        browseSectionView(section)
                     }
+                } else {
+                    caskGrid(viewModel.filteredCasks)
                 }
             }
             .frame(width: CHSize.contentWidth, alignment: .leading)
@@ -185,10 +218,43 @@ struct ContentView: View {
         }
         .contentMargins(.bottom, 44, for: .scrollContent)
         .scrollContentBackground(.hidden)
+        // Recreate the scroll view per sidebar selection so navigating
+        // (View All, sidebar clicks) always lands at the top.
+        .id(selectedSidebar)
     }
 
-    private var gridCasks: [Cask] {
-        heroCask == nil ? viewModel.filteredCasks : Array(viewModel.filteredCasks.dropFirst())
+    private func caskGrid(_ casks: [Cask]) -> some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: CHSpace.gridGap) {
+            ForEach(casks) { cask in
+                CaskCardView(
+                    cask: cask,
+                    downloads: viewModel.formattedDownloads(for: cask.token),
+                    category: categoryInfo(for: cask),
+                    onSelectCategory: { selectedSidebar = .category($0) }
+                )
+            }
+        }
+    }
+
+    private func browseSectionView(_ section: BrowseSection) -> some View {
+        VStack(alignment: .leading, spacing: CHSpace.s3) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(section.title)
+                    .font(CHType.section)
+                    .foregroundStyle(Color.chTextTitle)
+                Spacer()
+                Button {
+                    selectedSidebar = section.destination
+                } label: {
+                    Text("View All")
+                        .font(CHType.button)
+                        .foregroundStyle(Color.chTextBrand)
+                }
+                .buttonStyle(.plain)
+            }
+            caskGrid(section.casks)
+        }
+        .padding(.top, CHSpace.s3)
     }
 
     // MARK: - List View
@@ -202,6 +268,7 @@ struct ContentView: View {
         }
         .contentMargins(.bottom, 44, for: .scrollContent)
         .scrollContentBackground(.hidden)
+        .id(selectedSidebar)
     }
 
     // MARK: - Error View

--- a/CaskHub/DesignSystem/Components/StatusBarView.swift
+++ b/CaskHub/DesignSystem/Components/StatusBarView.swift
@@ -56,7 +56,7 @@ struct StatusBarView: View {
         var parts: [String] = []
         if let brewVersion { parts.append("brew \(brewVersion)") }
         parts.append("tap homebrew/cask")
-        parts.append("\(caskCount) casks")
+        parts.append("\(caskCount.formatted()) casks")
         return parts.joined(separator: " · ")
     }
 }

--- a/CaskHub/DesignSystem/Components/TopBarView.swift
+++ b/CaskHub/DesignSystem/Components/TopBarView.swift
@@ -21,6 +21,8 @@ struct TopBarView: View {
     var onSelectPeriod: ((AnalyticsPeriod) -> Void)?
     /// Hidden on Featured — that list is curated, sorting doesn't apply.
     var showsSort = true
+    /// Called when the user presses Return in the search field.
+    var onSubmitSearch: (() -> Void)?
 
     @State private var showSortMenu = false
     @State private var showPeriodMenu = false
@@ -214,6 +216,7 @@ struct TopBarView: View {
                 .font(CHType.field)
                 .foregroundStyle(Color.chTextTitle)
                 .focused(searchFocus)
+                .onSubmit { onSubmitSearch?() }
             Keycap(symbol: "⌘F")
         }
         .padding(.vertical, 5)

--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -8,6 +8,15 @@
 import Foundation
 import Observation
 
+/// One shelf on the Browse page: a titled row group with a "View All" destination.
+struct BrowseSection: Identifiable {
+    let title: String
+    let destination: SidebarSelection
+    let casks: [Cask]
+
+    var id: String { destination.id }
+}
+
 enum SortOption: String, CaseIterable, Identifiable {
     case mostPopular = "Most Popular"
     case nameAZ = "Name (A→Z)"
@@ -23,7 +32,7 @@ final class CaskCatalogViewModel {
     private(set) var isLoading = false
     private(set) var errorMessage: String?
     private var analyticsByPeriod: [AnalyticsPeriod: [String: Int]] = [:]
-    private(set) var analyticsPeriod: AnalyticsPeriod = .days30
+    private(set) var analyticsPeriod: AnalyticsPeriod = .days365
     var searchText = ""
 
     /// Top Charts respects the picked period; every other section stays on 365d.
@@ -76,6 +85,47 @@ final class CaskCatalogViewModel {
         return categoryService.categoryTokenSets.mapValues {
             $0.intersection(catalogTokens).count
         }
+    }
+
+    // MARK: - Browse Sections
+
+    /// Cards per Browse shelf: two rows of the fixed 4-column grid.
+    private static let browseSectionSize = 8
+
+    /// Shelves for the Browse page: Most Popular, Recently Added, then every
+    /// category except "other" — each holding its top casks by 365d downloads.
+    var browseSections: [BrowseSection] {
+        let counts = analyticsByPeriod[.days365] ?? [:]
+        func top(_ source: [Cask]) -> [Cask] {
+            Array(
+                source
+                    .sorted { (counts[$0.token] ?? 0) > (counts[$1.token] ?? 0) }
+                    .prefix(Self.browseSectionSize)
+            )
+        }
+
+        let recentTokens = recentlyAddedTracker.recentTokens()
+        var sections = [
+            BrowseSection(
+                title: "Most Popular",
+                destination: .discover(.topCharts),
+                casks: top(casks)
+            ),
+            BrowseSection(
+                title: "Recently Added",
+                destination: .discover(.recentlyAdded),
+                casks: top(casks.filter { recentTokens.contains($0.token) })
+            )
+        ]
+        for entry in categoryService.orderedCategories where entry.id != "other" {
+            let tokens = categoryService.tokens(in: entry.id)
+            sections.append(BrowseSection(
+                title: entry.definition.displayName,
+                destination: .category(entry.id),
+                casks: top(casks.filter { tokens.contains($0.token) })
+            ))
+        }
+        return sections.filter { !$0.casks.isEmpty }
     }
 
     // MARK: - Filtered Casks (3-stage pipeline)


### PR DESCRIPTION
## Summary
- Browse renders titled shelves — **Most Popular**, **Recently Added**, then every category except *Other* — each showing its top 8 casks (two rows) ranked by 365d downloads, with a **View All** button that navigates to the matching sidebar destination (Most Popular → Top Charts).
- Top Charts now defaults to the **Year** analytics period instead of 30 Days (data already loaded at launch, so no extra fetch).
- Search field no longer steals initial key focus; it activates only via ⌘F. Return commits the search, drops focus, and shows a *Results for "…"* header under the top bar. Clearing a submitted search also drops focus, while backspacing mid-composition keeps the field active.
- Sidebar navigation (including View All) resets the content scroll to top.
- Status bar cask count uses thousands separators, matching the top bar.

## Testing
- `xcodebuild -scheme CaskHub` Debug build succeeds after each change.