### PR TITLE
feat: Install phase states, cancellable downloads, and CLI cask tiles

### DIFF
--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -18,7 +18,7 @@ struct CaskActionsView: View {
 
     var body: some View {
         if let inFlight = localHomebrew.inFlightActions[cask.token] {
-            inFlightCapsule(label: inFlight.inProgressLabel)
+            inFlightCapsule(for: inFlight)
         } else if let installation = localHomebrew.installedCasks[cask.token] {
             installedActions(for: installation)
         } else {
@@ -65,12 +65,35 @@ struct CaskActionsView: View {
         }
     }
 
-    private func inFlightCapsule(label: String) -> some View {
-        HStack(spacing: 6) {
+    private func inFlightCapsule(for action: CaskAction) -> some View {
+        let token = cask.token
+        let isCanceling = localHomebrew.cancelRequested.contains(token)
+        let canCancel = localHomebrew.cancellableDownloads.contains(token) && !isCanceling
+        let label = isCanceling
+            ? "Canceling…"
+            : (canCancel ? "Downloading…" : action.inProgressLabel)
+
+        return HStack(spacing: 6) {
             ProgressView().controlSize(.small)
             Text(label)
                 .font(CHType.bodySm)
                 .foregroundStyle(Color.chTextBody)
+            if canCancel {
+                Spacer(minLength: 0)
+                Button {
+                    localHomebrew.cancelInstall(token: token)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(Color.chTextBody)
+                        .padding(4)
+                        .background(Circle().fill(Color.chSurfaceField))
+                        .overlay(Circle().strokeBorder(Color.chHairline, lineWidth: 1))
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .help("Cancel download")
+            }
         }
         .frame(maxWidth: fullWidth ? .infinity : nil)
         .padding(.vertical, 5)

--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -7,6 +7,32 @@
 
 import Foundation
 
+/// One `artifacts` stanza from the brew API — heterogeneous single-key
+/// objects ({"app": [...]}, {"binary": [...]}); only the keys matter here.
+struct ArtifactStanza: Codable, Hashable {
+    let keys: Set<String>
+
+    private struct AnyKey: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { nil }
+    }
+
+    init(from decoder: Decoder) throws {
+        // Lenient: a malformed stanza must not sink the whole catalog decode.
+        keys = Set((try? decoder.container(keyedBy: AnyKey.self))?
+            .allKeys.map(\.stringValue) ?? [])
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyKey.self)
+        for key in keys {
+            try container.encode(true, forKey: AnyKey(stringValue: key)!)
+        }
+    }
+}
+
 struct Cask: Codable, Identifiable, Hashable {
     let token: String
     let fullToken: String?
@@ -23,8 +49,25 @@ struct Cask: Codable, Identifiable, Hashable {
     let deprecated: Bool
     let disabled: Bool
     let autoUpdates: Bool?
+    var artifacts: [ArtifactStanza]? = nil
 
     var id: String { token }
+
+    /// Ships a command-line `binary` (or a `stage_only` payload like sqlcl)
+    /// and nothing GUI (no app/suite/pkg). The binary/stage requirement keeps
+    /// installer-app GUI casks (autodesk-fusion, logi-options+) off the CLI
+    /// treatment; pkg-based CLIs (git-credential-manager, ibm-cloud-cli)
+    /// stay non-CLI and keep their real icons.
+    ///
+    /// Drives only the placeholder: CLI casks show a terminal tile instead
+    /// of the window glyph. Which CLI casks get real icons anyway (Android
+    /// SDK tools, tuist, conda family) is CaskKit's call — whatever its
+    /// icons branch serves wins over the tile.
+    var isCLI: Bool {
+        guard let artifacts, !artifacts.isEmpty else { return false }
+        return artifacts.contains { !$0.keys.isDisjoint(with: ["binary", "stageOnly", "stage_only"]) }
+            && !artifacts.contains { !$0.keys.isDisjoint(with: ["app", "suite", "pkg"]) }
+    }
 
     var displayName: String {
         name.first ?? token

--- a/CaskHub/Services/ImageCacheService.swift
+++ b/CaskHub/Services/ImageCacheService.swift
@@ -83,8 +83,11 @@ final class ImageCacheService {
             }
 
             // Tier 1: App-Fair app icon (also original; frozen pre-2022 —
-            // covers some casks CaskKit can't extract today)
-            if let url = CaskIconURL.appFairIconURL(for: token),
+            // covers some casks CaskKit can't extract today). Skipped for
+            // CLI casks: their icon policy is CaskKit's alone — anything
+            // else falls through to the app's CLI tile.
+            if !cask.isCLI,
+               let url = CaskIconURL.appFairIconURL(for: token),
                let image = await fetch(url) {
                 cache(image: image, token: token)
                 return image

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -80,6 +80,16 @@ final class LocalHomebrewService {
     /// Token → currently-running action, used by views to show spinners and disable buttons.
     private(set) var inFlightActions: [String: CaskAction] = [:]
 
+    /// Tokens whose install is still in the download phase — the only window
+    /// where cancelling is guaranteed residual-free (nothing staged yet).
+    private(set) var cancellableDownloads: Set<String> = []
+
+    /// Tokens the user asked to cancel; cleared when the process exits.
+    private(set) var cancelRequested: Set<String> = []
+
+    /// Token → live brew process, kept for cancellation. Not UI state.
+    @ObservationIgnored private var runningProcesses: [String: Process] = [:]
+
     /// Token → most recent error message from a failed action. Cleared on the next attempt.
     private(set) var actionErrors: [String: String] = [:]
 
@@ -226,58 +236,158 @@ final class LocalHomebrewService {
         try await runMutation(.updating, token: token, args: ["upgrade", "--cask", token])
     }
 
+    /// Cancels an in-flight install. Only honored during the download phase —
+    /// once brew starts staging files, cancelling could leave a broken install.
+    /// Sends SIGINT to brew and its children (curl); escalates to SIGTERM if
+    /// the tree hasn't exited after 5 seconds.
+    func cancelInstall(token: String) {
+        guard cancellableDownloads.contains(token),
+              let process = runningProcesses[token] else { return }
+        cancelRequested.insert(token)
+        cancellableDownloads.remove(token)
+
+        let pid = process.processIdentifier
+        Task.detached(priority: .userInitiated) {
+            Self.signalTree(pid: pid, signal: SIGINT)
+            try? await Task.sleep(for: .seconds(5))
+            if process.isRunning { process.terminate() }
+        }
+    }
+
     // MARK: - Mutation Plumbing
 
     private func runMutation(_ action: CaskAction, token: String, args: [String]) async throws {
         guard inFlightActions[token] == nil else { return }
         inFlightActions[token] = action
         actionErrors[token] = nil
-        defer { inFlightActions[token] = nil }
+        let startedAt = Date.now
+        defer {
+            inFlightActions[token] = nil
+            cancellableDownloads.remove(token)
+            runningProcesses[token] = nil
+        }
 
         do {
-            try await Self.runBrew(args: args)
+            try await runBrewStreaming(token: token, args: args, cancellable: action == .installing)
+            cancelRequested.remove(token)
             await refresh()
-        } catch let error as LocalHomebrewError {
-            actionErrors[token] = error.errorDescription
-            throw error
         } catch {
-            actionErrors[token] = error.localizedDescription
+            if cancelRequested.contains(token) {
+                // User cancelled — not an error. Remove the partial download
+                // brew left behind so nothing accumulates in its cache.
+                cancelRequested.remove(token)
+                Task.detached(priority: .utility) {
+                    Self.cleanupIncompleteDownloads(since: startedAt)
+                }
+                await refresh()
+                return
+            }
+            if let error = error as? LocalHomebrewError {
+                actionErrors[token] = error.errorDescription
+            } else {
+                actionErrors[token] = error.localizedDescription
+            }
             throw error
         }
     }
 
-    /// Spawns the `brew` binary off the main actor and waits for it to exit.
-    /// stdout is discarded to `/dev/null` to avoid pipe-buffer deadlocks on chatty
-    /// commands like `brew upgrade`. stderr is captured for error reporting.
-    private nonisolated static func runBrew(args: [String]) async throws {
-        guard let brewURL = locateBrewBinary() else {
+    /// Spawns `brew` attached to a pseudo-terminal and streams its output.
+    ///
+    /// The stream is watched for the `==> Installing Cask` marker that closes
+    /// the safe-to-cancel window. The output tail doubles as stderr for error
+    /// reporting.
+    private func runBrewStreaming(token: String, args: [String], cancellable: Bool) async throws {
+        guard let brewURL = Self.locateBrewBinary() else {
             throw LocalHomebrewError.brewBinaryNotFound
         }
 
-        try await Task.detached(priority: .userInitiated) {
-            let process = Process()
-            process.executableURL = brewURL
-            process.arguments = args
-            process.standardOutput = FileHandle.nullDevice
-            let stderrPipe = Pipe()
-            process.standardError = stderrPipe
+        let process = Process()
+        process.executableURL = brewURL
+        process.arguments = args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        process.standardInput = FileHandle.nullDevice
 
-            try process.run()
-            process.waitUntilExit()
+        try process.run()
+        runningProcesses[token] = process
+        if cancellable { cancellableDownloads.insert(token) }
 
-            let stderr = String(
-                data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
-                encoding: .utf8
-            ) ?? ""
+        let handle = pipe.fileHandleForReading
+        let outputTail = await Task.detached(priority: .userInitiated) { () -> String in
+            var tail = ""
+            while true {
+                let data = handle.availableData
+                guard !data.isEmpty else { break }  // EOF
+                guard let text = String(data: data, encoding: .utf8) else { continue }
+                tail = String((tail + text).suffix(2000))
 
-            if process.terminationStatus != 0 {
-                throw LocalHomebrewError.brewCommandFailed(
-                    args: args,
-                    exitCode: process.terminationStatus,
-                    stderr: stderr
-                )
+                if text.contains("==> Installing Cask") {
+                    // Download finished — cancelling is no longer residual-free.
+                    Task { @MainActor in self.cancellableDownloads.remove(token) }
+                }
             }
+            process.waitUntilExit()
+            return tail
         }.value
+
+        if process.terminationStatus != 0 {
+            throw LocalHomebrewError.brewCommandFailed(
+                args: args,
+                exitCode: process.terminationStatus,
+                stderr: outputTail.components(separatedBy: "\n").suffix(6).joined(separator: "\n")
+            )
+        }
+    }
+
+    /// Sends `signal` to a process and all of its descendants (brew forks curl;
+    /// signalling only brew would leave curl downloading to a dead parent).
+    private nonisolated static func signalTree(pid: Int32, signal: Int32) {
+        let pgrep = Process()
+        pgrep.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        pgrep.arguments = ["-P", "\(pid)"]
+        let stdout = Pipe()
+        pgrep.standardOutput = stdout
+        pgrep.standardError = FileHandle.nullDevice
+        if (try? pgrep.run()) != nil {
+            let data = stdout.fileHandleForReading.readDataToEndOfFile()
+            pgrep.waitUntilExit()
+            let children = String(data: data, encoding: .utf8)?
+                .split(whereSeparator: \.isNewline)
+                .compactMap { Int32($0) } ?? []
+            for child in children {
+                signalTree(pid: child, signal: signal)
+            }
+        }
+        kill(pid, signal)
+    }
+
+    /// Deletes downloads newer than `cutoff` from Homebrew's cache — the only
+    /// residue a download-phase cancel leaves behind. Covers both `*.incomplete`
+    /// partials and just-finished archives (cancel can land after the download
+    /// completed but before staging began).
+    private nonisolated static func cleanupIncompleteDownloads(since cutoff: Date) {
+        let fm = FileManager.default
+        let cacheURL: URL
+        if let override = ProcessInfo.processInfo.environment["HOMEBREW_CACHE"], !override.isEmpty {
+            cacheURL = URL(fileURLWithPath: override)
+        } else {
+            cacheURL = fm.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Caches/Homebrew")
+        }
+        let downloadsURL = cacheURL.appendingPathComponent("downloads", isDirectory: true)
+        guard let files = try? fm.contentsOfDirectory(
+            at: downloadsURL,
+            includingPropertiesForKeys: [.contentModificationDateKey]
+        ) else { return }
+
+        for file in files {
+            let modified = (try? file.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate) ?? .distantPast
+            if modified >= cutoff {
+                try? fm.removeItem(at: file)
+            }
+        }
     }
 
     /// Runs `brew --version` and returns the bare version ("Homebrew 4.6.15" → "4.6.15").

--- a/CaskHub/Views/Shared/CaskIconView.swift
+++ b/CaskHub/Views/Shared/CaskIconView.swift
@@ -20,12 +20,11 @@ struct CaskIconView: View {
 
     var body: some View {
         ZStack {
-            wellShape
-                .fill(Color.chSurfaceField)
-                .overlay(wellShape.strokeBorder(Color.chHairlineStrong, lineWidth: 1))
-                .frame(width: size, height: size)
-
             if let loadedImage {
+                wellShape
+                    .fill(Color.chSurfaceField)
+                    .overlay(wellShape.strokeBorder(Color.chHairlineStrong, lineWidth: 1))
+                    .frame(width: size, height: size)
                 Image(nsImage: loadedImage)
                     .resizable()
                     .interpolation(.high)
@@ -33,7 +32,17 @@ struct CaskIconView: View {
                     .frame(width: size * 0.8, height: size * 0.8)
                     .clipShape(RoundedRectangle(cornerRadius: size * 0.18, style: .continuous))
                     .transition(.opacity)
+            } else if cask.isCLI {
+                // CLI casks hold no icon at the source — a branded terminal
+                // tile is their placeholder. CaskKit's icons branch decides
+                // the exceptions (Android SDK tools, tuist, conda family):
+                // whatever it serves loads like any other icon.
+                cliTile
             } else {
+                wellShape
+                    .fill(Color.chSurfaceField)
+                    .overlay(wellShape.strokeBorder(Color.chHairlineStrong, lineWidth: 1))
+                    .frame(width: size, height: size)
                 Image(systemName: "macwindow")
                     .font(.system(size: size * 0.4))
                     .foregroundStyle(Color.chTextMuted)
@@ -43,6 +52,18 @@ struct CaskIconView: View {
         .task(id: cask.token) {
             loadedImage = await imageCache.image(for: cask)
         }
+    }
+
+    private var cliTile: some View {
+        wellShape
+            .fill(Color.chInk)
+            .overlay(wellShape.strokeBorder(Color.chHairlineStrong, lineWidth: 1))
+            .overlay(
+                Text(">_")
+                    .font(Font.custom(CHType.monoFamily, size: size * 0.34).weight(.bold))
+                    .foregroundStyle(Color.chCream)
+            )
+            .frame(width: size, height: size)
     }
 }
 


### PR DESCRIPTION
## Summary
- **Install streaming**: `brew install` output is now streamed through a pipe; the in-flight capsule shows **Downloading…** until brew prints its `==> Installing Cask` marker, then **Installing…**.
- **Cancel without residue**: a ✕ button appears during the download phase only — the window where aborting can't leave a broken Caskroom entry. Cancel SIGINTs brew and its children (SIGTERM escalation after 5s), deletes any cache files brew touched during that install, and is treated as user intent rather than an error.
- **CLI cask tiles**: casks whose brew artifacts are binary/stage_only with no app/suite/pkg render a branded `>_` terminal tile instead of the generic window placeholder, and skip the App-Fair icon tier (CaskKit's icons branch remains the authority for exceptions).

## Testing
- Cancel verified end-to-end with the compiled service against a real `brew install --cask swiftformat-for-xcode`: SIGINT kills the process tree in ~200ms, app not installed, no download residue.
- Phase marker confirmed present in brew's plain piped output.
- Debug build succeeds.