### PR TITLE
enhancement: Keep a gap between the top bar and scrolled cards

### DIFF
--- a/CaskHub/ContentView.swift
+++ b/CaskHub/ContentView.swift
@@ -83,7 +83,9 @@ struct ContentView: View {
                 .frame(maxWidth: CHSize.contentWidth)
                 .padding(.horizontal, CHSpace.s5)
                 .frame(maxWidth: .infinity)
-                .padding(.top, CHSpace.s4)
+                // Bottom padding sits outside the scroll view, so scrolled
+                // cards clip 16pt below the bar instead of flush against it.
+                .padding(.vertical, CHSpace.s4)
 
                 if showsResultsHeader {
                     Text("Results for “\(viewModel.searchText)”")
@@ -92,7 +94,7 @@ struct ContentView: View {
                         .frame(maxWidth: CHSize.contentWidth, alignment: .leading)
                         .padding(.horizontal, CHSpace.s5)
                         .frame(maxWidth: .infinity)
-                        .padding(.top, CHSpace.s4)
+                        .padding(.bottom, CHSpace.s4)
                 }
 
                 detailContent
@@ -227,7 +229,6 @@ struct ContentView: View {
             }
             .frame(width: CHSize.contentWidth, alignment: .leading)
             .frame(maxWidth: .infinity)
-            .padding(.top, CHSpace.s4)
         }
         .contentMargins(.bottom, 44, for: .scrollContent)
         .scrollContentBackground(.hidden)


### PR DESCRIPTION
Scrolled cards clipped flush against the pill top bar because the scroll view's clip boundary sat exactly at the bar's bottom edge (VStack spacing 0), and the 16pt at-rest gap lived inside the scroll content so it scrolled away.

This moves the gap outside the scroll view:
- Top bar gets vertical padding, so its bottom padding becomes the persistent clip gap.
- The results header's padding moves from top to bottom for the same reason.
- The now-redundant top padding inside the grid's scroll content is removed.

At-rest spacing is unchanged (still 16pt); cards now clip 16pt below the bar while scrolling. The list view shares the same clip line and benefits too.