### PR TITLE
fix: Purge stale CLI icons pinned from before the curated cleanup

### DIFF
--- a/CaskHub/Services/ImageCacheService.swift
+++ b/CaskHub/Services/ImageCacheService.swift
@@ -42,6 +42,12 @@ final class ImageCacheService {
             return cached
         }
 
+        // CLI casks: icons cached before the cutover may since have been
+        // retired by CaskKit's curated CLI tier — drop and refetch once.
+        if cask.isCLI {
+            purgeStaleCLIIcon(token: token)
+        }
+
         // 2. Disk cache — fallback-tier hits also schedule a background
         // CaskKit upgrade check (at most daily), so icons cached from
         // favicon/avatar before CaskKit coverage arrived aren't pinned forever.
@@ -136,6 +142,29 @@ final class ImageCacheService {
             // mtime = now, so the first CaskKit re-check happens tomorrow —
             // CaskKit necessarily missed moments ago on this same chain run.
             try? Data().write(to: fallbackMarkerPath(for: token), options: .atomic)
+        }
+    }
+
+    // MARK: - CLI cutover purge
+
+    /// 2026-07-09 12:00 UTC — CaskKit's curated-CLI icon cleanup plus the
+    /// jsDelivr branch TTL that kept serving the retired files.
+    private static let cliIconCutover = Date(timeIntervalSince1970: 1_783_598_400)
+
+    private func purgeStaleCLIIcon(token: String) {
+        let path = diskPath(for: token)
+        guard let mtime = try? FileManager.default
+            .attributesOfItem(atPath: path.path)[.modificationDate] as? Date,
+            mtime < Self.cliIconCutover else {
+            return
+        }
+        try? FileManager.default.removeItem(at: path)
+        try? FileManager.default.removeItem(at: fallbackMarkerPath(for: token))
+        // jsDelivr's long max-age would replay the retired icon's cached 200
+        // from URLCache — evict so the refetch hits the network.
+        let urlCache = session.configuration.urlCache ?? .shared
+        for url in CaskIconURL.caskKitIconURLs(for: token) {
+            urlCache.removeCachedResponse(for: URLRequest(url: url))
         }
     }
 


### PR DESCRIPTION
## Summary
- **Why the tile regressed**: CaskKit's curated CLI tier retired the icons for CLI-only casks (claude-code, codex, 1password-cli), but the app pins CaskKit-tier disk caches forever ("terminal quality — never re-checked"), so the old icons kept rendering instead of the `>_` tile.
- **Cutover purge**: on lookup, a CLI cask whose cached icon predates 2026-07-09 12:00 UTC (CaskKit cleanup + jsDelivr branch TTL) is dropped and refetched once. A CaskKit re-hit (curated CLI icons) re-caches past the cutover and is never purged again; everything else falls through to the terminal tile.
- **URLCache eviction**: the purge also evicts the CaskKit URLs from URLSession's cache — jsDelivr serves week-long `max-age`, so without eviction the refetch replays the retired icon's cached 200 without touching the network (observed: purged PNGs re-pinned from `Cache.db`).

## Testing
- Verified all three sources (jsDelivr, raw.githubusercontent, App-Fair) now 404 for the retired tokens; jsDelivr edge purged manually.
- Confirmed the pre-fix failure chain live: disk purge fired, refetch re-pinned identical bytes from the app's `Cache.db` URLCache — the eviction closes exactly that path.
- Debug build succeeds.