### PR TITLE
feat: Native admin password prompt for pkg-based casks

### DIFF
--- a/CaskHub/CaskHubApp.swift
+++ b/CaskHub/CaskHubApp.swift
@@ -7,7 +7,45 @@
 
 import SwiftUI
 
+/// Branches before SwiftUI starts: when sudo launches this binary as its
+/// SUDO_ASKPASS helper (`--askpass <token>`), show a native password alert
+/// instead of booting the app.
 @main
+enum CaskHubMain {
+    static func main() {
+        if let flagIndex = CommandLine.arguments.firstIndex(of: "--askpass") {
+            let token = CommandLine.arguments.indices.contains(flagIndex + 1)
+                ? CommandLine.arguments[flagIndex + 1] : nil
+            runAskpassDialog(token: token)
+        }
+        CaskHubApp.main()
+    }
+
+    /// Prints the password to stdout for sudo on "Allow"; exits 1 on cancel
+    /// so sudo — and the brew install — abort cleanly.
+    private static func runAskpassDialog(token: String?) -> Never {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+
+        let alert = NSAlert()
+        alert.messageText = "CaskHub needs administrator access"
+        alert.informativeText = token.map {
+            "The installer for “\($0)” requires your login password."
+        } ?? "This installer requires your login password."
+        alert.addButton(withTitle: "Allow")
+        alert.addButton(withTitle: "Cancel")
+
+        let passwordField = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 230, height: 24))
+        alert.accessoryView = passwordField
+        alert.window.initialFirstResponder = passwordField
+
+        app.activate()
+        guard alert.runModal() == .alertFirstButtonReturn else { exit(1) }
+        print(passwordField.stringValue)
+        exit(0)
+    }
+}
+
 struct CaskHubApp: App {
     @AppStorage("appTheme") private var selectedTheme: String = AppTheme.system.rawValue
 

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -304,6 +304,13 @@ final class LocalHomebrewService {
         let process = Process()
         process.executableURL = brewURL
         process.arguments = args
+        // pkg-based casks run `sudo installer` internally; with no TTY sudo can't
+        // prompt. SUDO_ASKPASS makes brew pass `-A` so sudo asks via our GUI helper.
+        if let askpass = Self.ensureAskpassScript(token: token) {
+            var environment = ProcessInfo.processInfo.environment
+            environment["SUDO_ASKPASS"] = askpass.path
+            process.environment = environment
+        }
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = pipe
@@ -338,6 +345,36 @@ final class LocalHomebrewService {
                 stderr: outputTail.components(separatedBy: "\n").suffix(6).joined(separator: "\n")
             )
         }
+    }
+
+    /// Writes the SUDO_ASKPASS helper: re-execs this binary in `--askpass`
+    /// mode. Rewritten per mutation so the binary path (moves between dev
+    /// builds) and the token stay current.
+    private nonisolated static func ensureAskpassScript(token: String) -> URL? {
+        guard let executablePath = Bundle.main.executableURL?.path else { return nil }
+        // Interpolated into a shell script — keep only known-safe characters.
+        let safeToken = token.filter { $0.isLetter || $0.isNumber || "-_+@.".contains($0) }
+        let script = """
+        #!/bin/sh
+        exec "\(executablePath)" --askpass "\(safeToken)"
+        """
+        let fm = FileManager.default
+        guard let base = try? fm.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) else { return nil }
+        let dir = base.appendingPathComponent("CaskHub", isDirectory: true)
+        let url = dir.appendingPathComponent("askpass.sh")
+        do {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+            try script.write(to: url, atomically: true, encoding: .utf8)
+            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+        } catch {
+            return nil
+        }
+        return url
     }
 
     /// Sends `signal` to a process and all of its descendants (brew forks curl;


### PR DESCRIPTION
## Summary
- **Root cause**: pkg-based casks (e.g. `session-manager-plugin`) run `sudo /usr/sbin/installer` inside brew; launched from a GUI with no TTY, sudo had nowhere to prompt and the install failed with `sudo: a password is required`.
- **Fix**: `runBrewStreaming` now sets `SUDO_ASKPASS` — Homebrew whitelists it and passes `-A` to its internal sudo calls, which then asks via our helper instead of a TTY.
- **The helper is CaskHub itself**: the askpass script re-execs the app binary in a hidden `--askpass <token>` mode that shows a native NSAlert (app icon, secure field, names the cask) and prints the password to stdout for sudo. Cancel exits 1 so brew aborts cleanly.
- Covers install, upgrade, and uninstall — all three funnel through `runBrewStreaming`.

## Testing
- `CaskHub --askpass session-manager-plugin` run standalone: alert renders with app icon, Allow prints to stdout (exit 0), Cancel exits 1.
- Askpass script syntax validated with `sh -n`.
- Debug build succeeds.