### PR TITLE
feat: Show cask download size in the info popover

### DIFF
--- a/CaskHub/Views/Shared/CaskInfoPopover.swift
+++ b/CaskHub/Views/Shared/CaskInfoPopover.swift
@@ -11,6 +11,7 @@ struct CaskInfoPopover: View {
     let cask: Cask
 
     @Environment(LocalHomebrewService.self) private var localHomebrew
+    @State private var downloadSize: DownloadSizeCache.Result?
 
     var body: some View {
         Grid(alignment: .leadingFirstTextBaseline, verticalSpacing: 8) {
@@ -40,6 +41,9 @@ struct CaskInfoPopover: View {
         }
         .padding()
         .frame(minWidth: 400)
+        .task(id: cask.token) {
+            downloadSize = await DownloadSizeCache.fetch(urlString: cask.url)
+        }
     }
 
     private var headerRow: some View {
@@ -78,6 +82,13 @@ struct CaskInfoPopover: View {
                 value: url,
                 link: URL(string: url)
             ))
+            let sizeValue: String
+            switch downloadSize {
+            case .known(let bytes): sizeValue = bytes.formatted(.byteCount(style: .file))
+            case .unknown:          sizeValue = "Unknown"
+            case nil:               sizeValue = "Loading…"
+            }
+            result.append(InfoRow(property: "Download Size", value: sizeValue))
         }
 
         let localInstallation = localHomebrew.installedCasks[cask.token]
@@ -119,6 +130,52 @@ private struct InfoRow {
     let property: String
     let value: String
     var link: URL? = nil
+}
+
+/// Download size via HTTP headers — the brew API doesn't publish sizes.
+/// Cached (including failures) for the app's lifetime: cask URLs are
+/// version-pinned, so a size never changes under the same URL.
+/// ponytail: uses the API's default `url`; per-arch `variations` can differ.
+@MainActor
+enum DownloadSizeCache {
+    enum Result {
+        case known(Int64)
+        case unknown
+    }
+
+    private static var cache: [String: Result] = [:]
+
+    static func fetch(urlString: String?) async -> Result {
+        guard let urlString, let url = URL(string: urlString) else { return .unknown }
+        if let cached = cache[urlString] { return cached }
+
+        let result: Result
+        if let bytes = await contentLength(of: url) {
+            result = .known(bytes)
+        } else {
+            result = .unknown
+        }
+        cache[urlString] = result
+        return result
+    }
+
+    private static func contentLength(of url: URL) async -> Int64? {
+        var head = URLRequest(url: url, timeoutInterval: 15)
+        head.httpMethod = "HEAD"
+        if let response = try? await URLSession.shared.data(for: head).1,
+           response.expectedContentLength > 0 {
+            return response.expectedContentLength
+        }
+
+        // Fallback: 1-byte ranged GET; total size arrives as "bytes 0-0/<total>".
+        var ranged = URLRequest(url: url, timeoutInterval: 15)
+        ranged.setValue("bytes=0-0", forHTTPHeaderField: "Range")
+        guard let response = try? await URLSession.shared.data(for: ranged).1 as? HTTPURLResponse,
+              let contentRange = response.value(forHTTPHeaderField: "Content-Range"),
+              let total = contentRange.split(separator: "/").last.flatMap({ Int64($0) })
+        else { return nil }
+        return total
+    }
 }
 
 #Preview {


### PR DESCRIPTION
## Summary
- Adds a **Download Size** row to the cask info popover (under URL): `Loading…` → e.g. `196.2 MB`, or `Unknown` when the server won't say.
- The brew API publishes no size, so `DownloadSizeCache` resolves it from HTTP headers: `HEAD` reading `Content-Length`, with a 1-byte ranged `GET` (`Content-Range`) fallback for servers that refuse HEAD.
- Fetches once per popover open via `.task(id:)` — no per-card traffic while scrolling — and caches results (including failures) for the app's lifetime, since cask URLs are version-pinned.

## Testing
- Header logic verified against real cask URLs: 1Password (196 MB) and session-manager-plugin (9.9 MB) both answer HEAD with Content-Length after redirects.
- Debug build succeeds.