### PR TITLE
enhancement: friendly error message for checksum mismatch install failures

### DIFF
--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -55,6 +55,13 @@ enum LocalHomebrewError: LocalizedError {
         case .brewCommandFailed(let args, let code, let stderr):
             let cmd = (["brew"] + args).joined(separator: " ")
             let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            // "reports different checksum" = cask; "SHA256 mismatch" = formula dependency.
+            if trimmed.contains("reports different checksum") || trimmed.contains("SHA256 mismatch") {
+                return "The download doesn't match the checksum Homebrew has on record — "
+                    + "the developer likely replaced the release file after it was published. "
+                    + "This isn't a problem with your Mac; Homebrew refuses mismatched downloads "
+                    + "for security. Try again in a day or two once the cask is updated."
+            }
             return trimmed.isEmpty
                 ? "`\(cmd)` failed (exit \(code))."
                 : "`\(cmd)` failed (exit \(code)): \(trimmed)"


### PR DESCRIPTION
## Summary
- Detect Homebrew's checksum-mismatch failures (`Cask reports different checksum` for casks, `SHA256 mismatch` for formula downloads) in `LocalHomebrewError.brewCommandFailed` and show a plain-language explanation instead of the raw brew output dump.
- The message tells the user the upstream developer likely replaced the release file, that nothing is wrong with their Mac, and to retry once the cask definition is updated.
- All mutation flows (install, upgrade, uninstall) funnel errors through the same enum case, so one branch covers every path.

## Test plan
- Built the CaskHub scheme successfully.
- Verified against a real-world occurrence: `brew install --cask whispering` (v7.11.0) currently fails with a checksum mismatch because the upstream DMG was re-uploaded after Homebrew recorded its SHA-256.