### PR TITLE
feat: show activity indicator while cask icons load

### DIFF
--- a/CaskHub/Views/Shared/CaskIconView.swift
+++ b/CaskHub/Views/Shared/CaskIconView.swift
@@ -13,6 +13,7 @@ struct CaskIconView: View {
 
     @Environment(ImageCacheService.self) private var imageCache
     @State private var loadedImage: NSImage?
+    @State private var didResolve = false
 
     private var wellShape: RoundedRectangle {
         RoundedRectangle(cornerRadius: size * 0.28, style: .continuous)
@@ -43,14 +44,21 @@ struct CaskIconView: View {
                     .fill(Color.chSurfaceField)
                     .overlay(wellShape.strokeBorder(Color.chHairlineStrong, lineWidth: 1))
                     .frame(width: size, height: size)
-                Image(systemName: "macwindow")
-                    .font(.system(size: size * 0.4))
-                    .foregroundStyle(Color.chTextMuted)
+                if didResolve {
+                    Image(systemName: "macwindow")
+                        .font(.system(size: size * 0.4))
+                        .foregroundStyle(Color.chTextMuted)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                }
             }
         }
         .animation(.easeIn(duration: 0.2), value: loadedImage != nil)
         .task(id: cask.token) {
+            didResolve = false
             loadedImage = await imageCache.image(for: cask)
+            didResolve = true
         }
     }
 


### PR DESCRIPTION
## What

Adds a loading spinner to `CaskIconView` while a cask icon is fetched over the network.

## Why

The view had a single placeholder branch that rendered the `macwindow` glyph for **both** the in-flight fetch and the settled no-icon state. The two were visually indistinguishable, so a loading icon looked identical to one that genuinely had no icon — there was no loading feedback at all.

## How

- Track a `didResolve` flag to disambiguate *loading* from *settled with no icon*.
- Show a small `ProgressView` while the fetch is in flight; fall back to the `macwindow` placeholder only once resolution completes with no image.
- `didResolve` resets at the start of `.task` so recycled list cells re-show the spinner for the new cask.

## Notes

- Memory/disk cache hits resolve near-instantly, so no spinner flashes while scrolling.
- CLI casks keep their terminal tile unchanged (it's a permanent placeholder, not a loading state).

Build: `** BUILD SUCCEEDED **` (Debug).