### PR TITLE
feat: add privacy-friendly usage analytics via TelemetryDeck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ fastlane/test_output
 skills/
 .claude-plugin/
 *.txt
+
+Configs/Secrets.xcconfig

--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		41AD10032F68A00300BEABB8 /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = 41AD10022F68A00200BEABB8 /* TelemetryDeck */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		41EBDCEF2F37FD8C00BEABB8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -17,6 +21,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		41AD10042F68A00400BEABB8 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = Configs/Shared.xcconfig; sourceTree = "<group>"; };
 		41EBDCE12F37FD8B00BEABB8 /* CaskHub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaskHub.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41EBDCEE2F37FD8C00BEABB8 /* CaskHubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaskHubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -39,6 +44,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				41AD10032F68A00300BEABB8 /* TelemetryDeck in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,6 +61,7 @@
 		41EBDCD82F37FD8B00BEABB8 = {
 			isa = PBXGroup;
 			children = (
+				41AD10042F68A00400BEABB8 /* Shared.xcconfig */,
 				41EBDCE32F37FD8B00BEABB8 /* CaskHub */,
 				41EBDCF12F37FD8C00BEABB8 /* CaskHubTests */,
 				41EBDCE22F37FD8B00BEABB8 /* Products */,
@@ -90,6 +97,9 @@
 				41EBDCE32F37FD8B00BEABB8 /* CaskHub */,
 			);
 			name = CaskHub;
+			packageProductDependencies = (
+				41AD10022F68A00200BEABB8 /* TelemetryDeck */,
+			);
 			productName = CaskHub;
 			productReference = 41EBDCE12F37FD8B00BEABB8 /* CaskHub.app */;
 			productType = "com.apple.product-type.application";
@@ -143,6 +153,9 @@
 			);
 			mainGroup = 41EBDCD82F37FD8B00BEABB8;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				41AD10012F68A00100BEABB8 /* XCRemoteSwiftPackageReference "SwiftSDK" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 41EBDCE22F37FD8B00BEABB8 /* Products */;
 			projectDirPath = "";
@@ -222,6 +235,7 @@
 /* Begin XCBuildConfiguration section */
 		41EBDD002F37FD8C00BEABB8 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 41AD10042F68A00400BEABB8 /* Shared.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -288,6 +302,7 @@
 		};
 		41EBDD012F37FD8C00BEABB8 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 41AD10042F68A00400BEABB8 /* Shared.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -360,6 +375,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Configs/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -394,6 +410,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Configs/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -487,6 +504,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		41AD10012F68A00100BEABB8 /* XCRemoteSwiftPackageReference "SwiftSDK" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/TelemetryDeck/SwiftSDK";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		41AD10022F68A00200BEABB8 /* TelemetryDeck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 41AD10012F68A00100BEABB8 /* XCRemoteSwiftPackageReference "SwiftSDK" */;
+			productName = TelemetryDeck;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 41EBDCD92F37FD8B00BEABB8 /* Project object */;
 }

--- a/CaskHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CaskHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "fa7ab4bc9518bd495b4c17d8a96bebc401eb5a2f99ae8b4bc316b04b7b2aea05",
+  "pins" : [
+    {
+      "identity" : "swiftsdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TelemetryDeck/SwiftSDK",
+      "state" : {
+        "revision" : "ad4a03ec7ea7416a4081370f21c86e55b02a5b88",
+        "version" : "2.14.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/CaskHub/CaskHubApp.swift
+++ b/CaskHub/CaskHubApp.swift
@@ -51,6 +51,7 @@ struct CaskHubApp: App {
 
     init() {
         BrandFonts.register()
+        Analytics.start()
         // Apply before any window exists — state restoration can otherwise
         // revive an appearance archived under an older theme setting.
         Self.applyAppearance(UserDefaults.standard.string(forKey: "appTheme") ?? AppTheme.system.rawValue)

--- a/CaskHub/ContentView.swift
+++ b/CaskHub/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
     @State private var viewMode: ViewMode = .grid
     @FocusState private var searchFocused: Bool
     @State private var showsResultsHeader = false
+    @State private var searchSignalTask: Task<Void, Never>?
 
     /// Fixed 4-column grid from the design mock (cards never reflow wider).
     private let columns = Array(
@@ -69,10 +70,14 @@ struct ContentView: View {
                     searchFocus: $searchFocused,
                     analyticsPeriod: selectedSidebar == .discover(.topCharts) ? viewModel.analyticsPeriod : nil,
                     onSelectPeriod: { period in
+                        Analytics.topChartsPeriodChanged(period)
                         Task { await viewModel.selectAnalyticsPeriod(period) }
                     },
                     recentWindow: selectedSidebar == .discover(.recentlyAdded) ? viewModel.recentlyAddedWindow : nil,
-                    onSelectWindow: { viewModel.recentlyAddedWindow = $0 },
+                    onSelectWindow: {
+                        Analytics.recentWindowChanged($0)
+                        viewModel.recentlyAddedWindow = $0
+                    },
                     // Sections have a fixed popularity order; sorting is a no-op there.
                     showsSort: selectedSidebar != .discover(.featured) && !showsBrowseSections,
                     onSubmitSearch: {
@@ -132,6 +137,7 @@ struct ContentView: View {
             _ = await(catalog, local, categories, addedDates)
         }
         .onChange(of: selectedSidebar) { _, newValue in
+            Analytics.pageOpened(newValue)
             viewModel.selectedSidebar = newValue
             if newValue == .discover(.topCharts) {
                 // Fetch the current period's data if it hasn't loaded yet.
@@ -145,7 +151,23 @@ struct ContentView: View {
                 viewModel.sortOption = .mostPopular
             }
         }
+        .onChange(of: viewMode) { _, newValue in
+            Analytics.viewModeChanged(newValue)
+        }
         .onChange(of: viewModel.searchText) { _, newValue in
+            // Results filter per keystroke (no Return needed), so the search
+            // signal fires when typing settles — not per key, not on submit.
+            searchSignalTask?.cancel()
+            if !newValue.isEmpty {
+                searchSignalTask = Task {
+                    try? await Task.sleep(for: .seconds(2))
+                    guard !Task.isCancelled else { return }
+                    Analytics.searchPerformed(
+                        query: newValue,
+                        results: viewModel.filteredCasks.count
+                    )
+                }
+            }
             if newValue.isEmpty {
                 // Only drop focus when clearing a submitted search — while
                 // still composing (backspaced to empty), keep the field active.
@@ -207,10 +229,12 @@ struct ContentView: View {
         guard let id = categoryService.category(for: cask.token) else { return nil }
         return (id, categoryService.displayName(for: id))
     }
+}
 
-    // MARK: - Grid View
+// MARK: - Grid, List & Error Views
 
-    private var gridView: some View {
+private extension ContentView {
+    var gridView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: CHSpace.s4) {
                 if let hero = heroCask {
@@ -238,7 +262,7 @@ struct ContentView: View {
         .id(selectedSidebar)
     }
 
-    private func caskGrid(_ casks: [Cask]) -> some View {
+    func caskGrid(_ casks: [Cask]) -> some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: CHSpace.gridGap) {
             ForEach(casks) { cask in
                 CaskCardView(
@@ -251,7 +275,7 @@ struct ContentView: View {
         }
     }
 
-    private func browseSectionView(_ section: BrowseSection) -> some View {
+    func browseSectionView(_ section: BrowseSection) -> some View {
         VStack(alignment: .leading, spacing: CHSpace.s3) {
             HStack(alignment: .firstTextBaseline) {
                 Text(section.title)
@@ -259,6 +283,7 @@ struct ContentView: View {
                     .foregroundStyle(Color.chTextTitle)
                 Spacer()
                 Button {
+                    Analytics.viewAllTapped(to: section.destination)
                     selectedSidebar = section.destination
                 } label: {
                     Text("View All")
@@ -274,7 +299,7 @@ struct ContentView: View {
 
     // MARK: - List View
 
-    private var listView: some View {
+    var listView: some View {
         List(viewModel.filteredCasks) { cask in
             CaskRowView(
                 cask: cask,
@@ -288,7 +313,7 @@ struct ContentView: View {
 
     // MARK: - Error View
 
-    private func errorView(_ error: String) -> some View {
+    func errorView(_ error: String) -> some View {
         VStack(spacing: 12) {
             BarrelMark()
                 .frame(width: 56, height: 56)

--- a/CaskHub/DesignSystem/Components/TopBarView.swift
+++ b/CaskHub/DesignSystem/Components/TopBarView.swift
@@ -100,6 +100,9 @@ struct TopBarView: View {
     private func sortMenuRow(_ option: SortOption) -> some View {
         let isSelected = sortOption == option
         return Button {
+            // Tracked here, not via onChange: page switches also reset the
+            // sort programmatically, and only user picks should count.
+            if option != sortOption { Analytics.sortChanged(option) }
             sortOption = option
             showSortMenu = false
         } label: {

--- a/CaskHub/Services/Analytics+Events.swift
+++ b/CaskHub/Services/Analytics+Events.swift
@@ -1,0 +1,118 @@
+//
+//  Analytics+Events.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 11/07/2026.
+//
+
+import Foundation
+
+/// CaskHub's full signal vocabulary, in one place. Call sites go through
+/// these typed helpers — never raw signal strings — so everything the app
+/// can ever send stays auditable in this single file, and none of it knows
+/// which analytics provider is behind `Analytics.send`.
+extension Analytics {
+    // MARK: - Cask actions
+
+    /// Success signal for install / uninstall / update. App launches
+    /// (`.opening`) are deliberately not tracked.
+    static func caskActionCompleted(_ action: CaskAction, token: String) {
+        guard let verb = action.analyticsVerb else { return }
+        send("Cask.\(verb.past)", parameters: ["cask": token])
+    }
+
+    static func caskActionFailed(_ action: CaskAction, token: String) {
+        guard let verb = action.analyticsVerb else { return }
+        send("Cask.actionFailed", parameters: ["action": verb.base, "cask": token])
+    }
+
+    // MARK: - Navigation
+
+    /// Fires for every detail-page change: sidebar clicks, category clicks
+    /// on cards, and View All — they all route through the same selection.
+    static func pageOpened(_ selection: SidebarSelection) {
+        send("Page.opened", parameters: parameters(for: selection))
+    }
+
+    /// The Browse-shelf "View All" tap, sent alongside the `Page.opened`
+    /// the navigation itself produces.
+    static func viewAllTapped(to destination: SidebarSelection) {
+        send("Browse.viewAllTapped", parameters: parameters(for: destination))
+    }
+
+    // MARK: - Search
+
+    static func searchPerformed(query: String, results: Int) {
+        send("Search.performed", parameters: [
+            "query": query.trimmingCharacters(in: .whitespaces).lowercased(),
+            "results": "\(results)"
+        ])
+    }
+
+    // MARK: - Filters & view options
+
+    static func sortChanged(_ option: SortOption) {
+        send("Filter.sortChanged", parameters: ["option": option.rawValue])
+    }
+
+    static func topChartsPeriodChanged(_ period: AnalyticsPeriod) {
+        send("Filter.periodChanged", parameters: ["period": period.rawValue])
+    }
+
+    static func recentWindowChanged(_ window: RecentlyAddedWindow) {
+        send("Filter.windowChanged", parameters: ["window": "\(window.rawValue)d"])
+    }
+
+    static func viewModeChanged(_ mode: ViewMode) {
+        send("View.modeChanged", parameters: ["mode": mode.rawValue])
+    }
+
+    // MARK: - Settings
+
+    static func themeChanged(_ theme: String) {
+        send("Settings.themeChanged", parameters: ["theme": theme])
+    }
+
+    /// Turning telemetry OFF sends nothing — the opt-out applies instantly.
+    static func analyticsReEnabled() {
+        send("Settings.analyticsEnabled")
+    }
+
+    // MARK: - Parameter mapping
+
+    private static func parameters(for selection: SidebarSelection) -> [String: String] {
+        switch selection {
+        case let .discover(item):
+            return ["page": item.analyticsName]
+        case let .library(item):
+            return ["page": item.rawValue.lowercased()]
+        case let .category(categoryID):
+            return ["page": "category", "category": categoryID]
+        }
+    }
+}
+
+// MARK: - Analytics names for domain types
+
+private extension CaskAction {
+    /// Verb forms for signal names; nil means "don't track this action".
+    var analyticsVerb: (base: String, past: String)? {
+        switch self {
+        case .installing: return ("install", "installed")
+        case .uninstalling: return ("uninstall", "uninstalled")
+        case .updating: return ("update", "updated")
+        case .opening: return nil
+        }
+    }
+}
+
+private extension DiscoverItem {
+    var analyticsName: String {
+        switch self {
+        case .browse: return "browse"
+        case .featured: return "featured"
+        case .topCharts: return "topCharts"
+        case .recentlyAdded: return "recentlyAdded"
+        }
+    }
+}

--- a/CaskHub/Services/Analytics.swift
+++ b/CaskHub/Services/Analytics.swift
@@ -25,7 +25,8 @@ protocol AnalyticsProvider {
 enum Analytics {
     static let enabledKey = "analyticsEnabled"
 
-    static let provider: AnalyticsProvider = TelemetryDeckProvider()
+    /// `var` so tests can inject a spy; production never reassigns it.
+    static var provider: AnalyticsProvider = TelemetryDeckProvider()
 
     static var isEnabled: Bool {
         UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true

--- a/CaskHub/Services/Analytics.swift
+++ b/CaskHub/Services/Analytics.swift
@@ -1,0 +1,79 @@
+//
+//  Analytics.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 11/07/2026.
+//
+
+import Foundation
+import TelemetryDeck
+
+/// Abstraction over the analytics backend: swapping providers means writing
+/// one new conforming type — the event vocabulary (Analytics+Events.swift)
+/// and its call sites never change.
+protocol AnalyticsProvider {
+    /// Called once from `App.init()`, before any window exists.
+    /// `enabled` reflects the stored opt-out setting.
+    func start(enabled: Bool)
+    /// Live opt-out flip from the Settings toggle.
+    func setEnabled(_ enabled: Bool)
+    func send(_ signalName: String, parameters: [String: String])
+}
+
+/// The facade the app talks to. Owns the opt-out setting (Settings → Privacy)
+/// and forwards everything else to the provider.
+enum Analytics {
+    static let enabledKey = "analyticsEnabled"
+
+    static let provider: AnalyticsProvider = TelemetryDeckProvider()
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+    }
+
+    static func start() {
+        provider.start(enabled: isEnabled)
+    }
+
+    /// Re-reads the opt-out setting; call after the Settings toggle changes.
+    static func refresh() {
+        provider.setEnabled(isEnabled)
+    }
+
+    static func send(_ signalName: String, parameters: [String: String] = [:]) {
+        provider.send(signalName, parameters: parameters)
+    }
+}
+
+// MARK: - TelemetryDeck
+
+/// Session signals (launches, active users) are sent by the SDK automatically.
+final class TelemetryDeckProvider: AnalyticsProvider {
+    /// Injected at build time: Configs/Secrets.xcconfig → Info.plist → here
+    /// (see Configs/Secrets.xcconfig.template). Nil on builds without the
+    /// secret (fresh clones, CI) — analytics then stays off entirely.
+    private static var appID: String? {
+        let value = Bundle.main.object(forInfoDictionaryKey: "TelemetryDeckAppID") as? String
+        return value?.isEmpty == false ? value : nil
+    }
+
+    /// Config is a reference type the SDK reads at send time, so keeping it
+    /// lets `setEnabled` flip opt-out at runtime without re-initializing.
+    private var config: TelemetryDeck.Config?
+
+    func start(enabled: Bool) {
+        guard let appID = Self.appID else { return }
+        let config = TelemetryDeck.Config(appID: appID)
+        config.analyticsDisabled = !enabled
+        TelemetryDeck.initialize(config: config)
+        self.config = config
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        config?.analyticsDisabled = !enabled
+    }
+
+    func send(_ signalName: String, parameters: [String: String]) {
+        TelemetryDeck.signal(signalName, parameters: parameters)
+    }
+}

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -256,6 +256,7 @@ final class LocalHomebrewService {
         do {
             try await runBrewStreaming(token: token, args: args, cancellable: action == .installing)
             cancelRequested.remove(token)
+            Analytics.caskActionCompleted(action, token: token)
             await refresh()
         } catch {
             if cancelRequested.contains(token) {
@@ -268,6 +269,7 @@ final class LocalHomebrewService {
                 await refresh()
                 return
             }
+            Analytics.caskActionFailed(action, token: token)
             if let error = error as? LocalHomebrewError {
                 actionErrors[token] = error.errorDescription
             } else {

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -14,6 +14,10 @@ struct SettingsView: View {
                 .tabItem {
                     Label("Appearance", systemImage: "paintbrush")
                 }
+            PrivacySettingsView()
+                .tabItem {
+                    Label("Privacy", systemImage: "hand.raised")
+                }
         }
         .frame(width: 400, height: 200)
     }
@@ -38,6 +42,31 @@ struct AppearanceSettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+        .onChange(of: selectedTheme) { _, newValue in
+            Analytics.themeChanged(newValue)
+        }
+    }
+}
+
+struct PrivacySettingsView: View {
+    @AppStorage(Analytics.enabledKey) private var analyticsEnabled = true
+
+    var body: some View {
+        Form {
+            Toggle("Share anonymous usage analytics", isOn: $analyticsEnabled)
+            Text("""
+            Helps improve CaskHub via TelemetryDeck. No personal data, \
+            no tracking across apps — only anonymized usage signals.
+            """)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        }
+        .formStyle(.grouped)
+        .padding()
+        .onChange(of: analyticsEnabled) { _, isOn in
+            Analytics.refresh()
+            if isOn { Analytics.analyticsReEnabled() }
+        }
     }
 }
 

--- a/CaskHubTests/AnalyticsTests.swift
+++ b/CaskHubTests/AnalyticsTests.swift
@@ -1,0 +1,165 @@
+//
+//  AnalyticsTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 11/07/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+private final class SpyAnalyticsProvider: AnalyticsProvider {
+    var startedWith: [Bool] = []
+    var enabledChanges: [Bool] = []
+    var signals: [(name: String, parameters: [String: String])] = []
+
+    func start(enabled: Bool) { startedWith.append(enabled) }
+    func setEnabled(_ enabled: Bool) { enabledChanges.append(enabled) }
+    func send(_ signalName: String, parameters: [String: String]) {
+        signals.append((signalName, parameters))
+    }
+}
+
+final class AnalyticsTests: XCTestCase {
+    private var spy: SpyAnalyticsProvider!
+    private var originalProvider: AnalyticsProvider!
+
+    override func setUp() {
+        super.setUp()
+        spy = SpyAnalyticsProvider()
+        originalProvider = Analytics.provider
+        Analytics.provider = spy
+        UserDefaults.standard.removeObject(forKey: Analytics.enabledKey)
+    }
+
+    override func tearDown() {
+        Analytics.provider = originalProvider
+        UserDefaults.standard.removeObject(forKey: Analytics.enabledKey)
+        super.tearDown()
+    }
+
+    private var lastSignal: (name: String, parameters: [String: String])? {
+        spy.signals.last
+    }
+
+    // MARK: - Opt-out state
+
+    func testAnalyticsIsEnabledByDefault() {
+        XCTAssertTrue(Analytics.isEnabled)
+    }
+
+    func testIsEnabledReflectsStoredOptOut() {
+        UserDefaults.standard.set(false, forKey: Analytics.enabledKey)
+        XCTAssertFalse(Analytics.isEnabled)
+    }
+
+    func testStartPassesStoredSettingToProvider() {
+        UserDefaults.standard.set(false, forKey: Analytics.enabledKey)
+        Analytics.start()
+        XCTAssertEqual(spy.startedWith, [false])
+    }
+
+    func testRefreshForwardsCurrentSettingToProvider() {
+        UserDefaults.standard.set(false, forKey: Analytics.enabledKey)
+        Analytics.refresh()
+        UserDefaults.standard.set(true, forKey: Analytics.enabledKey)
+        Analytics.refresh()
+        XCTAssertEqual(spy.enabledChanges, [false, true])
+    }
+
+    // MARK: - Cask action events
+
+    func testCaskActionCompletedMapsActionsToPastTenseSignals() {
+        Analytics.caskActionCompleted(.installing, token: "firefox")
+        Analytics.caskActionCompleted(.uninstalling, token: "firefox")
+        Analytics.caskActionCompleted(.updating, token: "firefox")
+
+        XCTAssertEqual(
+            spy.signals.map(\.name),
+            ["Cask.installed", "Cask.uninstalled", "Cask.updated"]
+        )
+        XCTAssertEqual(lastSignal?.parameters, ["cask": "firefox"])
+    }
+
+    func testCaskActionCompletedIgnoresAppLaunches() {
+        Analytics.caskActionCompleted(.opening, token: "firefox")
+        XCTAssertTrue(spy.signals.isEmpty)
+    }
+
+    func testCaskActionFailedSendsBaseVerbAndToken() {
+        Analytics.caskActionFailed(.updating, token: "iterm2")
+        XCTAssertEqual(lastSignal?.name, "Cask.actionFailed")
+        XCTAssertEqual(lastSignal?.parameters, ["action": "update", "cask": "iterm2"])
+    }
+
+    func testCaskActionFailedIgnoresAppLaunches() {
+        Analytics.caskActionFailed(.opening, token: "firefox")
+        XCTAssertTrue(spy.signals.isEmpty)
+    }
+
+    // MARK: - Navigation events
+
+    func testPageOpenedMapsDiscoverPages() {
+        Analytics.pageOpened(.discover(.topCharts))
+        XCTAssertEqual(lastSignal?.name, "Page.opened")
+        XCTAssertEqual(lastSignal?.parameters, ["page": "topCharts"])
+    }
+
+    func testPageOpenedMapsLibraryPages() {
+        Analytics.pageOpened(.library(.installed))
+        XCTAssertEqual(lastSignal?.parameters, ["page": "installed"])
+    }
+
+    func testPageOpenedMapsCategoriesWithID() {
+        Analytics.pageOpened(.category("productivity"))
+        XCTAssertEqual(
+            lastSignal?.parameters,
+            ["page": "category", "category": "productivity"]
+        )
+    }
+
+    func testViewAllTappedCarriesDestinationParameters() {
+        Analytics.viewAllTapped(to: .category("developer-tools"))
+        XCTAssertEqual(lastSignal?.name, "Browse.viewAllTapped")
+        XCTAssertEqual(
+            lastSignal?.parameters,
+            ["page": "category", "category": "developer-tools"]
+        )
+    }
+
+    // MARK: - Search
+
+    func testSearchPerformedNormalizesQueryAndCountsResults() {
+        Analytics.searchPerformed(query: "  FireFox ", results: 3)
+        XCTAssertEqual(lastSignal?.name, "Search.performed")
+        XCTAssertEqual(lastSignal?.parameters, ["query": "firefox", "results": "3"])
+    }
+
+    // MARK: - Filters, view mode & settings
+
+    func testFilterAndSettingsEventNamesAndParameters() {
+        Analytics.sortChanged(.nameAZ)
+        Analytics.topChartsPeriodChanged(.days90)
+        Analytics.recentWindowChanged(.days30)
+        Analytics.viewModeChanged(.list)
+        Analytics.themeChanged("Dark")
+        Analytics.analyticsReEnabled()
+
+        XCTAssertEqual(spy.signals.map(\.name), [
+            "Filter.sortChanged",
+            "Filter.periodChanged",
+            "Filter.windowChanged",
+            "View.modeChanged",
+            "Settings.themeChanged",
+            "Settings.analyticsEnabled"
+        ])
+        XCTAssertEqual(spy.signals.map(\.parameters), [
+            ["option": "Name (A→Z)"],
+            ["period": "90d"],
+            ["window": "30d"],
+            ["mode": "list"],
+            ["theme": "Dark"],
+            [:]
+        ])
+    }
+}

--- a/Configs/Info.plist
+++ b/Configs/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Build-time injected values (Configs/*.xcconfig). Xcode merges these
+	     entries with the generated Info.plist (GENERATE_INFOPLIST_FILE). -->
+	<key>TelemetryDeckAppID</key>
+	<string>$(TELEMETRYDECK_APP_ID)</string>
+</dict>
+</plist>

--- a/Configs/Secrets.xcconfig.template
+++ b/Configs/Secrets.xcconfig.template
@@ -1,0 +1,7 @@
+// Copy this file to Secrets.xcconfig (same directory, gitignored) and fill
+// in the real values. Builds succeed without it — analytics just stays off —
+// so only release builds need it. A future release workflow should write
+// this file from repository secrets, e.g.:
+//   printf 'TELEMETRYDECK_APP_ID = %s\n' "$TELEMETRYDECK_APP_ID" > Configs/Secrets.xcconfig
+
+TELEMETRYDECK_APP_ID = paste-your-telemetrydeck-app-id-here

--- a/Configs/Shared.xcconfig
+++ b/Configs/Shared.xcconfig
@@ -1,0 +1,7 @@
+// Base build configuration for all targets.
+//
+// Secrets live in Secrets.xcconfig (gitignored) — copy Secrets.xcconfig.template
+// to create it. The optional #include? means builds succeed without it:
+// injected values just stay empty and the app skips analytics.
+
+#include? "Secrets.xcconfig"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ cd CaskHub
 open CaskHub.xcodeproj
 ```
 
-Select the **CaskHub** scheme and run (⌘R). There are no third-party dependencies to resolve - the app is built entirely on Apple frameworks.
+Select the **CaskHub** scheme and run (⌘R). Xcode resolves the single Swift package dependency ([TelemetryDeck](https://github.com/TelemetryDeck/SwiftSDK)) automatically.
+
+Optional: copy `Configs/Secrets.xcconfig.template` to `Configs/Secrets.xcconfig` and fill in the analytics key — builds work fine without it; analytics just stays off.
 
 ## Architecture
 
@@ -78,6 +80,12 @@ Tests run with XCTest on every push and pull request to `master` and `develop`, 
 ```bash
 xcodebuild test -project CaskHub.xcodeproj -scheme CaskHub -destination 'platform=macOS'
 ```
+
+## Privacy & Analytics
+
+CaskHub collects anonymous usage analytics through [TelemetryDeck](https://telemetrydeck.com), a privacy-first analytics service. No personal data or identifiers ever leave your Mac — user IDs are salted and hashed on-device, and there is no tracking across apps or websites.
+
+You can opt out at any time in **Settings → Privacy**.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Adds the TelemetryDeck Swift SDK and an `Analytics` facade with a provider protocol, so the backend can be swapped by writing one conforming type
- Tracks page opens, View All taps, debounced search queries, sort/period/window filters, the grid/list toggle, theme picks, and cask install/uninstall/update outcomes — each event fires once at a single chokepoint, and the full signal vocabulary lives in `Analytics+Events.swift`
- Analytics is on by default with a visible opt-out in Settings → Privacy; turning it off applies instantly and sends nothing. The README discloses what is collected
- The TelemetryDeck app ID is injected at build time from a gitignored `Configs/Secrets.xcconfig` (template included) via Info.plist. Builds without the secret succeed and simply keep analytics off, so fresh clones and CI need no setup

## Test plan

- [x] Full test suite passes
- [x] SwiftLint clean
- [x] Built app's Info.plist verified to contain the injected key alongside generated entries
- [x] Verified the build succeeds with `Secrets.xcconfig` absent (CI / fresh-clone path)