### PR TITLE
fix: sort the Browse Recently Added shelf by newest instead of downloads

### DIFF
--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -105,8 +105,9 @@ final class CaskCatalogViewModel {
     /// Cards per Browse shelf: two rows of the fixed 4-column grid.
     private static let browseSectionSize = 8
 
-    /// Shelves for the Browse page: Most Popular, Recently Added, then every
-    /// category except "other" — each holding its top casks by 365d downloads.
+    /// Shelves for the Browse page: Most Popular, Recently Added (newest
+    /// first), then every category except "other" — the rest holding their
+    /// top casks by 365d downloads.
     var browseSections: [BrowseSection] {
         let counts = analyticsByPeriod[.days365] ?? [:]
         func top(_ source: [Cask]) -> [Cask] {
@@ -123,7 +124,7 @@ final class CaskCatalogViewModel {
             BrowseSection(
                 title: "Recently Added",
                 destination: .discover(.recentlyAdded),
-                casks: top(casks.filter { recentTokens.contains($0.token) })
+                casks: Array(sortedByNewest(casks.filter { recentTokens.contains($0.token) }).prefix(Self.browseSectionSize))
             )
         ]
         for entry in categoryService.orderedCategories where entry.id != "other" {
@@ -188,6 +189,10 @@ final class CaskCatalogViewModel {
         source.sorted { (counts[$0.token] ?? 0) > (counts[$1.token] ?? 0) }
     }
 
+    private func sortedByNewest(_ source: [Cask]) -> [Cask] {
+        source.sorted { (recentlyAdded.addedDate(for: $0.token) ?? "") > (recentlyAdded.addedDate(for: $1.token) ?? "") }
+    }
+
     private func applySort(to casks: [Cask]) -> [Cask] {
         switch sortOption {
         case .mostPopular:
@@ -197,7 +202,7 @@ final class CaskCatalogViewModel {
         case .nameZA:
             return casks.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedDescending }
         case .newest:
-            return casks.sorted { (recentlyAdded.addedDate(for: $0.token) ?? "") > (recentlyAdded.addedDate(for: $1.token) ?? "") }
+            return sortedByNewest(casks)
         case .oldest:
             return casks.sorted { (recentlyAdded.addedDate(for: $0.token) ?? "9999") < (recentlyAdded.addedDate(for: $1.token) ?? "9999") }
         }

--- a/CaskHubTests/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/CaskCatalogViewModelTests.swift
@@ -222,6 +222,25 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(sections[1].casks.first?.token, "browser-9") // top downloads first
     }
 
+    @MainActor
+    func test_browse_recently_added_shelf_orders_by_newest_not_downloads() async {
+        let recent = RecentlyAddedService()
+        recent.addedDates = [
+            "old-hit": dateString(daysAgo: 20),
+            "new-app": dateString(daysAgo: 1)
+        ]
+        let api = MockBrewAPIClient()
+        api.casks = [makeCask("old-hit"), makeCask("new-app")]
+        api.analyticsResponses[.days365] = analyticsResponse([
+            ("old-hit", "1000"), ("new-app", "10")
+        ])
+        let vm = makeViewModel(api: api, recentlyAdded: recent)
+        await vm.fetchCasks()
+
+        let shelf = vm.browseSections.first { $0.title == "Recently Added" }
+        XCTAssertEqual(shelf?.casks.map(\.token), ["new-app", "old-hit"])
+    }
+
     // MARK: Analytics
 
     @MainActor

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/alielsokary/CaskHub?include_prereleases)](https://github.com/alielsokary/CaskHub/releases)
 
-<img width="850" height="250" alt="caskhub-banner-dark" src="https://github.com/user-attachments/assets/ef6dec52-6e19-4b09-b344-61cadad4a741" />
+<img width="1700" height="500" alt="caskhub-banner-dark" src="https://github.com/user-attachments/assets/24326700-e485-4714-993f-648c2a36c25b" />
 
 **A native macOS app store for Homebrew casks.** Browse, search, install, update, and uninstall thousands of Mac apps distributed through [Homebrew](https://brew.sh) - with original app icons extracted from the source, categories, popularity charts, and one-click actions, all in a clean SwiftUI interface.
 


### PR DESCRIPTION
## Summary

- The Browse page's "Recently Added" shelf reused the same top-by-365d-downloads ranking as every other shelf, so it showed "popular among recent" rather than the newest additions
- Extract the existing newest-first comparator from `applySort` into a `sortedByNewest(_:)` helper and use it for the shelf (dates are ISO `YYYY-MM-DD` strings, so lexicographic order is chronological)
- Add a regression test that gives the older cask far more downloads and asserts the newer one still ranks first


## Test plan

- `CaskCatalogViewModelTests` (14 tests) pass, including the new `test_browse_recently_added_shelf_orders_by_newest_not_downloads`