### PR TITLE
fix: Status-bar updates count and search focus behavior

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */; };
 		41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B130028F9F00608C7A /* CaskHubTests.swift */; };
 		ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */; };
+		ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */; };
 		41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */; };
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
 /* End PBXBuildFile section */
@@ -122,6 +123,7 @@
 		41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
 		41DFD4B130028F9F00608C7A /* CaskHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubTests.swift; sourceTree = "<group>"; };
 		ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewTests.swift; sourceTree = "<group>"; };
+		ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewTests.swift; sourceTree = "<group>"; };
 		41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogViewModelTests.swift; sourceTree = "<group>"; };
 		41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		41EBDCE12F37FD8B00BEABB8 /* CaskHub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaskHub.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -311,6 +313,7 @@
 				41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */,
 				41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */,
 				41DFD4B130028F9F00608C7A /* CaskHubTests.swift */,
+				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
 				ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */,
 				41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */,
 			);
@@ -524,6 +527,7 @@
 				41AD10162F68B00700BEABB8 /* CrashReporterTests.swift in Sources */,
 				41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */,
 				41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */,
+				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,
 				41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */,
 			);

--- a/CaskHub/DesignSystem/Components/StatusBarView.swift
+++ b/CaskHub/DesignSystem/Components/StatusBarView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct StatusBarView: View {
     var caskCount: Int
-    var updatesCount: Int = 0
     var brewVersion: String?
     var caskFlowRelease: String?
 
@@ -21,15 +20,6 @@ struct StatusBarView: View {
             Text(statusLine)
                 .font(CHType.statusMono)
                 .foregroundStyle(Color.chTextBody)
-
-            if updatesCount > 0 {
-                HStack(spacing: 5) {
-                    CountBadge(count: updatesCount)
-                    Text("updates available")
-                        .font(CHType.bodySm)
-                        .foregroundStyle(Color.chTextBody)
-                }
-            }
 
             Spacer()
 
@@ -65,7 +55,7 @@ struct StatusBarView: View {
 #Preview {
     ZStack(alignment: .bottom) {
         WindowBackdrop()
-        StatusBarView(caskCount: 3781, updatesCount: 2, caskFlowRelease: "caskflow-v2026.07.10")
+        StatusBarView(caskCount: 3781, caskFlowRelease: "caskflow-v2026.07.10")
     }
     .frame(width: 700, height: 200)
 }

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -90,6 +90,11 @@ struct ContentView: View {
             // The hidden title bar still reserves toolbar height as safe area;
             // ignore it so the top bar sits 16pt from the window edge.
             .ignoresSafeArea(.container, edges: .top)
+            // Click on empty space (not a button/field) drops search focus.
+            // Interactive children consume their own taps, so clicking into
+            // the search field still focuses it.
+            .contentShape(Rectangle())
+            .onTapGesture { searchFocused = false }
         }
         .overlay {
             // Invisible ⌘F target: focuses the custom search field.
@@ -101,7 +106,6 @@ struct ContentView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             StatusBarView(
                 caskCount: viewModel.casks.count,
-                updatesCount: viewModel.updatesCount,
                 brewVersion: localHomebrew.brewVersion,
                 caskFlowRelease: categoryService.releaseTag
             )

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -21,7 +21,6 @@ struct ContentView: View {
     @FocusState private var searchFocused: Bool
     @State private var showsResultsHeader = false
     @State private var searchSignalTask: Task<Void, Never>?
-    @State private var clickMonitor: Any?
 
     private let columns = Array(
         repeating: GridItem(.fixed(CHSize.cardWidth), spacing: CHSpace.gridGap),
@@ -160,25 +159,11 @@ struct ContentView: View {
             // AppKit hands the window's initial key focus to the first text
             // field; take it back so the search field only activates via ⌘F.
             DispatchQueue.main.async { searchFocused = false }
-
-            // Clicking anywhere outside the active field editor drops search
-            // focus. A local monitor only observes — the event is returned
-            // untouched, so buttons and the field itself stay fully clickable.
-            // While focused, the field's text is edited by an NSTextView
-            // (the window's field editor), so clicks inside it keep focus.
-            clickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
-                if searchFocused,
-                   let frameView = event.window?.contentView?.superview,
-                   !(frameView.hitTest(event.locationInWindow) is NSTextView) {
-                    searchFocused = false
-                }
-                return event
-            }
         }
-        .onDisappear {
-            if let clickMonitor { NSEvent.removeMonitor(clickMonitor) }
-            clickMonitor = nil
-        }
+        .modifier(ResignFocusOnOutsideClick(
+            isFocused: { searchFocused },
+            resign: { searchFocused = false }
+        ))
     }
 
     // MARK: - Detail Content
@@ -324,6 +309,37 @@ private extension ContentView {
                 Task { await viewModel.fetchCasks() }
             }
         }
+    }
+}
+
+// MARK: - Outside-Click Focus Handling
+
+/// Drops focus when a click lands anywhere outside the active field editor.
+/// A local monitor only observes — the event is returned untouched, so
+/// buttons and the field itself stay fully clickable. While a text field is
+/// focused, its text is edited by an NSTextView (the window's field editor),
+/// so clicks inside it keep focus.
+struct ResignFocusOnOutsideClick: ViewModifier {
+    let isFocused: () -> Bool
+    let resign: () -> Void
+    @State private var monitor: Any?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                    if isFocused(),
+                       let frameView = event.window?.contentView?.superview,
+                       !(frameView.hitTest(event.locationInWindow) is NSTextView) {
+                        resign()
+                    }
+                    return event
+                }
+            }
+            .onDisappear {
+                if let monitor { NSEvent.removeMonitor(monitor) }
+                monitor = nil
+            }
     }
 }
 

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
     @FocusState private var searchFocused: Bool
     @State private var showsResultsHeader = false
     @State private var searchSignalTask: Task<Void, Never>?
+    @State private var clickMonitor: Any?
 
     private let columns = Array(
         repeating: GridItem(.fixed(CHSize.cardWidth), spacing: CHSpace.gridGap),
@@ -90,11 +91,6 @@ struct ContentView: View {
             // The hidden title bar still reserves toolbar height as safe area;
             // ignore it so the top bar sits 16pt from the window edge.
             .ignoresSafeArea(.container, edges: .top)
-            // Click on empty space (not a button/field) drops search focus.
-            // Interactive children consume their own taps, so clicking into
-            // the search field still focuses it.
-            .contentShape(Rectangle())
-            .onTapGesture { searchFocused = false }
         }
         .overlay {
             // Invisible ⌘F target: focuses the custom search field.
@@ -164,6 +160,24 @@ struct ContentView: View {
             // AppKit hands the window's initial key focus to the first text
             // field; take it back so the search field only activates via ⌘F.
             DispatchQueue.main.async { searchFocused = false }
+
+            // Clicking anywhere outside the active field editor drops search
+            // focus. A local monitor only observes — the event is returned
+            // untouched, so buttons and the field itself stay fully clickable.
+            // While focused, the field's text is edited by an NSTextView
+            // (the window's field editor), so clicks inside it keep focus.
+            clickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                if searchFocused,
+                   let frameView = event.window?.contentView?.superview,
+                   !(frameView.hitTest(event.locationInWindow) is NSTextView) {
+                    searchFocused = false
+                }
+                return event
+            }
+        }
+        .onDisappear {
+            if let clickMonitor { NSEvent.removeMonitor(clickMonitor) }
+            clickMonitor = nil
         }
     }
 

--- a/CaskHubTests/.swiftlint.yml
+++ b/CaskHubTests/.swiftlint.yml
@@ -1,0 +1,6 @@
+# Test-only overrides, merged on top of the root config (nested configuration).
+# Test suites grow linearly with the features they cover, so the default
+# 250-line type cap bites test classes far earlier than app classes.
+type_body_length:
+  warning: 400
+  error: 500

--- a/CaskHubTests/ContentViewTests.swift
+++ b/CaskHubTests/ContentViewTests.swift
@@ -1,0 +1,133 @@
+//
+//  ContentViewTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 16/07/2026.
+//
+
+@testable import CaskHub
+import SwiftUI
+import XCTest
+
+/// Drives ResignFocusOnOutsideClick's local event monitor with a real window
+/// and synthetic clicks — the AppKit path a render smoke test can't reach.
+final class ContentViewTests: XCTestCase {
+    /// Stands in for ContentView's @FocusState: the modifier's closures
+    /// read `focused` and bump `resignCount`.
+    @MainActor
+    private final class FocusProbe {
+        var focused = true
+        var appeared = false
+        private(set) var resignCount = 0
+        func resign() { resignCount += 1 }
+    }
+
+    // MARK: - Harness
+
+    @MainActor
+    private func makeWindow(probe: FocusProbe) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: Color.clear
+            .modifier(ResignFocusOnOutsideClick(
+                isFocused: { probe.focused },
+                resign: { probe.resign() }
+            ))
+            .onAppear { probe.appeared = true })
+        window.orderFrontRegardless()
+
+        // Spin the run loop until onAppear has installed the monitor.
+        let deadline = Date().addingTimeInterval(2)
+        while !probe.appeared, Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertTrue(probe.appeared, "hosted view never appeared")
+
+        addTeardownBlock { @MainActor in
+            window.contentView = NSView() // onDisappear removes the monitor
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+            window.close()
+        }
+        return window
+    }
+
+    /// Sends a left click through NSApp so local monitors observe it. The
+    /// matching mouse-up is queued first so no control can stall the test
+    /// waiting inside a mouse-tracking loop.
+    @MainActor
+    private func click(at point: NSPoint, in window: NSWindow) {
+        NSApp.postEvent(mouseEvent(.leftMouseUp, at: point, in: window), atStart: false)
+        NSApp.sendEvent(mouseEvent(.leftMouseDown, at: point, in: window))
+    }
+
+    @MainActor
+    private func mouseEvent(_ type: NSEvent.EventType, at point: NSPoint, in window: NSWindow) -> NSEvent {
+        NSEvent.mouseEvent(
+            with: type,
+            location: point,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+    }
+
+    // MARK: - Tests
+
+    @MainActor
+    func test_click_outside_field_editor_resigns_focus() {
+        let probe = FocusProbe()
+        let window = makeWindow(probe: probe)
+
+        click(at: NSPoint(x: 20, y: 20), in: window)
+
+        XCTAssertEqual(probe.resignCount, 1)
+    }
+
+    @MainActor
+    func test_click_on_field_editor_keeps_focus() {
+        let probe = FocusProbe()
+        let window = makeWindow(probe: probe)
+        // While a field is focused its text is edited by the window's field
+        // editor, an NSTextView — clicks landing on one must keep focus.
+        let fieldEditor = NSTextView(frame: NSRect(x: 50, y: 50, width: 100, height: 100))
+        fieldEditor.isEditable = false
+        fieldEditor.isSelectable = false
+        window.contentView!.addSubview(fieldEditor)
+
+        click(at: NSPoint(x: 100, y: 100), in: window)
+
+        XCTAssertEqual(probe.resignCount, 0)
+    }
+
+    @MainActor
+    func test_click_while_unfocused_is_ignored() {
+        let probe = FocusProbe()
+        let window = makeWindow(probe: probe)
+        probe.focused = false
+
+        click(at: NSPoint(x: 20, y: 20), in: window)
+
+        XCTAssertEqual(probe.resignCount, 0)
+    }
+
+    @MainActor
+    func test_monitor_is_removed_when_view_disappears() {
+        let probe = FocusProbe()
+        let window = makeWindow(probe: probe)
+
+        window.contentView = NSView() // onDisappear tears the monitor down
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        click(at: NSPoint(x: 20, y: 20), in: window)
+
+        XCTAssertEqual(probe.resignCount, 0)
+    }
+}


### PR DESCRIPTION
## Summary

Two small UX fixes unrelated to the Settings page.

- **Remove the "N updates available" badge from the bottom status bar.** The count is redundant with the sidebar's Updates item.
- **Resign search focus on outside click.** Clicking empty space in the detail area now drops the search field's focus. Uses a high-priority tap on the detail container, so interactive children (buttons, cards, the field itself) still consume their own taps - clicking into the search field continues to focus it.
