### PR TITLE
chore: Drop v prefix from release tags, titles, and download URLs

### DIFF
--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -12,7 +12,7 @@ WORK="$REPO_ROOT/.build/release"
 NOTARY_PROFILE="caskhub-notary"
 TEAM_ID="USYCM7BRK3"
 SPARKLE_VERSION="2.9.4"
-DOWNLOAD_URL_PREFIX="https://github.com/alielsokary/CaskHub/releases/download/v$VERSION/"
+DOWNLOAD_URL_PREFIX="https://github.com/alielsokary/CaskHub/releases/download/$VERSION/"
 
 cd "$REPO_ROOT"
 
@@ -106,13 +106,13 @@ echo "==> Generating appcast (signs with EdDSA key from Keychain)"
 cp "$WORK/updates/appcast.xml" "$REPO_ROOT/appcast.xml"
 
 # --- Publish ------------------------------------------------------------------
-echo "==> Creating GitHub release v$VERSION"
-gh release create "v$VERSION" "$ZIP" --title "CaskHub v$VERSION" --generate-notes \
+echo "==> Creating GitHub release $VERSION"
+gh release create "$VERSION" "$ZIP" --title "$VERSION" --generate-notes \
     --target "$(git rev-parse HEAD)"
 
 echo "==> Committing appcast"
 git add appcast.xml
-git commit -m "release: v$VERSION appcast"
+git commit -m "release: $VERSION appcast"
 git push
 
-echo "==> Done. v$VERSION is live; Sparkle clients will see it via appcast.xml."
+echo "==> Done. $VERSION is live; Sparkle clients will see it via appcast.xml."

--- a/appcast.xml
+++ b/appcast.xml
@@ -8,7 +8,7 @@
             <sparkle:version>116</sparkle:version>
             <sparkle:shortVersionString>0.3.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>26.2</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/alielsokary/CaskHub/releases/download/v0.3.0/CaskHub-0.3.0.zip" length="4694739" type="application/octet-stream" sparkle:edSignature="cn6RJIy9vpIAvx5usdJkhJXCXYj7Rz2kYYdm1sdl4dJr3vkJyoAAv0xdoxSm1QuabLI8sOYgIUZn8Slrb3StBA=="/>
+            <enclosure url="https://github.com/alielsokary/CaskHub/releases/download/0.3.0/CaskHub-0.3.0.zip" length="4694739" type="application/octet-stream" sparkle:edSignature="cn6RJIy9vpIAvx5usdJkhJXCXYj7Rz2kYYdm1sdl4dJr3vkJyoAAv0xdoxSm1QuabLI8sOYgIUZn8Slrb3StBA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
GitHub releases and tags now use bare version numbers (`0.3.0`, not `v0.3.0` / `CaskHub v0.3.0`).

- `Scripts/release.sh`: tag name, release title, and download URL prefix drop the `v`
- `appcast.xml`: enclosure URL updated to the renamed `0.3.0` release asset (the old `v0.3.0` asset URL stopped existing when the tag was renamed)

Existing tags/releases (`v0.1.0`, `v0.3.0`) were already renamed on GitHub to `0.1.0` / `0.3.0` with the same commits and assets.