### PR TITLE
feat: Run releases on GitHub Actions with publish-on-merge

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,31 @@
+name: Publish release
+
+# When a release PR merges to master, publish the draft release that the
+# Release build workflow created. Publishing creates the tag and makes the
+# zip's download URL (already referenced by master's appcast.xml) live.
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish draft release matching the merged version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="$(grep -m1 'MARKETING_VERSION = ' CaskHub.xcodeproj/project.pbxproj \
+            | sed 's/.*= \(.*\);/\1/')"
+          if [ "$(gh release view "$VERSION" --json isDraft --jq .isDraft 2>/dev/null)" = "true" ]; then
+            gh release edit "$VERSION" --draft=false --latest
+            echo "Published $VERSION"
+          else
+            echo "No draft release for $VERSION — nothing to publish."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release build
+
+# Builds, notarizes, and drafts a release from a release/* branch.
+# The draft goes live only when the release PR merges to master
+# (see publish-release.yml).
+#
+# Required repository secrets:
+#   DEVELOPER_ID_P12 / DEVELOPER_ID_P12_PASSWORD   base64 .p12 + its password
+#   NOTARY_KEY / NOTARY_KEY_ID / NOTARY_ISSUER_ID  App Store Connect API key
+#   SPARKLE_ED_PRIVATE_KEY                         from `generate_keys -x`
+#   TELEMETRYDECK_APP_ID / SENTRY_DSN              analytics (optional values)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.5.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-26
+    steps:
+      - name: Preflight
+        env:
+          REF: ${{ github.ref }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          case "$REF" in
+            refs/heads/release/*) ;;
+            *) echo "::error::Run this workflow from a release/* branch (got $REF)"; exit 1 ;;
+          esac
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version must be a bare number like 0.5.0 (got '$VERSION')"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # build number = git rev-list --count HEAD
+
+      - name: Import Developer ID certificate
+        env:
+          DEVELOPER_ID_P12: ${{ secrets.DEVELOPER_ID_P12 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/release.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          printf '%s' "$DEVELOPER_ID_P12" | base64 -d > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
+            -P "$DEVELOPER_ID_P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+          rm "$RUNNER_TEMP/cert.p12"
+
+      - name: Write credential files
+        env:
+          NOTARY_KEY: ${{ secrets.NOTARY_KEY }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          TELEMETRYDECK_APP_ID: ${{ secrets.TELEMETRYDECK_APP_ID }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          printf '%s' "$NOTARY_KEY" > "$RUNNER_TEMP/AuthKey.p8"
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$RUNNER_TEMP/sparkle_ed_key"
+          # xcconfig treats // as a comment even inside values; keep the DSN's
+          # scheme intact with an empty $() substitution (see Secrets.xcconfig.template)
+          printf 'TELEMETRYDECK_APP_ID = %s\nSENTRY_DSN = %s\n' \
+            "$TELEMETRYDECK_APP_ID" \
+            "$(printf '%s' "$SENTRY_DSN" | sed 's|//|/$()/|')" \
+            > Configs/Secrets.xcconfig
+
+      - name: Build, notarize, and draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NOTARY_KEY_FILE: ${{ runner.temp }}/AuthKey.p8
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+          SPARKLE_ED_KEY_FILE: ${{ runner.temp }}/sparkle_ed_key
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "Ali Elsokary"
+          git config user.email "galaxysokary92@gmail.com"
+          Scripts/release.sh "$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,5 +86,5 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           git config user.name "Ali Elsokary"
-          git config user.email "galaxysokary92@gmail.com"
+          git config user.email "ali.elsokary.w@gmail.com"
           Scripts/release.sh "$VERSION"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -3,6 +3,10 @@
 # appcast → GitHub release. Requires: Developer ID cert in Keychain, notarytool
 # keychain profile "caskhub-notary", gh CLI authenticated.
 #
+# CI (.github/workflows/release.yml) overrides the Keychain-based credentials:
+#   NOTARY_KEY_FILE / NOTARY_KEY_ID / NOTARY_ISSUER_ID  App Store Connect API key
+#   SPARKLE_ED_KEY_FILE                                 EdDSA private key file
+#
 # Usage: Scripts/release.sh <version>   e.g. Scripts/release.sh 1.0.0
 set -euo pipefail
 
@@ -75,8 +79,14 @@ APP="$WORK/export/CaskHub.app"
 # --- Notarize & staple --------------------------------------------------------
 echo "==> Notarizing (this can take a few minutes)"
 ditto -c -k --keepParent "$APP" "$WORK/notarize.zip"
-xcrun notarytool submit "$WORK/notarize.zip" \
-    --keychain-profile "$NOTARY_PROFILE" --wait
+if [[ -n "${NOTARY_KEY_FILE:-}" ]]; then
+    xcrun notarytool submit "$WORK/notarize.zip" \
+        --key "$NOTARY_KEY_FILE" --key-id "$NOTARY_KEY_ID" \
+        --issuer "$NOTARY_ISSUER_ID" --wait
+else
+    xcrun notarytool submit "$WORK/notarize.zip" \
+        --keychain-profile "$NOTARY_PROFILE" --wait
+fi
 
 echo "==> Stapling"
 xcrun stapler staple "$APP"
@@ -101,18 +111,24 @@ if [[ -z "$GENERATE_APPCAST" ]]; then
     GENERATE_APPCAST="$WORK/sparkle-dist/bin/generate_appcast"
 fi
 
-echo "==> Generating appcast (signs with EdDSA key from Keychain)"
-"$GENERATE_APPCAST" --download-url-prefix "$DOWNLOAD_URL_PREFIX" "$WORK/updates"
+echo "==> Generating appcast"
+APPCAST_ARGS=(--download-url-prefix "$DOWNLOAD_URL_PREFIX")
+if [[ -n "${SPARKLE_ED_KEY_FILE:-}" ]]; then
+    APPCAST_ARGS+=(--ed-key-file "$SPARKLE_ED_KEY_FILE")
+fi
+"$GENERATE_APPCAST" "${APPCAST_ARGS[@]}" "$WORK/updates"
 cp "$WORK/updates/appcast.xml" "$REPO_ROOT/appcast.xml"
 
 # --- Publish ------------------------------------------------------------------
-echo "==> Creating GitHub release $VERSION"
+# Draft: nothing is public (no release, no tag) until the release PR merges to
+# master and .github/workflows/publish-release.yml flips the draft live.
+echo "==> Creating draft GitHub release $VERSION"
 gh release create "$VERSION" "$ZIP" --title "$VERSION" --generate-notes \
-    --target "$(git rev-parse HEAD)"
+    --draft --target "$(git rev-parse HEAD)"
 
 echo "==> Committing appcast"
 git add appcast.xml
 git commit -m "release: $VERSION appcast"
 git push
 
-echo "==> Done. $VERSION is live; Sparkle clients will see it via appcast.xml."
+echo "==> Done. $VERSION is drafted. Merge the release PR into master to publish it."


### PR DESCRIPTION
## Flow
1. Prep a `release/x.y.z` branch as before (categories sync, version bump).
2. Run the **Release build** workflow on that branch (`gh workflow run "Release build" --ref release/x.y.z -f version=x.y.z`). It archives, notarizes, staples, and creates a **draft** release — no public release, no tag yet. The appcast commit rides on the release branch.
3. Open the release PR → master. Checks run (tests, bundled-categories freshness).
4. On merge, **Publish release** (push to master) flips the matching draft live — tag is created, the zip URL referenced by master's appcast becomes downloadable, Sparkle clients see the update.

`Scripts/release.sh` still works locally (Keychain credentials) — CI passes App Store Connect API key / Sparkle EdDSA key via env vars instead. Runner is `macos-26` (`macos-latest` is still macOS 15, older than this app's SDK).
