### PR TITLE
release: 0.4.1

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -694,7 +694,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mag.caskhub;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -731,7 +731,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.4.0;
+				MARKETING_VERSION = 0.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mag.caskhub;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/CaskHub/Resources/categories.json
+++ b/CaskHub/Resources/categories.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
-  "generatedDate": "2026-07-15",
-  "totalCasks": 3800,
+  "generatedDate": "2026-07-16",
+  "totalCasks": 3803,
   "categories": {
     "developerTools": {
       "displayName": "Developer Tools",
@@ -6780,6 +6780,12 @@
       "primary": "utilities",
       "secondary": []
     },
+    "juicy": {
+      "primary": "menuBar",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "jukebox": {
       "primary": "audioMusic",
       "secondary": []
@@ -10114,6 +10120,12 @@
         "ai"
       ]
     },
+    "oscar": {
+      "primary": "scienceEducation",
+      "secondary": [
+        "utilities"
+      ]
+    },
     "oscilloscope": {
       "primary": "audioMusic",
       "secondary": []
@@ -12903,6 +12915,12 @@
     "sloth": {
       "primary": "developerTools",
       "secondary": []
+    },
+    "smallstepagent": {
+      "primary": "securityPrivacy",
+      "secondary": [
+        "developerTools"
+      ]
     },
     "smart-converter-pro": {
       "primary": "videoMedia",
@@ -16377,5 +16395,5 @@
       "secondary": []
     }
   },
-  "releaseTag": "caskflow-v2026.07.15"
+  "releaseTag": "caskflow-v2026.07.17"
 }

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -53,6 +53,7 @@ xcodebuild -project CaskHub.xcodeproj -scheme CaskHub -configuration Release \
     -derivedDataPath "$WORK/DerivedData" \
     MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
     CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="Developer ID Application" \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
     | tail -5
 
 cat > "$WORK/ExportOptions.plist" <<PLIST

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -48,8 +48,6 @@ mkdir -p "$WORK/updates"
 
 # --- Archive & export with Developer ID --------------------------------------
 echo "==> Archiving"
-# Sign with Developer ID at archive time — the project's automatic "Apple
-# Development" identity only exists on Ali's Mac, not in the CI keychain.
 xcodebuild -project CaskHub.xcodeproj -scheme CaskHub -configuration Release \
     archive -archivePath "$WORK/CaskHub.xcarchive" \
     -derivedDataPath "$WORK/DerivedData" \

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -48,10 +48,13 @@ mkdir -p "$WORK/updates"
 
 # --- Archive & export with Developer ID --------------------------------------
 echo "==> Archiving"
+# Sign with Developer ID at archive time — the project's automatic "Apple
+# Development" identity only exists on Ali's Mac, not in the CI keychain.
 xcodebuild -project CaskHub.xcodeproj -scheme CaskHub -configuration Release \
     archive -archivePath "$WORK/CaskHub.xcarchive" \
     -derivedDataPath "$WORK/DerivedData" \
     MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+    CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="Developer ID Application" \
     | tail -5
 
 cat > "$WORK/ExportOptions.plist" <<PLIST

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>CaskHub</title>
         <item>
-            <title>0.4.0</title>
-            <pubDate>Thu, 16 Jul 2026 03:13:16 +0300</pubDate>
-            <sparkle:version>147</sparkle:version>
-            <sparkle:shortVersionString>0.4.0</sparkle:shortVersionString>
+            <title>0.4.1</title>
+            <pubDate>Fri, 17 Jul 2026 00:59:10 +0000</pubDate>
+            <sparkle:version>159</sparkle:version>
+            <sparkle:shortVersionString>0.4.1</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>26.2</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/alielsokary/CaskHub/releases/download/0.4.0/CaskHub-0.4.0.zip" length="4715068" type="application/octet-stream" sparkle:edSignature="cjxlB8T5bj3vXjBb+JR1jj6MYJaWoMAHo5Snv9SKkSv7jb2TzpitEisi1wdsdIeef7cpzdKWw4W06njH774SCA=="/>
+            <enclosure url="https://github.com/alielsokary/CaskHub/releases/download/0.4.1/CaskHub-0.4.1.zip" length="4722857" type="application/octet-stream" sparkle:edSignature="CdirWYPkbfojgToEwMyfop9qwq/cHEVIQ0y0Di8iDFscOOX7Fu5DCYrySIGyJ+lwDMrRfSk46nBunWH2lOWnDA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
First CI-built release (run [29546148283](https://github.com/alielsokary/CaskHub/actions/runs/29546148283), build 159): notarized, stapled, Gatekeeper-verified, Sparkle signature verified against the app's embedded public key. Draft release `0.4.1` is staged — **merging this PR publishes it** via the Publish release workflow.

- Bundled categories synced to caskflow-v2026.07.17
- CI signing fixes in `release.sh`: archive with Developer ID identity + explicit `DEVELOPMENT_TEAM` so SPM package targets sign on the runner
- MARKETING_VERSION → 0.4.1, appcast → 0.4.1 entry