### PR TITLE
ci: Document Actions PR-creation setting sync-develop requires

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -2,6 +2,11 @@ name: Sync develop with master
 
 # Back-merge automation: every push to master opens (or reuses) a
 # "chore: master to develop" PR so develop never drifts behind releases.
+#
+# Requires the repo setting "Allow GitHub Actions to create and approve pull
+# requests" (Settings → Actions → General). Without it, gh pr create fails
+# with "GitHub Actions is not permitted to create or approve pull requests"
+# even though this workflow has pull-requests: write.
 on:
   push:
     branches: [master]


### PR DESCRIPTION
The sync-develop workflow failed on its first real run ([29558548203](https://github.com/alielsokary/CaskHub/actions/runs/29558548203)) with "GitHub Actions is not permitted to create or approve pull requests" — the repo setting "Allow GitHub Actions to create and approve pull requests" (Settings → Actions → General) was off, and it blocks `GITHUB_TOKEN` PR creation regardless of the workflow's `pull-requests: write` permission.

The setting is now enabled and the rerun succeeded (opened #65). This PR documents the requirement in the workflow header so the failure mode is diagnosable if the setting ever gets reset.