### PR TITLE
refactor: Remove redundant comments and dead code

### DIFF
--- a/CaskHub/App/Askpass.swift
+++ b/CaskHub/App/Askpass.swift
@@ -7,13 +7,7 @@
 
 import AppKit
 
-/// The `--askpass` program mode: sudo re-launches this binary as its
-/// SUDO_ASKPASS helper (script written by
-/// `LocalHomebrewService.ensureAskpassScript`) and reads the password
-/// from stdout.
 enum Askpass {
-    /// Prints the password to stdout for sudo on "Allow"; exits 1 on cancel
-    /// so sudo — and the brew install — abort cleanly.
     static func runDialog(token: String?) -> Never {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)

--- a/CaskHub/DesignSystem/BrandFonts.swift
+++ b/CaskHub/DesignSystem/BrandFonts.swift
@@ -8,8 +8,6 @@
 import CoreText
 import Foundation
 
-/// Registers the bundled brand fonts (Baloo 2, Nunito, JetBrains Mono — all SIL OFL)
-/// for this process. Called once from CaskHubApp.init.
 enum BrandFonts {
     static func register() {
         for name in ["Baloo2", "Nunito", "JetBrainsMono"] {

--- a/CaskHub/DesignSystem/Components/BarrelMark.swift
+++ b/CaskHub/DesignSystem/Components/BarrelMark.swift
@@ -76,7 +76,6 @@ struct BarrelMark: View {
     }
 }
 
-/// "caskhub" wordmark: barrel + Baloo 2 lettering with terracotta "hub".
 struct BrandWordmark: View {
     var body: some View {
         HStack(spacing: 9) {

--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-/// Shared action strip for a cask: install / update / open / installed / in-flight,
-/// driven by LocalHomebrewService. Used by the hero, cards and rows.
 struct CaskActionsView: View {
     let cask: Cask
     var fullWidth = true

--- a/CaskHub/DesignSystem/Components/Controls.swift
+++ b/CaskHub/DesignSystem/Components/Controls.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-// Tonal liquid-glass controls: capsule action buttons, count badge, keycap.
-
 enum CaskActionStyle {
     case install, update, open, installed
 
@@ -98,7 +96,6 @@ struct ActionCapsuleButton: View {
     }
 }
 
-/// Amber count badge (sidebar "Updates", status bar).
 struct CountBadge: View {
     let count: Int
 
@@ -112,7 +109,6 @@ struct CountBadge: View {
     }
 }
 
-/// Glass keycap for keyboard hints (⌘K, /, U …).
 struct Keycap: View {
     let symbol: String
 

--- a/CaskHub/DesignSystem/Components/GlassPanel.swift
+++ b/CaskHub/DesignSystem/Components/GlassPanel.swift
@@ -7,9 +7,6 @@
 
 import SwiftUI
 
-// Glass recipe: frosted tinted surface · white hairline (lit from the top) ·
-// soft shadow.
-
 private struct GlassPanelModifier: ViewModifier {
     var radius: CGFloat
     var surface: Color
@@ -47,8 +44,6 @@ extension View {
     }
 }
 
-/// Window backdrop: warm gradient, three glowing color blobs, halftone dot texture.
-/// The glass panels above blur these blobs — that's the whole liquid-glass effect.
 struct WindowBackdrop: View {
     var body: some View {
         GeometryReader { geo in
@@ -80,7 +75,6 @@ struct WindowBackdrop: View {
     }
 }
 
-/// Halftone dot grid (1px dots on a 9px grid), from tokens/surfaces.css.
 struct HalftoneTexture: View {
     var body: some View {
         // ponytail: O(w·h/81) dots per redraw; switch to a tiled image if resize ever stutters

--- a/CaskHub/DesignSystem/Components/TopBarView.swift
+++ b/CaskHub/DesignSystem/Components/TopBarView.swift
@@ -7,29 +7,21 @@
 
 import SwiftUI
 
-/// Floating glass pill top bar: screen title, cask count,
-/// sort chip, grid/list toggle and the search field with its ⌘F keycap.
 struct TopBarView: View {
     let title: String
     let caskCount: Int
     @Binding var sortOption: SortOption
-    /// Sort choices for the current page (Recently Added adds Newest/Oldest).
     var sortOptions: [SortOption] = SortOption.standard
     @Binding var viewMode: ViewMode
     @Binding var searchText: String
     var searchFocus: FocusState<Bool>.Binding
-    /// Non-nil on Top Charts: shows the analytics period chip next to the sort chip.
     var analyticsPeriod: AnalyticsPeriod?
     var onSelectPeriod: ((AnalyticsPeriod) -> Void)?
-    /// Non-nil on Recently Added: shows the 30/60/90-day window chip.
     var recentWindow: RecentlyAddedWindow?
     var onSelectWindow: ((RecentlyAddedWindow) -> Void)?
-    /// Non-nil on Updates with pending updates: shows the Update All capsule.
     var onUpdateAll: (() -> Void)?
     var isUpdatingAll = false
-    /// Hidden on Featured — that list is curated, sorting doesn't apply.
     var showsSort = true
-    /// Called when the user presses Return in the search field.
     var onSubmitSearch: (() -> Void)?
 
     @State private var showSortMenu = false
@@ -72,8 +64,6 @@ struct TopBarView: View {
 
     // MARK: - Update All chip
 
-    /// Amber capsule matching the per-cask Update action; spins and disables
-    /// while the queue is draining.
     private var updateAllChip: some View {
         Button {
             onUpdateAll?()
@@ -101,8 +91,6 @@ struct TopBarView: View {
 
     // MARK: - Sort chip
 
-    /// Custom popover instead of Menu: NSMenu items ignore custom fonts, and
-    /// the dropdown must render Nunito like the rest of the bar.
     private var sortChip: some View {
         Button {
             showSortMenu.toggle()
@@ -164,8 +152,6 @@ struct TopBarView: View {
 
     // MARK: - Time window chip (Top Charts period / Recently Added window)
 
-    /// Only one window chip is ever visible at a time, so both share the
-    /// single showPeriodMenu state.
     private func periodChip<Option: Identifiable & Equatable>(
         current: Option,
         options: [Option],

--- a/CaskHub/DesignSystem/Components/TopBarView.swift
+++ b/CaskHub/DesignSystem/Components/TopBarView.swift
@@ -112,42 +112,16 @@ struct TopBarView: View {
         .popover(isPresented: $showSortMenu, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 2) {
                 ForEach(sortOptions) { option in
-                    sortMenuRow(option)
+                    menuRow(label: option.rawValue, isSelected: sortOption == option) {
+                        if option != sortOption { Analytics.sortChanged(option) }
+                        sortOption = option
+                        showSortMenu = false
+                    }
                 }
             }
             .padding(8)
             .frame(width: 190)
         }
-    }
-
-    private func sortMenuRow(_ option: SortOption) -> some View {
-        let isSelected = sortOption == option
-        return Button {
-            if option != sortOption { Analytics.sortChanged(option) }
-            sortOption = option
-            showSortMenu = false
-        } label: {
-            HStack {
-                Text(option.rawValue)
-                    .font(isSelected ? CHType.navActive : CHType.navItem)
-                    .foregroundStyle(isSelected ? Color.chActionInstallFg : Color.chTextNav)
-                Spacer(minLength: 8)
-                if isSelected {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundStyle(Color.chActionInstallFg)
-                }
-            }
-            .padding(.vertical, 5)
-            .padding(.horizontal, 10)
-            .background {
-                if isSelected {
-                    Capsule().fill(Color.chActionInstallBg)
-                }
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     // MARK: - Time window chip (Top Charts period / Recently Added window)
@@ -178,8 +152,9 @@ struct TopBarView: View {
         .popover(isPresented: $showPeriodMenu, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 2) {
                 ForEach(options) { option in
-                    periodMenuRow(label: option[keyPath: label], isSelected: option == current) {
+                    menuRow(label: option[keyPath: label], isSelected: option == current) {
                         onSelect(option)
+                        showPeriodMenu = false
                     }
                 }
             }
@@ -188,11 +163,8 @@ struct TopBarView: View {
         }
     }
 
-    private func periodMenuRow(label: String, isSelected: Bool, onSelect: @escaping () -> Void) -> some View {
-        Button {
-            onSelect()
-            showPeriodMenu = false
-        } label: {
+    private func menuRow(label: String, isSelected: Bool, onSelect: @escaping () -> Void) -> some View {
+        Button(action: onSelect) {
             HStack {
                 Text(label)
                     .font(isSelected ? CHType.navActive : CHType.navItem)

--- a/CaskHub/DesignSystem/Tokens/ColorTokens.swift
+++ b/CaskHub/DesignSystem/Tokens/ColorTokens.swift
@@ -30,8 +30,6 @@ extension Color {
     static let chInk = Color(nsColor: NSColor(hex: 0x33304A))
     static let chTerracotta = Color(nsColor: NSColor(hex: 0xC8674A))
     static let chTerracottaLid = Color(nsColor: NSColor(hex: 0xA94F36))
-    static let chSage = Color(nsColor: NSColor(hex: 0x6FA287))
-    static let chAmber = Color(nsColor: NSColor(hex: 0xD99A4E))
     static let chGoldBand = Color(nsColor: NSColor(hex: 0xF0D59A))
 
     // ── Window background gradient stops ──────────────
@@ -40,7 +38,6 @@ extension Color {
     static let chBg3 = adaptive(light: NSColor(hex: 0xF3E6C6), dark: NSColor(hex: 0x262234))
 
     // ── Glass surfaces ─────────────────────────────────
-    static let chSurfaceSidebar = adaptive(light: NSColor(hex: 0xFDF6E4, alpha: 0.80), dark: NSColor(hex: 0x242132, alpha: 0.88))
     static let chSurfaceToolbar = adaptive(light: NSColor(hex: 0xFDF6E4, alpha: 0.82), dark: NSColor(hex: 0x353147, alpha: 0.85))
     static let chSurfaceCard = adaptive(light: NSColor(hex: 0xFDF6E4, alpha: 0.80), dark: NSColor(hex: 0x353147, alpha: 0.85))
     static let chSurfaceHero = adaptive(light: NSColor(hex: 0xFDF6E4, alpha: 0.78), dark: NSColor(hex: 0x3A3450, alpha: 0.85))
@@ -51,7 +48,6 @@ extension Color {
     // ── Hairlines & separators ─────────────────────────
     static let chHairline = adaptive(light: NSColor(hex: 0xFFFFFF, alpha: 0.75), dark: NSColor(hex: 0xFFFFFF, alpha: 0.14))
     static let chHairlineStrong = adaptive(light: NSColor(hex: 0xFFFFFF, alpha: 0.90), dark: NSColor(hex: 0xFFFFFF, alpha: 0.22))
-    static let chSeparator = adaptive(light: NSColor(hex: 0x33304A, alpha: 0.18), dark: NSColor(hex: 0xF6E9CB, alpha: 0.12))
 
     // ── Text ───────────────────────────────────────────
     static let chTextTitle = adaptive(light: NSColor(hex: 0x33304A), dark: NSColor(hex: 0xF6E9CB))

--- a/CaskHub/DesignSystem/Tokens/SurfaceTokens.swift
+++ b/CaskHub/DesignSystem/Tokens/SurfaceTokens.swift
@@ -8,13 +8,10 @@
 import SwiftUI
 
 enum CHRadius {
-    static let window: CGFloat = 20
     static let hero: CGFloat = 20
     static let card: CGFloat = 18
     static let iconLg: CGFloat = 26 // hero app icon well
-    static let icon: CGFloat = 11 // card app icon well
     static let keycap: CGFloat = 5
-    static let badge: CGFloat = 9
     // fields, pills and buttons are capsules
 }
 
@@ -27,11 +24,8 @@ enum CHSize {
 }
 
 enum CHSpace {
-    static let s1: CGFloat = 4
-    static let s2: CGFloat = 8
     static let s3: CGFloat = 12
     static let s4: CGFloat = 16
     static let s5: CGFloat = 24
-    static let s6: CGFloat = 32
     static let gridGap: CGFloat = 14 // cask card grid gap
 }

--- a/CaskHub/DesignSystem/Tokens/TypographyTokens.swift
+++ b/CaskHub/DesignSystem/Tokens/TypographyTokens.swift
@@ -14,7 +14,6 @@ enum CHType {
 
     // Display — wordmark, screen titles, section heads
     static let wordmark = Font.custom(displayFamily, size: 19).weight(.heavy)
-    static let screenTitle = Font.custom(displayFamily, size: 26).weight(.heavy)
     static let heroTitle = Font.custom(displayFamily, size: 28).weight(.heavy)
     static let section = Font.custom(displayFamily, size: 16).weight(.heavy)
 

--- a/CaskHub/Models/AppTheme.swift
+++ b/CaskHub/Models/AppTheme.swift
@@ -24,12 +24,7 @@ enum AppTheme: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Theme switching via NSApp.appearance instead of preferredColorScheme:
-    /// the window backdrop (containerBackground) and the dynamic NSColor tokens
-    /// then resolve against the same appearance. preferredColorScheme(nil)
-    /// left the two out of sync after a Light/Dark → System switch.
     static func apply(_ raw: String) {
-        // NSApplication.shared, not NSApp — NSApp is still nil during App.init().
         let app = NSApplication.shared
         switch AppTheme(rawValue: raw) ?? .system {
         case .system: app.appearance = nil

--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -92,23 +92,19 @@ extension Cask {
         token: String,
         name: String? = nil,
         desc: String? = nil,
-        homepage: String = "https://example.com",
-        url: String? = nil,
         version: String = "1.0",
         deprecated: Bool = false,
         disabled: Bool = false,
-        autoUpdates: Bool? = nil,
-        fullToken: String? = nil,
-        tap: String? = nil
+        autoUpdates: Bool? = nil
     ) -> Cask {
         Cask(
             token: token,
-            fullToken: fullToken,
-            tap: tap,
+            fullToken: nil,
+            tap: nil,
             name: [name ?? token],
             desc: desc,
-            homepage: homepage,
-            url: url,
+            homepage: "https://example.com",
+            url: nil,
             version: version,
             bundleVersion: nil,
             bundleShortVersion: nil,

--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -47,7 +47,6 @@ struct Cask: Codable, Identifiable, Hashable {
     let homepage: String
     let url: String?
     let version: String
-    let installed: String?
     let bundleVersion: String?
     let bundleShortVersion: String?
     let outdated: Bool
@@ -79,10 +78,6 @@ struct Cask: Codable, Identifiable, Hashable {
         return numeric.isEmpty ? base : numeric
     }
 
-    var homepageDomain: String? {
-        URL(string: homepage)?.host
-    }
-
     func metaLine(downloads: String?) -> String {
         var parts: [String] = []
         if let downloads { parts.append("↓ \(downloads)") }
@@ -90,3 +85,38 @@ struct Cask: Codable, Identifiable, Hashable {
         return parts.joined(separator: " · ")
     }
 }
+
+#if DEBUG
+extension Cask {
+    static func preview(
+        token: String,
+        name: String? = nil,
+        desc: String? = nil,
+        homepage: String = "https://example.com",
+        url: String? = nil,
+        version: String = "1.0",
+        deprecated: Bool = false,
+        disabled: Bool = false,
+        autoUpdates: Bool? = nil,
+        fullToken: String? = nil,
+        tap: String? = nil
+    ) -> Cask {
+        Cask(
+            token: token,
+            fullToken: fullToken,
+            tap: tap,
+            name: [name ?? token],
+            desc: desc,
+            homepage: homepage,
+            url: url,
+            version: version,
+            bundleVersion: nil,
+            bundleShortVersion: nil,
+            outdated: false,
+            deprecated: deprecated,
+            disabled: disabled,
+            autoUpdates: autoUpdates
+        )
+    }
+}
+#endif

--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-/// One `artifacts` stanza from the brew API — heterogeneous single-key
-/// objects ({"app": [...]}, {"binary": [...]}); only the keys matter here.
 struct ArtifactStanza: Codable, Hashable {
     let keys: Set<String>
 
@@ -28,7 +26,6 @@ struct ArtifactStanza: Codable, Hashable {
     }
 
     init(from decoder: Decoder) throws {
-        // Lenient: a malformed stanza must not sink the whole catalog decode.
         keys = Set((try? decoder.container(keyedBy: AnyKey.self))?
             .allKeys.map(\.stringValue) ?? [])
     }
@@ -63,16 +60,6 @@ struct Cask: Codable, Identifiable, Hashable {
         token
     }
 
-    /// Ships a command-line `binary` (or a `stage_only` payload like sqlcl)
-    /// and nothing GUI (no app/suite/pkg). The binary/stage requirement keeps
-    /// installer-app GUI casks (autodesk-fusion, logi-options+) off the CLI
-    /// treatment; pkg-based CLIs (git-credential-manager, ibm-cloud-cli)
-    /// stay non-CLI and keep their real icons.
-    ///
-    /// Drives only the placeholder: CLI casks show a terminal tile instead
-    /// of the window glyph. Which CLI casks get real icons anyway (Android
-    /// SDK tools, tuist, conda family) is CaskFlow's call — whatever its
-    /// icons branch serves wins over the tile.
     var isCLI: Bool {
         guard let artifacts, !artifacts.isEmpty else { return false }
         return artifacts.contains { !$0.keys.isDisjoint(with: ["binary", "stageOnly", "stage_only"]) }
@@ -96,7 +83,6 @@ struct Cask: Codable, Identifiable, Hashable {
         URL(string: homepage)?.host
     }
 
-    /// "↓ 1.2M · v125.0" — the downloads part is omitted when unknown.
     func metaLine(downloads: String?) -> String {
         var parts: [String] = []
         if let downloads { parts.append("↓ \(downloads)") }

--- a/CaskHub/Models/CaskIconURL.swift
+++ b/CaskHub/Models/CaskIconURL.swift
@@ -7,12 +7,7 @@
 
 import Foundation
 
-/// Icon sources, all original app icons keyed by cask token — no generated
-/// fallbacks (favicons, avatars). Casks without an extracted icon show the
-/// placeholder until CaskFlow's daily pipeline picks them up.
 enum CaskIconURL {
-    /// Original app icons extracted by CaskFlow (icons branch, keyed by token).
-    /// jsDelivr edge CDN first, raw.githubusercontent.com as fallback.
     static func caskFlowIconURLs(for token: String) -> [URL] {
         [
             URL(string: "https://cdn.jsdelivr.net/gh/alielsokary/CaskFlow@icons/\(token).png"),
@@ -20,9 +15,6 @@ enum CaskIconURL {
         ].compactMap { $0 }
     }
 
-    /// App-Fair/appcasks GitHub releases — also original icons, but frozen
-    /// pre-2022. Covers some casks CaskFlow can't extract (EULA walls, dead
-    /// vendor URLs that worked back then).
     static func appFairIconURL(for token: String) -> URL? {
         URL(string: "https://github.com/App-Fair/appcasks/releases/download/cask-\(token)/AppIcon.png")
     }

--- a/CaskHub/Services/Analytics+Events.swift
+++ b/CaskHub/Services/Analytics+Events.swift
@@ -14,8 +14,6 @@ import Foundation
 extension Analytics {
     // MARK: - Cask actions
 
-    /// Success signal for install / uninstall / update. App launches
-    /// (`.opening`) are deliberately not tracked.
     static func caskActionCompleted(_ action: CaskAction, token: String) {
         guard let verb = action.analyticsVerb else { return }
         send("Cask.\(verb.past)", parameters: ["cask": token])
@@ -34,8 +32,7 @@ extension Analytics {
 
     // MARK: - Navigation
 
-    /// Fires for every detail-page change: sidebar clicks, category clicks
-    /// on cards, and View All — they all route through the same selection.
+    /// Fires for every detail-page change: sidebar clicks, category clicks on cards, and View All
     static func pageOpened(_ selection: SidebarSelection) {
         send("Page.opened", parameters: parameters(for: selection))
     }

--- a/CaskHub/Services/Analytics.swift
+++ b/CaskHub/Services/Analytics.swift
@@ -8,24 +8,15 @@
 import Foundation
 import TelemetryDeck
 
-/// Abstraction over the analytics backend: swapping providers means writing
-/// one new conforming type — the event vocabulary (Analytics+Events.swift)
-/// and its call sites never change.
 protocol AnalyticsProvider {
-    /// Called once from `App.init()`, before any window exists.
-    /// `enabled` reflects the stored opt-out setting.
     func start(enabled: Bool)
-    /// Live opt-out flip from the Settings toggle.
     func setEnabled(_ enabled: Bool)
     func send(_ signalName: String, parameters: [String: String])
 }
 
-/// The facade the app talks to. Owns the opt-out setting (Settings → Privacy)
-/// and forwards everything else to the provider.
 enum Analytics {
     static let enabledKey = "analyticsEnabled"
 
-    /// `var` so tests can inject a spy; production never reassigns it.
     static var provider: AnalyticsProvider = TelemetryDeckProvider()
 
     static var isEnabled: Bool {
@@ -36,15 +27,11 @@ enum Analytics {
         provider.start(enabled: isEnabled)
     }
 
-    /// Re-reads the opt-out setting; call after the Settings toggle changes.
     static func refresh() {
         provider.setEnabled(isEnabled)
     }
 
     static func send(_ signalName: String, parameters: [String: String] = [:]) {
-        // Usage events double as pre-crash breadcrumbs. Governed by the
-        // crash-reporting consent, not the analytics one — breadcrumbs only
-        // leave the machine attached to a Sentry event.
         CrashReporter.breadcrumb(signalName, data: parameters)
         provider.send(signalName, parameters: parameters)
     }
@@ -54,16 +41,11 @@ enum Analytics {
 
 /// Session signals (launches, active users) are sent by the SDK automatically.
 final class TelemetryDeckProvider: AnalyticsProvider {
-    /// Injected at build time: Configs/Secrets.xcconfig → Info.plist → here
-    /// (see Configs/Secrets.xcconfig.template). Nil on builds without the
-    /// secret (fresh clones, CI) — analytics then stays off entirely.
     private static var appID: String? {
         let value = Bundle.main.object(forInfoDictionaryKey: "TelemetryDeckAppID") as? String
         return value?.isEmpty == false ? value : nil
     }
 
-    /// Config is a reference type the SDK reads at send time, so keeping it
-    /// lets `setEnabled` flip opt-out at runtime without re-initializing.
     private var config: TelemetryDeck.Config?
 
     func start(enabled: Bool) {
@@ -79,8 +61,6 @@ final class TelemetryDeckProvider: AnalyticsProvider {
     }
 
     func send(_ signalName: String, parameters: [String: String]) {
-        // Never initialized (no secret): the SDK's shared-instance getter
-        // asserts in Debug builds, so signals must not reach it.
         guard config != nil else { return }
         TelemetryDeck.signal(signalName, parameters: parameters)
     }

--- a/CaskHub/Services/BrewAPIClient.swift
+++ b/CaskHub/Services/BrewAPIClient.swift
@@ -12,10 +12,6 @@ protocol BrewAPIClientProtocol {
     func fetchAnalytics(period: AnalyticsPeriod) async throws -> CaskAnalyticsResponse
 }
 
-/// The two formulae.brew.sh endpoints the app consumes. Unlike the
-/// best-effort CaskFlowReleases fetches, these throw: the catalog is the
-/// app's main content, so the ViewModel surfaces `localizedDescription`
-/// with a Retry button.
 final class BrewAPIClient: BrewAPIClientProtocol {
     struct HTTPError: LocalizedError {
         let statusCode: Int

--- a/CaskHub/Services/CaskFlowReleases.swift
+++ b/CaskHub/Services/CaskFlowReleases.swift
@@ -7,16 +7,11 @@
 
 import Foundation
 
-/// Fetches data assets from CaskFlow's latest GitHub release.
 enum CaskFlowReleases {
-    /// GitHub redirects `releases/latest/download/<asset>` to the newest
-    /// release's asset, so these URLs are stable across releases.
     private static let baseURL = URL(
         string: "https://github.com/alielsokary/CaskFlow/releases/latest/download/"
     )!
 
-    /// Best-effort fetch and decode of a release asset. Returns nil on any
-    /// network, HTTP, or decoding failure — callers keep their current data.
     static func fetch<T: Decodable>(_: T.Type, asset: String) async -> T? {
         var request = URLRequest(url: baseURL.appendingPathComponent(asset))
         request.timeoutInterval = 10

--- a/CaskHub/Services/CategoryService.swift
+++ b/CaskHub/Services/CategoryService.swift
@@ -23,8 +23,6 @@ struct TokenCategoryMapping: Codable, Hashable {
 struct CaskCategoryData: Codable {
     let version: Int
     let generatedDate: String
-    /// GitHub release tag (e.g. "caskflow-v2026.07.10"), stamped into the
-    /// asset by CaskFlow's release workflow. Absent in older data.
     let releaseTag: String?
     let totalCasks: Int
     let categories: [String: CategoryDefinition]
@@ -61,9 +59,6 @@ final class CategoryService {
         applyData(catalog)
     }
 
-    /// Best-effort fetch of the latest categories.json from CaskFlow's GitHub Releases.
-    /// Silent on every failure path — bundled data remains in use.
-    /// Schema-version mismatches and older `generatedDate` values are also rejected.
     func refreshFromRemote() async {
         guard let remote = await CaskFlowReleases.fetch(CaskCategoryData.self, asset: "categories.json"),
               remote.version == version,
@@ -90,12 +85,10 @@ final class CategoryService {
         releaseTag = catalog.releaseTag
     }
 
-    /// Returns the primary category for a cask token.
     func category(for token: String) -> CategoryID? {
         tokenMappings[token]?.primary
     }
 
-    /// Returns all cask tokens in a category (includes both primary and secondary assignments).
     func tokens(in categoryID: CategoryID) -> Set<String> {
         categoryTokenSets[categoryID] ?? []
     }

--- a/CaskHub/Services/CrashReporter.swift
+++ b/CaskHub/Services/CrashReporter.swift
@@ -8,38 +8,24 @@
 import Foundation
 import Sentry
 
-/// Handle for an in-flight trace span so call sites and tests never see
-/// Sentry types.
 protocol CrashSpan {
     func finish()
     func finish(error: Error)
 }
 
-/// Abstraction over the crash-reporting backend, mirroring AnalyticsProvider:
-/// swapping providers means one new conforming type.
 protocol CrashReporterProvider {
-    /// Called once from `App.init()`, before any window exists.
-    /// `enabled` reflects the stored opt-out setting.
     func start(enabled: Bool)
-    /// Live opt-out flip from the Settings toggle.
     func setEnabled(_ enabled: Bool)
     func capture(_ error: Error)
     func addBreadcrumb(_ message: String, data: [String: String])
     func startSpan(name: String, operation: String) -> CrashSpan
 }
 
-/// The facade the app talks to. Owns the opt-out setting (Settings → Privacy)
-/// and the per-launch capture rate limit; forwards everything else to the
-/// provider. Implicitly @MainActor (module default isolation) — detached
-/// tasks call it with `await`.
 enum CrashReporter {
     static let enabledKey = "crashReportingEnabled"
 
-    /// `var` so tests can inject a spy; production never reassigns it.
     static var provider: CrashReporterProvider = SentryProvider()
 
-    /// Per-launch capture counts by error signature. Internal (not private)
-    /// so tests can reset between cases.
     static var captureCounts: [String: Int] = [:]
     private static let captureLimit = 5
 
@@ -51,14 +37,10 @@ enum CrashReporter {
         provider.start(enabled: isEnabled)
     }
 
-    /// Re-reads the opt-out setting; call after the Settings toggle changes.
     static func refresh() {
         provider.setEnabled(isEnabled)
     }
 
-    /// Reports a handled error. Capped at `captureLimit` per error signature
-    /// per launch so a tight failure loop (e.g. disk full on every icon
-    /// write) can't burn the event quota.
     static func capture(_ error: Error) {
         guard isEnabled else { return }
         let nsError = error as NSError
@@ -80,7 +62,6 @@ enum CrashReporter {
     }
 }
 
-/// Inert span for the opted-out and no-DSN paths.
 struct NoOpCrashSpan: CrashSpan {
     func finish() {}
     func finish(error: Error) {}
@@ -89,27 +70,18 @@ struct NoOpCrashSpan: CrashSpan {
 // MARK: - Sentry
 
 final class SentryProvider: CrashReporterProvider {
-    /// Injected at build time: Configs/Secrets.xcconfig → Info.plist → here
-    /// (see Configs/Secrets.xcconfig.template). Nil on builds without the
-    /// secret (fresh clones, CI) — crash reporting then stays off entirely.
     private static var dsn: String? {
         let value = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String
         return value?.isEmpty == false ? value : nil
     }
 
-    /// Sentry has no runtime pause: opt-out closes the SDK, opt-in restarts
-    /// it. `started` also gates spans so we never hand out live transactions
-    /// from a closed SDK.
     private var started = false
 
     func start(enabled: Bool) {
         guard enabled, let dsn = Self.dsn else { return }
         SentrySDK.start { options in
             options.dsn = dsn
-            // Small user base — lower if volume grows.
             options.tracesSampleRate = 1.0
-            // Release/dist come from the SDK's bundle-derived defaults;
-            // environment defaults to "production".
             #if DEBUG
             options.environment = "debug"
             #endif

--- a/CaskHub/Services/ImageCacheService.swift
+++ b/CaskHub/Services/ImageCacheService.swift
@@ -17,8 +17,6 @@ final class ImageCacheService {
     private var upgradeInFlight: Set<String> = []
     private let session: URLSession
 
-    /// How long a full-chain miss suppresses re-fetching. Misses re-try daily
-    /// so users pick up newly backfilled CaskFlow icons without launch chatter.
     private static let missRetryInterval: TimeInterval = 24 * 60 * 60
 
     private static let cacheDirectory: URL = {
@@ -27,7 +25,6 @@ final class ImageCacheService {
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         } catch {
-            // Disk cache is dead for the session — icons fall back to memory-only.
             CrashReporter.capture(error)
         }
         return dir
@@ -42,41 +39,29 @@ final class ImageCacheService {
     func image(for cask: Cask) async -> NSImage? {
         let token = cask.token
 
-        // 1. Memory cache
         if let cached = memoryCache.object(forKey: token as NSString) {
             return cached
         }
 
-        // CLI casks: icons cached before the cutover may since have been
-        // retired by CaskFlow's curated CLI tier — drop and refetch once.
         if cask.isCLI {
             purgeStaleCLIIcon(token: token)
         }
 
-        // 2. Disk cache — fallback-tier hits also schedule a background
-        // CaskFlow upgrade check (at most daily), so icons cached from
-        // favicon/avatar before CaskFlow coverage arrived aren't pinned forever.
         if let diskImage = loadFromDisk(token: token) {
             memoryCache.setObject(diskImage, forKey: token as NSString)
             maybeUpgradeFallbackIcon(token: token)
             return diskImage
         }
 
-        // 3. Recent-miss cooldown: every tier failed with real HTTP responses
-        // within the last day — skip the whole chain until the cooldown lapses.
         if hasRecentMiss(token: token) {
             return nil
         }
 
-        // 4. Coalesce in-flight requests
         if let existing = inFlightTasks[token] {
             return await existing.value
         }
 
         let task = Task<NSImage?, Never> {
-            // Track whether any tier got an actual HTTP response: a miss is
-            // only recorded when servers answered (offline must not poison
-            // the cooldown for a day).
             var sawHTTPResponse = false
             func fetch(_ url: URL) async -> NSImage? {
                 let (image, responded) = await self.downloadImage(from: url)
@@ -84,8 +69,6 @@ final class ImageCacheService {
                 return image
             }
 
-            // Tier 0: CaskFlow original icon (our own extraction pipeline —
-            // jsDelivr CDN with raw.githubusercontent fallback, backfilling)
             for url in CaskIconURL.caskFlowIconURLs(for: token) {
                 if let image = await fetch(url) {
                     cache(image: image, token: token, fromCaskFlow: true)
@@ -93,10 +76,6 @@ final class ImageCacheService {
                 }
             }
 
-            // Tier 1: App-Fair app icon (also original; frozen pre-2022 —
-            // covers some casks CaskFlow can't extract today). Skipped for
-            // CLI casks: their icon policy is CaskFlow's alone — anything
-            // else falls through to the app's CLI tile.
             if !cask.isCLI,
                let url = CaskIconURL.appFairIconURL(for: token),
                let image = await fetch(url) {
@@ -104,8 +83,6 @@ final class ImageCacheService {
                 return image
             }
 
-            // No generated fallbacks (favicons, avatars) — by design the
-            // placeholder shows until an original icon exists.
             if sawHTTPResponse {
                 markMiss(token: token)
             }
@@ -118,8 +95,6 @@ final class ImageCacheService {
         return result
     }
 
-    /// Wipes the in-memory and on-disk icon caches. Each icon re-downloads
-    /// through the normal CaskFlow → App-Fair chain the next time it's shown.
     func clearCache() {
         memoryCache.removeAllObjects()
         try? FileManager.default.removeItem(at: Self.cacheDirectory)
@@ -130,8 +105,6 @@ final class ImageCacheService {
 
     // MARK: - Private
 
-    /// gotResponse distinguishes "server said no" (404 etc.) from transport
-    /// failure (offline) — only real responses may arm the miss cooldown.
     private func downloadImage(from url: URL) async -> (image: NSImage?, gotResponse: Bool) {
         guard let (data, response) = try? await session.data(from: url),
               let httpResponse = response as? HTTPURLResponse
@@ -152,20 +125,14 @@ final class ImageCacheService {
         saveToDisk(image: image, token: token)
         try? FileManager.default.removeItem(at: missMarkerPath(for: token))
         if fromCaskFlow {
-            // Terminal quality — never re-checked.
             try? FileManager.default.removeItem(at: fallbackMarkerPath(for: token))
         } else {
-            // Fallback tier (App-Fair/favicon/avatar): upgrade-eligible.
-            // mtime = now, so the first CaskFlow re-check happens tomorrow —
-            // CaskFlow necessarily missed moments ago on this same chain run.
             try? Data().write(to: fallbackMarkerPath(for: token), options: .atomic)
         }
     }
 
     // MARK: - CLI cutover purge
 
-    /// 2026-07-09 12:00 UTC — CaskFlow's curated-CLI icon cleanup plus the
-    /// jsDelivr branch TTL that kept serving the retired files.
     private static let cliIconCutover = Date(timeIntervalSince1970: 1_783_598_400)
 
     private func purgeStaleCLIIcon(token: String) {
@@ -178,8 +145,6 @@ final class ImageCacheService {
         }
         try? FileManager.default.removeItem(at: path)
         try? FileManager.default.removeItem(at: fallbackMarkerPath(for: token))
-        // jsDelivr's long max-age would replay the retired icon's cached 200
-        // from URLCache — evict so the refetch hits the network.
         let urlCache = session.configuration.urlCache ?? .shared
         for url in CaskIconURL.caskFlowIconURLs(for: token) {
             urlCache.removeCachedResponse(for: URLRequest(url: url))
@@ -192,9 +157,6 @@ final class ImageCacheService {
         Self.cacheDirectory.appendingPathComponent("\(token).fallback")
     }
 
-    /// A disk-cached fallback icon is re-checked against CaskFlow at most once
-    /// per missRetryInterval — lazily, only when the cask is actually shown.
-    /// A hit permanently replaces the cached icon and retires the marker.
     private func maybeUpgradeFallbackIcon(token: String) {
         let marker = fallbackMarkerPath(for: token)
         guard let mtime = try? FileManager.default
@@ -214,7 +176,6 @@ final class ImageCacheService {
                     return
                 }
             }
-            // Still not on CaskFlow — reset the daily timer.
             try? FileManager.default.setAttributes(
                 [.modificationDate: Date()], ofItemAtPath: marker.path
             )
@@ -222,12 +183,6 @@ final class ImageCacheService {
         }
     }
 
-    /// One-time migration: purge cached icons that predate the original-only
-    /// chain. Anything carrying a fallback marker (or unmarked from before
-    /// tier tracking) may be a favicon/avatar — delete it and let the cask
-    /// refetch through CaskFlow → App-Fair. CaskFlow-tier caches are unmarked
-    /// only if fetched after tier tracking, so we key off the v1 flag:
-    /// pre-tracking installs purge everything marked or migrated.
     private nonisolated static func purgeGeneratedIconsIfNeeded() {
         Task.detached(priority: .utility) {
             let dir = await Self.cacheDirectory
@@ -243,7 +198,6 @@ final class ImageCacheService {
                 )
                 try? FileManager.default.removeItem(at: marker)
             }
-            // Retired artifacts from the avatar tier and the v1 migration.
             try? FileManager.default.removeItem(
                 at: dir.deletingLastPathComponent()
                     .appendingPathComponent("github_owner_types.json")

--- a/CaskHub/Services/InstallReceipt.swift
+++ b/CaskHub/Services/InstallReceipt.swift
@@ -7,24 +7,7 @@
 
 import Foundation
 
-/// Minimal parser for Homebrew's per-cask install receipt at
-/// `<Caskroom>/<token>/.metadata/INSTALL_RECEIPT.json`.
-///
-/// Uses `JSONSerialization` rather than `Decodable`: `uninstall_artifacts`
-/// is a heterogeneous array of single-key dictionaries with mixed value
-/// types. Decodable handles that shape too (`ArtifactStanza` decodes the
-/// same kind of stanza with a custom key type), but extracting a single
-/// key is fewer lines as a tree walk than as a custom `init(from:)`.
-///
-/// Marked `nonisolated` because the project uses `-default-isolation=MainActor`
-/// and this parser is invoked from a background `Task.detached` in the scan loop.
 nonisolated struct InstallReceipt {
-    /// `.app` bundle filenames extracted from `uninstall_artifacts`, e.g. `["Firefox.app"]`.
-    /// Empty when the cask installs no apps (CLI-only casks like `android-platform-tools`).
-    ///
-    /// Note: the receipt also contains `source.version` and `time`, but these freeze at the
-    /// original install and never update after `brew upgrade`. The authoritative version comes
-    /// from the Caskroom **version directory name**, and the date from its filesystem timestamp.
     let appBundleNames: [String]
 
     init(jsonData: Data) throws {

--- a/CaskHub/Services/LocalHomebrewService+Brew.swift
+++ b/CaskHub/Services/LocalHomebrewService+Brew.swift
@@ -7,15 +7,9 @@
 
 import Foundation
 
-/// The nonisolated plumbing that talks to the Homebrew installation directly:
-/// process helpers, Caskroom scanning, and path discovery. No UI state here —
-/// everything is static and safe to call off the main actor.
 extension LocalHomebrewService {
     // MARK: - Process Helpers
 
-    /// Writes the SUDO_ASKPASS helper: re-execs this binary in `--askpass`
-    /// mode. Rewritten per mutation so the binary path (moves between dev
-    /// builds) and the token stay current.
     nonisolated static func ensureAskpassScript(token: String) -> URL? {
         guard let executablePath = Bundle.main.executableURL?.path else { return nil }
         // Interpolated into a shell script — keep only known-safe characters.
@@ -43,8 +37,6 @@ extension LocalHomebrewService {
         return url
     }
 
-    /// Sends `signal` to a process and all of its descendants (brew forks curl;
-    /// signalling only brew would leave curl downloading to a dead parent).
     nonisolated static func signalTree(pid: Int32, signal: Int32) {
         let pgrep = Process()
         pgrep.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
@@ -65,10 +57,6 @@ extension LocalHomebrewService {
         kill(pid, signal)
     }
 
-    /// Deletes downloads newer than `cutoff` from Homebrew's cache — the only
-    /// residue a download-phase cancel leaves behind. Covers both `*.incomplete`
-    /// partials and just-finished archives (cancel can land after the download
-    /// completed but before staging began).
     nonisolated static func cleanupIncompleteDownloads(since cutoff: Date) {
         let fm = FileManager.default
         let cacheURL: URL
@@ -89,7 +77,6 @@ extension LocalHomebrewService {
         }
     }
 
-    /// Runs `brew --version` and returns the bare version ("Homebrew 4.6.15" → "4.6.15").
     nonisolated static func fetchBrewVersion() async -> String? {
         guard let brewURL = locateBrewBinary() else { return nil }
         return await Task.detached(priority: .utility) {
@@ -116,7 +103,6 @@ extension LocalHomebrewService {
 
     // MARK: - Filesystem Scanning
 
-    /// Scans the Caskroom to build a map of locally-installed casks.
     nonisolated static func scanCaskroom(
         fileManager: FileManager
     ) -> Result<[String: LocalCaskInstallation], LocalHomebrewError> {
@@ -140,26 +126,14 @@ extension LocalHomebrewService {
         return .success(result)
     }
 
-    /// Builds the snapshot for one `Caskroom/<token>/` directory.
-    ///
-    /// **Version**: read from the version-directory NAME (e.g.
-    /// `Caskroom/finetune/1.4.1/`), NOT from `INSTALL_RECEIPT.json`'s
-    /// `source.version` which freezes at the original install and never
-    /// updates after `brew upgrade`. When several version directories exist,
-    /// the most recently modified one wins.
-    ///
-    /// **Date**: the version directory's modification date — when Homebrew
-    /// staged the files for that version.
-    ///
-    /// **App bundles**: extracted from the install receipt's
-    /// `uninstall_artifacts` — the app name rarely changes between versions.
+    /// Version comes from the version-directory name, not the receipt's `source.version`,
+    /// which freezes at the original install and never updates after `brew upgrade`.
     private nonisolated static func scanCaskEntry(
         _ entry: URL,
         fileManager: FileManager
     ) -> LocalCaskInstallation? {
         var isDir: ObjCBool = false
         guard fileManager.fileExists(atPath: entry.path, isDirectory: &isDir), isDir.boolValue,
-              // `.skipsHiddenFiles` also excludes the `.metadata/` directory.
               let subDirs = try? fileManager.contentsOfDirectory(
                   at: entry,
                   includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey],
@@ -197,8 +171,6 @@ extension LocalHomebrewService {
 
     // MARK: - Path Discovery
 
-    /// Candidate locations for `relativePath` under the Homebrew prefix:
-    /// `$HOMEBREW_PREFIX` first, then Apple Silicon, then Intel default.
     private nonisolated static func brewPrefixCandidates(_ relativePath: String) -> [URL] {
         var candidates: [URL] = []
         if let prefix = ProcessInfo.processInfo.environment["HOMEBREW_PREFIX"], !prefix.isEmpty {

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -11,7 +11,6 @@ import Observation
 
 // MARK: - Public Types
 
-/// Snapshot of one locally-installed cask, derived from its INSTALL_RECEIPT.json.
 struct LocalCaskInstallation: Hashable, Identifiable {
     let token: String
     let installedVersion: String
@@ -23,13 +22,11 @@ struct LocalCaskInstallation: Hashable, Identifiable {
     }
 }
 
-/// Which background action is currently running for a given cask, if any.
 enum CaskAction: Equatable {
     case opening
     case installing
     case updating
     case uninstalling
-    /// In the Update All queue, not yet started.
     case queued
 
     var inProgressLabel: String {
@@ -60,7 +57,6 @@ enum LocalHomebrewError: LocalizedError {
         case let .brewCommandFailed(args, code, stderr):
             let cmd = (["brew"] + args).joined(separator: " ")
             let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            // "reports different checksum" = cask; "SHA256 mismatch" = formula dependency.
             if trimmed.contains("reports different checksum") || trimmed.contains("SHA256 mismatch") {
                 return "The download doesn't match the checksum Homebrew has on record — "
                     + "the developer likely replaced the release file after it was published. "
@@ -76,45 +72,27 @@ enum LocalHomebrewError: LocalizedError {
 
 // MARK: - LocalHomebrewService
 
-/// Single source of truth for *this Mac's* local Homebrew cask state.
-///
-/// - Detection is filesystem-only (reads `Caskroom/<token>/.metadata/INSTALL_RECEIPT.json`),
-///   so it's fast and doesn't require `brew` to be in PATH.
-/// - Mutations (`uninstall`, `upgrade`) shell out to the real `brew` binary so its
-///   bookkeeping stays consistent.
-/// - All public state is observed through `@Observable`; views auto-redraw on changes.
 @MainActor
 @Observable
 final class LocalHomebrewService {
-    /// Token → installation snapshot. Repopulated by `refresh()`.
     var installedCasks: [String: LocalCaskInstallation] = [:]
 
-    /// Token → currently-running action, used by views to show spinners and disable buttons.
     private(set) var inFlightActions: [String: CaskAction] = [:]
 
-    /// Tokens whose install is still in the download phase — the only window
-    /// where cancelling is guaranteed residual-free (nothing staged yet).
     private(set) var cancellableDownloads: Set<String> = []
 
-    /// Tokens the user asked to cancel; cleared when the process exits.
     private(set) var cancelRequested: Set<String> = []
 
-    /// Token → live brew process, kept for cancellation. Not UI state.
     @ObservationIgnored private var runningProcesses: [String: Process] = [:]
 
-    /// Token → most recent error message from a failed action. Cleared on the next attempt.
     private(set) var actionErrors: [String: String] = [:]
 
-    /// True while `updateAll` is walking its queue; drives the Update All button.
     private(set) var isUpdatingAll = false
 
-    /// Last successful refresh timestamp; nil before the first scan completes.
     private(set) var lastRefresh: Date?
 
-    /// Most recent error from `refresh()` itself (e.g. Caskroom missing).
     private(set) var refreshError: LocalHomebrewError?
 
-    /// Installed Homebrew version ("4.6.15"), fetched once on first refresh.
     private(set) var brewVersion: String?
 
     private let fileManager: FileManager
@@ -125,8 +103,6 @@ final class LocalHomebrewService {
 
     // MARK: - Detection
 
-    /// Re-scans the Caskroom directory and rebuilds `installedCasks`.
-    /// Cheap (~ms for typical installs) — safe to call after every action.
     func refresh() async {
         let fm = fileManager
         if brewVersion == nil {
@@ -151,15 +127,10 @@ final class LocalHomebrewService {
         installedCasks[token] != nil
     }
 
-    /// Clears the stored error for a token (called when the user dismisses the error alert).
     func clearError(for token: String) {
         actionErrors[token] = nil
     }
 
-    /// Compares versions with the packaging suffix stripped — cask versions
-    /// aren't semver (`125.0,build42` has a build suffix, `125.0_1` a cask
-    /// revision), so comparing normalized prefixes avoids flagging an update
-    /// when only the packaging changed.
     func isOutdated(token: String, remoteVersion: String) -> Bool {
         guard let installation = installedCasks[token] else { return false }
         return Self.comparableVersion(installation.installedVersion)
@@ -170,21 +141,12 @@ final class LocalHomebrewService {
         version.prefix { $0 != "," && $0 != "_" }
     }
 
-    /// Single source of truth for "should this cask show an Update button / appear
-    /// in the Updates sidebar?" Combines the version check with the auto-update
-    /// exclusion so every caller gets the same answer.
-    ///
-    /// Casks with `autoUpdates == true` (BetterDisplay, Wireshark, etc.) handle
-    /// their own updates outside Homebrew — matching `brew outdated --cask`
-    /// (non-greedy, the default) and Applite's default behavior.
     func hasAvailableUpdate(token: String, remoteVersion: String, autoUpdates: Bool?) -> Bool {
         autoUpdates != true && isOutdated(token: token, remoteVersion: remoteVersion)
     }
 
     // MARK: - Actions
 
-    /// Launches the installed app via `NSWorkspace`. Errors are written to
-    /// `actionErrors[token]` so the view has one consistent error path.
     func openApp(token: String) {
         actionErrors[token] = nil
 
@@ -214,30 +176,22 @@ final class LocalHomebrewService {
         )
     }
 
-    /// Runs `brew install --cask <token>`. Refreshes local state on success.
     func install(token: String) async throws {
         try await runMutation(.installing, token: token, args: ["install", "--cask", token])
     }
 
-    /// Runs `brew uninstall --cask <token>`. Refreshes local state on success.
     func uninstall(token: String) async throws {
         try await runMutation(.uninstalling, token: token, args: ["uninstall", "--cask", token])
     }
 
-    /// Runs `brew upgrade --cask <token>`. Refreshes local state on success.
     func upgrade(token: String) async throws {
         try await runMutation(.updating, token: token, args: ["upgrade", "--cask", token])
     }
 
-    /// Upgrades every token, one at a time — concurrent brew processes contend
-    /// for Homebrew's locks. A failed upgrade lands in `actionErrors[token]`
-    /// (surfaced by that cask's alert) without stopping the rest of the queue.
     func updateAll(tokens: [String]) async {
         guard !isUpdatingAll else { return }
         isUpdatingAll = true
         defer { isUpdatingAll = false }
-        // Mark the whole queue up front: waiting cards show "Waiting…"
-        // instead of a tappable Update button that would race the queue.
         for token in tokens where inFlightActions[token] == nil {
             inFlightActions[token] = .queued
         }
@@ -246,10 +200,6 @@ final class LocalHomebrewService {
         }
     }
 
-    /// Cancels an in-flight install. Only honored during the download phase —
-    /// once brew starts staging files, cancelling could leave a broken install.
-    /// Sends SIGINT to brew and its children (curl); escalates to SIGTERM if
-    /// the tree hasn't exited after 5 seconds.
     func cancelInstall(token: String) {
         guard cancellableDownloads.contains(token),
               let process = runningProcesses[token] else { return }
@@ -267,8 +217,6 @@ final class LocalHomebrewService {
     // MARK: - Mutation Plumbing
 
     private func runMutation(_ action: CaskAction, token: String, args: [String]) async throws {
-        // .queued is a placeholder set by updateAll — its upgrade may proceed;
-        // anything else means a real action is already running.
         guard inFlightActions[token] == nil || inFlightActions[token] == .queued else { return }
         inFlightActions[token] = action
         actionErrors[token] = nil
@@ -288,8 +236,6 @@ final class LocalHomebrewService {
             await refresh()
         } catch {
             if cancelRequested.contains(token) {
-                // User cancelled — not an error. Remove the partial download
-                // brew left behind so nothing accumulates in its cache.
                 span.finish()
                 cancelRequested.remove(token)
                 Task.detached(priority: .utility) {
@@ -310,11 +256,6 @@ final class LocalHomebrewService {
         }
     }
 
-    /// Spawns `brew` attached to a pseudo-terminal and streams its output.
-    ///
-    /// The stream is watched for the `==> Installing Cask` marker that closes
-    /// the safe-to-cancel window. The output tail doubles as stderr for error
-    /// reporting.
     private func runBrewStreaming(token: String, args: [String], cancellable: Bool) async throws {
         guard let brewURL = Self.locateBrewBinary() else {
             throw LocalHomebrewError.brewBinaryNotFound
@@ -323,8 +264,6 @@ final class LocalHomebrewService {
         let process = Process()
         process.executableURL = brewURL
         process.arguments = args
-        // pkg-based casks run `sudo installer` internally; with no TTY sudo can't
-        // prompt. SUDO_ASKPASS makes brew pass `-A` so sudo asks via our GUI helper.
         if let askpass = Self.ensureAskpassScript(token: token) {
             var environment = ProcessInfo.processInfo.environment
             environment["SUDO_ASKPASS"] = askpass.path
@@ -344,12 +283,11 @@ final class LocalHomebrewService {
             var tail = ""
             while true {
                 let data = handle.availableData
-                guard !data.isEmpty else { break } // EOF
+                guard !data.isEmpty else { break }
                 guard let text = String(data: data, encoding: .utf8) else { continue }
                 tail = String((tail + text).suffix(2000))
 
                 if text.contains("==> Installing Cask") {
-                    // Download finished — cancelling is no longer residual-free.
                     Task { @MainActor in self.cancellableDownloads.remove(token) }
                 }
             }

--- a/CaskHub/Services/RecentlyAddedService.swift
+++ b/CaskHub/Services/RecentlyAddedService.swift
@@ -8,7 +8,6 @@
 import Foundation
 import Observation
 
-/// Window options for the Recently Added page.
 enum RecentlyAddedWindow: Int, CaseIterable, Identifiable {
     case days30 = 30
     case days60 = 60
@@ -23,10 +22,6 @@ enum RecentlyAddedWindow: Int, CaseIterable, Identifiable {
     }
 }
 
-/// Cask token → date it was added to homebrew-cask, mined from the tap's git
-/// history by CaskFlow and published as `added_dates.json` with each data
-/// release. Dates stay as "YYYY-MM-DD" strings — lexicographic order is
-/// chronological order, so no Date parsing is needed.
 @MainActor
 @Observable
 final class RecentlyAddedService {
@@ -40,8 +35,6 @@ final class RecentlyAddedService {
 
     var addedDates: [String: String] = [:]
 
-    /// Best-effort fetch, silent on failure — Recently Added stays empty
-    /// offline, which is moot since the catalog itself is network-backed.
     func refreshFromRemote() async {
         guard let remote = await CaskFlowReleases.fetch(AddedDatesData.self, asset: "added_dates.json"),
               remote.version == Self.schemaVersion
@@ -50,13 +43,11 @@ final class RecentlyAddedService {
         addedDates = remote.tokenAddedDates
     }
 
-    /// Tokens added to Homebrew within the given number of days.
     func recentTokens(within days: Int) -> Set<String> {
         let cutoff = Self.dateString(daysAgo: days)
         return Set(addedDates.filter { $0.value >= cutoff }.keys)
     }
 
-    /// "YYYY-MM-DD" the token entered homebrew-cask, or nil if unknown.
     func addedDate(for token: String) -> String? {
         addedDates[token]
     }

--- a/CaskHub/Services/UpdaterService.swift
+++ b/CaskHub/Services/UpdaterService.swift
@@ -9,8 +9,6 @@ import Combine
 import Sparkle
 import SwiftUI
 
-/// Owns Sparkle's updater lifecycle: starts the standard updater controller
-/// and exposes check state for menu items.
 @Observable
 final class UpdaterService {
     private let controller: SPUStandardUpdaterController
@@ -33,14 +31,12 @@ final class UpdaterService {
         controller.updater.checkForUpdates()
     }
 
-    /// Mirrors Sparkle's own auto-check preference (persisted by Sparkle).
     var automaticallyChecksForUpdates: Bool {
         get { controller.updater.automaticallyChecksForUpdates }
         set { controller.updater.automaticallyChecksForUpdates = newValue }
     }
 }
 
-/// Menu item that stays disabled while Sparkle is mid-check.
 struct CheckForUpdatesView: View {
     let updater: UpdaterService
 

--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -263,13 +263,7 @@ final class CaskCatalogViewModel {
 
     func formattedDownloads(for token: String) -> String? {
         guard let count = downloadCounts[token], count > 0 else { return nil }
-        switch count {
-        case 1_000_000...:
-            return String(format: "%.1fM", Double(count) / 1_000_000)
-        case 1000...:
-            return String(format: "%.1fK", Double(count) / 1000)
-        default:
-            return "\(count)"
-        }
+        // ponytail: en_US pin keeps the K/M suffixes stable across locales
+        return count.formatted(.number.notation(.compactName).locale(Locale(identifier: "en_US")))
     }
 }

--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -8,7 +8,6 @@
 import Foundation
 import Observation
 
-/// One shelf on the Browse page: a titled row group with a "View All" destination.
 struct BrowseSection: Identifiable {
     let title: String
     let destination: SidebarSelection
@@ -30,7 +29,6 @@ enum SortOption: String, CaseIterable, Identifiable {
         rawValue
     }
 
-    /// Date sorts only make sense where add dates drive the page.
     static let standard: [SortOption] = [.mostPopular, .nameAZ, .nameZA]
 }
 
@@ -47,9 +45,6 @@ final class CaskCatalogViewModel {
     private static let periodKey = "analyticsPeriod"
     private static let windowKey = "recentlyAddedWindow"
 
-    /// Top Charts respects the picked period; every other section stays on 365d.
-    /// Falls back to 365d while a shorter period is still loading so the
-    /// popularity sort doesn't collapse to arbitrary order.
     var downloadCounts: [String: Int] {
         guard selectedSidebar == .discover(.topCharts) else {
             return analyticsByPeriod[.days365] ?? [:]
@@ -62,7 +57,6 @@ final class CaskCatalogViewModel {
     var sortOption: SortOption = .mostPopular
     var selectedSidebar: SidebarSelection = .discover(.browse)
 
-    /// Window for the Recently Added page and Browse shelf.
     private(set) var recentlyAddedWindow: RecentlyAddedWindow = .days30
 
     private let apiClient: BrewAPIClientProtocol
@@ -84,7 +78,6 @@ final class CaskCatalogViewModel {
         self.localHomebrew = localHomebrew
         self.defaults = defaults
 
-        // Restore persisted picks.
         if let raw = defaults.string(forKey: Self.periodKey),
            let period = AnalyticsPeriod(rawValue: raw) {
             analyticsPeriod = period
@@ -96,9 +89,6 @@ final class CaskCatalogViewModel {
 
     // MARK: - Sidebar Counts
 
-    /// Locally-installed, non-auto-updating casks whose installed version
-    /// differs from the latest available version in the catalog. Feeds the
-    /// sidebar badge, the Updates page and the Update All button.
     var updatableCasks: [Cask] {
         casks.filter { [localHomebrew] in
             localHomebrew.hasAvailableUpdate(token: $0.token, remoteVersion: $0.version, autoUpdates: $0.autoUpdates)
@@ -109,8 +99,6 @@ final class CaskCatalogViewModel {
         updatableCasks.count
     }
 
-    /// Category ID → number of catalog casks in it (intersected with the
-    /// mapping data, so sidebar counts match what clicking the category shows).
     var categoryCounts: [String: Int] {
         let catalogTokens = Set(casks.map(\.token))
         return categoryService.categoryTokenSets.mapValues {
@@ -120,12 +108,8 @@ final class CaskCatalogViewModel {
 
     // MARK: - Browse Sections
 
-    /// Cards per Browse shelf: two rows of the fixed 4-column grid.
     private static let browseSectionSize = 8
 
-    /// Shelves for the Browse page: Most Popular, Recently Added (newest
-    /// first), then every category except "other" — the rest holding their
-    /// top casks by 365d downloads.
     var browseSections: [BrowseSection] {
         let counts = analyticsByPeriod[.days365] ?? [:]
         func top(_ source: [Cask]) -> [Cask] {
@@ -256,13 +240,11 @@ final class CaskCatalogViewModel {
         isLoading = false
     }
 
-    /// Switches the Recently Added window and remembers the pick.
     func selectRecentlyAddedWindow(_ window: RecentlyAddedWindow) {
         recentlyAddedWindow = window
         defaults.set(window.rawValue, forKey: Self.windowKey)
     }
 
-    /// Switches the Top Charts window, fetching that period's data on first use.
     func selectAnalyticsPeriod(_ period: AnalyticsPeriod) async {
         analyticsPeriod = period
         defaults.set(period.rawValue, forKey: Self.periodKey)

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -36,7 +36,6 @@ struct ContentView: View {
                 installedCount: localHomebrew.installedCasks.count,
                 categoryCounts: viewModel.categoryCounts
             )
-            // Min width sized so the longest category name never truncates.
             .navigationSplitViewColumnWidth(min: 245, ideal: 245, max: 300)
         } detail: {
             VStack(spacing: 0) {
@@ -68,19 +67,15 @@ struct ContentView: View {
                         }
                         : nil,
                     isUpdatingAll: localHomebrew.isUpdatingAll,
-                    // Sections have a fixed popularity order; sorting is a no-op there.
                     showsSort: selectedSidebar != .discover(.featured) && !showsBrowseSections,
                     onSubmitSearch: {
                         searchFocused = false
                         showsResultsHeader = !viewModel.searchText.isEmpty
                     }
                 )
-                // Never wider than the card grid below it, centered to match.
                 .frame(maxWidth: CHSize.contentWidth)
                 .padding(.horizontal, CHSpace.s5)
                 .frame(maxWidth: .infinity)
-                // Bottom padding sits outside the scroll view, so scrolled
-                // cards clip 16pt below the bar instead of flush against it.
                 .padding(.vertical, CHSpace.s4)
 
                 if showsResultsHeader {
@@ -95,12 +90,9 @@ struct ContentView: View {
 
                 detailContent
             }
-            // The hidden title bar still reserves toolbar height as safe area;
-            // ignore it so the top bar sits 16pt from the window edge.
             .ignoresSafeArea(.container, edges: .top)
         }
         .overlay {
-            // Invisible ⌘F target: focuses the custom search field.
             Button("") { searchFocused = true }
                 .keyboardShortcut("f", modifiers: .command)
                 .opacity(0)
@@ -128,11 +120,8 @@ struct ContentView: View {
             Analytics.pageOpened(newValue)
             viewModel.selectedSidebar = newValue
             if newValue == .discover(.topCharts) {
-                // Fetch the current period's data if it hasn't loaded yet.
                 Task { await viewModel.selectAnalyticsPeriod(viewModel.analyticsPeriod) }
             }
-            // Recently Added defaults to Newest; its date sorts don't exist
-            // in other pages' menus, so drop back to Most Popular on leave.
             if newValue == .discover(.recentlyAdded) {
                 viewModel.sortOption = .newest
             } else if !SortOption.standard.contains(viewModel.sortOption) {
@@ -143,8 +132,6 @@ struct ContentView: View {
             Analytics.viewModeChanged(newValue)
         }
         .onChange(of: viewModel.searchText) { _, newValue in
-            // Results filter per keystroke (no Return needed), so the search
-            // signal fires when typing settles — not per key, not on submit.
             searchSignalTask?.cancel()
             if !newValue.isEmpty {
                 searchSignalTask = Task {
@@ -157,15 +144,11 @@ struct ContentView: View {
                 }
             }
             if newValue.isEmpty {
-                // Only drop focus when clearing a submitted search — while
-                // still composing (backspaced to empty), keep the field active.
                 if showsResultsHeader { searchFocused = false }
                 showsResultsHeader = false
             }
         }
         .onAppear {
-            // AppKit hands the window's initial key focus to the first text
-            // field; take it back so the search field only activates via ⌘F.
             DispatchQueue.main.async { searchFocused = false }
         }
         .modifier(ResignFocusOnOutsideClick(
@@ -203,14 +186,11 @@ struct ContentView: View {
         }
     }
 
-    /// House pick: shown on Browse when not searching.
     private var heroCask: Cask? {
         guard showsBrowseSections else { return nil }
         return viewModel.filteredCasks.first
     }
 
-    /// Browse shows titled shelves instead of the flat grid — unless searching,
-    /// where a flat result grid is more useful. List mode stays a flat list.
     private var showsBrowseSections: Bool {
         selectedSidebar == .discover(.browse)
             && viewModel.searchText.isEmpty
@@ -249,8 +229,6 @@ private extension ContentView {
         }
         .contentMargins(.bottom, 44, for: .scrollContent)
         .scrollContentBackground(.hidden)
-        // Recreate the scroll view per sidebar selection so navigating
-        // (View All, sidebar clicks) always lands at the top.
         .id(selectedSidebar)
     }
 
@@ -322,11 +300,6 @@ private extension ContentView {
 
 // MARK: - Outside-Click Focus Handling
 
-/// Drops focus when a click lands anywhere outside the active field editor.
-/// A local monitor only observes — the event is returned untouched, so
-/// buttons and the field itself stay fully clickable. While a text field is
-/// focused, its text is edited by an NSTextView (the window's field editor),
-/// so clicks inside it keep focus.
 struct ResignFocusOnOutsideClick: ViewModifier {
     let isFocused: () -> Bool
     let resign: () -> Void

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -113,7 +113,6 @@ struct GeneralSettingsView: View {
             }
         } catch {
             CrashReporter.capture(error)
-            // Reflect the real state — the change didn't take.
             launchAtLogin = SMAppService.mainApp.status == .enabled
         }
     }
@@ -181,7 +180,6 @@ struct PrivacySettingsView: View {
         }
     }
 
-    /// Checkbox with its explanation underneath, indented to the checkbox title.
     private func checkboxRow(
         _ title: String,
         isOn: Binding<Bool>,

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-/// The uninstall-confirmation and action-error alerts shared by every view
-/// that renders a cask (cards and rows).
 private struct CaskActionAlerts: ViewModifier {
     let cask: Cask
     @Binding var showUninstallConfirmation: Bool

--- a/CaskHub/Views/Shared/CaskCardView.swift
+++ b/CaskHub/Views/Shared/CaskCardView.swift
@@ -104,21 +104,11 @@ struct CaskCardView: View {
         WindowBackdrop()
         HStack {
             CaskCardView(
-                cask: Cask(
+                cask: .preview(
                     token: "firefox",
-                    fullToken: "firefox",
-                    tap: "homebrew/cask",
-                    name: ["Firefox"],
+                    name: "Firefox",
                     desc: "Web browser developed by Mozilla Foundation",
-                    homepage: "https://www.mozilla.org/firefox/",
-                    url: "https://download.mozilla.org/firefox.dmg",
                     version: "125.0",
-                    installed: nil,
-                    bundleVersion: nil,
-                    bundleShortVersion: nil,
-                    outdated: false,
-                    deprecated: false,
-                    disabled: false,
                     autoUpdates: true
                 ),
                 downloads: "1.2M"
@@ -126,22 +116,11 @@ struct CaskCardView: View {
             .frame(width: 250)
 
             CaskCardView(
-                cask: Cask(
+                cask: .preview(
                     token: "ledger-live",
-                    fullToken: "ledger-live",
-                    tap: "homebrew/cask",
-                    name: ["Ledger Live"],
+                    name: "Ledger Live",
                     desc: "Manage your crypto assets and hardware wallet securely.",
-                    homepage: "https://www.ledger.com",
-                    url: nil,
-                    version: "2.80.0",
-                    installed: nil,
-                    bundleVersion: nil,
-                    bundleShortVersion: nil,
-                    outdated: false,
-                    deprecated: false,
-                    disabled: false,
-                    autoUpdates: nil
+                    version: "2.80.0"
                 ),
                 downloads: "45K"
             )

--- a/CaskHub/Views/Shared/CaskCardView.swift
+++ b/CaskHub/Views/Shared/CaskCardView.swift
@@ -38,8 +38,6 @@ struct CaskCardView: View {
 
     // MARK: - Header (icon well + name + info)
 
-    /// Fixed-height header (room for a 2-line title + tag) keeps the description,
-    /// metadata and action button at the same position on every card.
     private var headerRow: some View {
         HStack(alignment: .top, spacing: 10) {
             CaskIconView(cask: cask, size: 38)

--- a/CaskHub/Views/Shared/CaskIconView.swift
+++ b/CaskHub/Views/Shared/CaskIconView.swift
@@ -72,23 +72,7 @@ struct CaskIconView: View {
 }
 
 #Preview {
-    let sampleCask = Cask(
-        token: "firefox",
-        fullToken: nil,
-        tap: nil,
-        name: ["Firefox"],
-        desc: "Web browser",
-        homepage: "https://www.mozilla.org/firefox/",
-        url: nil,
-        version: "125.0",
-        installed: nil,
-        bundleVersion: nil,
-        bundleShortVersion: nil,
-        outdated: false,
-        deprecated: false,
-        disabled: false,
-        autoUpdates: true
-    )
+    let sampleCask = Cask.preview(token: "firefox", name: "Firefox", desc: "Web browser", version: "125.0")
     HStack(spacing: 20) {
         CaskIconView(cask: sampleCask, size: 32)
         CaskIconView(cask: sampleCask, size: 44)

--- a/CaskHub/Views/Shared/CaskInfoPopover.swift
+++ b/CaskHub/Views/Shared/CaskInfoPopover.swift
@@ -176,16 +176,21 @@ enum DownloadSizeCache {
 
 #Preview {
     CaskInfoPopover(
-        cask: .preview(
+        cask: Cask(
             token: "1password",
-            name: "1Password",
+            fullToken: "1password",
+            tap: "homebrew/cask",
+            name: ["1Password"],
             desc: "Password manager",
             homepage: "https://1password.com/",
             url: "https://downloads.1password.com/mac/1Password-8.12.10-aarch64.zip",
             version: "8.12.10",
-            autoUpdates: true,
-            fullToken: "1password",
-            tap: "homebrew/cask"
+            bundleVersion: nil,
+            bundleShortVersion: nil,
+            outdated: false,
+            deprecated: false,
+            disabled: false,
+            autoUpdates: true
         )
     )
     .environment(LocalHomebrewService())

--- a/CaskHub/Views/Shared/CaskInfoPopover.swift
+++ b/CaskHub/Views/Shared/CaskInfoPopover.swift
@@ -176,22 +176,16 @@ enum DownloadSizeCache {
 
 #Preview {
     CaskInfoPopover(
-        cask: Cask(
+        cask: .preview(
             token: "1password",
-            fullToken: "1password",
-            tap: "homebrew/cask",
-            name: ["1Password"],
+            name: "1Password",
             desc: "Password manager",
             homepage: "https://1password.com/",
             url: "https://downloads.1password.com/mac/1Password-8.12.10-aarch64.zip",
             version: "8.12.10",
-            installed: nil,
-            bundleVersion: nil,
-            bundleShortVersion: nil,
-            outdated: false,
-            deprecated: false,
-            disabled: false,
-            autoUpdates: true
+            autoUpdates: true,
+            fullToken: "1password",
+            tap: "homebrew/cask"
         )
     )
     .environment(LocalHomebrewService())

--- a/CaskHub/Views/Shared/CaskInfoPopover.swift
+++ b/CaskHub/Views/Shared/CaskInfoPopover.swift
@@ -132,9 +132,6 @@ private struct InfoRow {
     var link: URL?
 }
 
-/// Download size via HTTP headers — the brew API doesn't publish sizes.
-/// Cached (including failures) for the app's lifetime: cask URLs are
-/// version-pinned, so a size never changes under the same URL.
 /// ponytail: uses the API's default `url`; per-arch `variations` can differ.
 @MainActor
 enum DownloadSizeCache {
@@ -167,7 +164,6 @@ enum DownloadSizeCache {
             return response.expectedContentLength
         }
 
-        // Fallback: 1-byte ranged GET; total size arrives as "bytes 0-0/<total>".
         var ranged = URLRequest(url: url, timeoutInterval: 15)
         ranged.setValue("bytes=0-0", forHTTPHeaderField: "Range")
         guard let response = try? await URLSession.shared.data(for: ranged).1 as? HTTPURLResponse,

--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -94,21 +94,11 @@ struct CaskRowView: View {
 #Preview {
     List {
         CaskRowView(
-            cask: Cask(
+            cask: .preview(
                 token: "firefox",
-                fullToken: nil,
-                tap: nil,
-                name: ["Firefox"],
+                name: "Firefox",
                 desc: "Web browser developed by Mozilla Foundation",
-                homepage: "https://www.mozilla.org/firefox/",
-                url: nil,
                 version: "125.0",
-                installed: nil,
-                bundleVersion: nil,
-                bundleShortVersion: nil,
-                outdated: false,
-                deprecated: false,
-                disabled: false,
                 autoUpdates: true
             ),
             downloads: "1.2M"

--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -20,8 +20,6 @@ struct CaskRowView: View {
             appInfo
             Spacer()
             metadata
-            // Fixed-width action column + reserved menu slot keep every
-            // capsule vertically aligned across rows.
             actionsControl
                 .frame(width: 130)
             menuSlot

--- a/CaskHub/Views/Sidebar/SidebarView.swift
+++ b/CaskHub/Views/Sidebar/SidebarView.swift
@@ -18,11 +18,9 @@ struct SidebarView: View {
         VStack(alignment: .leading, spacing: 0) {
             BrandWordmark()
                 .padding(.horizontal, 18)
-                .padding(.top, 38) // just below the traffic lights (hidden title bar)
+                .padding(.top, 38)
                 .padding(.bottom, 6)
 
-            // Custom rows instead of List selection: the terracotta capsule
-            // highlight must not turn gray when the sidebar loses focus.
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     sectionHeader("DISCOVER")

--- a/CaskHubTests/AnalyticsTests.swift
+++ b/CaskHubTests/AnalyticsTests.swift
@@ -97,7 +97,6 @@ final class AnalyticsTests: XCTestCase {
         XCTAssertTrue(spy.signals.isEmpty)
     }
 
-    /// Queued is a UI placeholder, not an outcome — it must never emit.
     func test_cask_action_events_ignore_queued_state() {
         Analytics.caskActionCompleted(.queued, token: "firefox")
         Analytics.caskActionFailed(.queued, token: "firefox")
@@ -110,8 +109,6 @@ final class AnalyticsTests: XCTestCase {
         XCTAssertEqual(lastSignal?.parameters, ["count": "3"])
     }
 
-    /// Builds without the TelemetryDeck secret never initialize the SDK;
-    /// sending must be a no-op then, not a Debug-build assertion crash.
     func test_uninitialized_telemetry_provider_drops_signals() {
         TelemetryDeckProvider().send("Test.signal", parameters: [:])
     }

--- a/CaskHubTests/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/CaskCatalogViewModelTests.swift
@@ -276,7 +276,7 @@ final class CaskCatalogViewModelTests: XCTestCase {
 
         vm.selectedSidebar = .discover(.topCharts)
         await vm.selectAnalyticsPeriod(.days30)
-        XCTAssertEqual(vm.formattedDownloads(for: "firefox"), "5.0K")
+        XCTAssertEqual(vm.formattedDownloads(for: "firefox"), "5K")
 
         vm.selectedSidebar = .discover(.browse)
         XCTAssertEqual(vm.formattedDownloads(for: "firefox"), "100")

--- a/CaskHubTests/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/CaskCatalogViewModelTests.swift
@@ -63,13 +63,13 @@ final class CaskCatalogViewModelTests: XCTestCase {
             makeCask("slack", name: "Slack")
         ])
 
-        vm.searchText = "browser" // description match
+        vm.searchText = "browser"
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["firefox"])
 
-        vm.searchText = "studio" // token + name match
+        vm.searchText = "studio"
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["visual-studio-code"])
 
-        vm.searchText = "SLACK" // case-insensitive
+        vm.searchText = "SLACK"
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["slack"])
 
         vm.searchText = ""
@@ -108,9 +108,9 @@ final class CaskCatalogViewModelTests: XCTestCase {
     func test_installed_and_updates_pages_reflect_local_state() async {
         let local = LocalHomebrewService()
         local.installedCasks = [
-            "firefox": installation("firefox", version: "1.0"), // outdated
-            "slack": installation("slack", version: "2.0"),     // current
-            "chrome": installation("chrome", version: "1.0")    // outdated but auto-updates
+            "firefox": installation("firefox", version: "1.0"),
+            "slack": installation("slack", version: "2.0"),
+            "chrome": installation("chrome", version: "1.0")
         ]
         let (vm, _) = await makeSUT(
             casks: [
@@ -145,7 +145,7 @@ final class CaskCatalogViewModelTests: XCTestCase {
 
         vm.selectedSidebar = .discover(.recentlyAdded)
 
-        XCTAssertEqual(vm.filteredCasks.map(\.token), ["new-app"]) // default 30d window
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["new-app"])
         vm.selectRecentlyAddedWindow(.days90)
         XCTAssertEqual(Set(vm.filteredCasks.map(\.token)), ["new-app"])
     }
@@ -174,7 +174,7 @@ final class CaskCatalogViewModelTests: XCTestCase {
         vm.sortOption = .nameZA
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["charlie", "bravo", "alpha"])
 
-        vm.sortOption = .newest // undated casks sink to the end
+        vm.sortOption = .newest
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["bravo", "alpha", "charlie"])
 
         vm.sortOption = .oldest
@@ -203,13 +203,11 @@ final class CaskCatalogViewModelTests: XCTestCase {
 
         let sections = vm.browseSections
 
-        // "Recently Added" (no dates), "Developer Tools" (no casks) and
-        // "Other" (always) are dropped.
         XCTAssertEqual(sections.map(\.title), ["Most Popular", "Browsers"])
         XCTAssertEqual(sections[0].destination, .discover(.topCharts))
         XCTAssertEqual(sections[1].destination, .category("browsers"))
-        XCTAssertEqual(sections[0].casks.count, 8) // two grid rows max
-        XCTAssertEqual(sections[1].casks.first?.token, "browser-9") // top downloads first
+        XCTAssertEqual(sections[0].casks.count, 8)
+        XCTAssertEqual(sections[1].casks.first?.token, "browser-9")
     }
 
     @MainActor
@@ -264,7 +262,7 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(api.analyticsFetches, [.days365, .days30])
         XCTAssertEqual(vm.analyticsPeriod, .days30)
 
-        await vm.selectAnalyticsPeriod(.days30) // cached — no refetch
+        await vm.selectAnalyticsPeriod(.days30)
         XCTAssertEqual(api.analyticsFetches, [.days365, .days30])
     }
 
@@ -316,7 +314,6 @@ final class CaskCatalogViewModelTests: XCTestCase {
         await vm.selectAnalyticsPeriod(.days30)
         vm.selectRecentlyAddedWindow(.days90)
 
-        // "Relaunch": a fresh view model over the same defaults.
         let relaunched = makeViewModel(api: MockBrewAPIClient(), defaults: defaults)
         XCTAssertEqual(relaunched.analyticsPeriod, .days30)
         XCTAssertEqual(relaunched.recentlyAddedWindow, .days90)
@@ -330,7 +327,6 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(fresh.analyticsPeriod, .days365)
         XCTAssertEqual(fresh.recentlyAddedWindow, .days30)
 
-        // Unknown raw values (e.g. from a future version) fall back safely.
         defaults.set("14d", forKey: "analyticsPeriod")
         defaults.set(45, forKey: "recentlyAddedWindow")
         let garbled = makeViewModel(api: MockBrewAPIClient(), defaults: defaults)

--- a/CaskHubTests/CaskHubTests.swift
+++ b/CaskHubTests/CaskHubTests.swift
@@ -16,7 +16,6 @@ final class CaskHubTests: XCTestCase {
         XCTAssertEqual(makeCask("test", version: "125.0_1").displayVersion, "125.0")
         XCTAssertEqual(makeCask("test", version: "1.2.3-beta").displayVersion, "1.2.3")
         XCTAssertEqual(makeCask("test", version: "2024.10.13").displayVersion, "2024.10.13")
-        // Entirely non-numeric versions fall back to the raw value.
         XCTAssertEqual(makeCask("test", version: "beta").displayVersion, "beta")
     }
 
@@ -26,8 +25,6 @@ final class CaskHubTests: XCTestCase {
         XCTAssertEqual(makeCask("test", version: "125.0").metaLine(downloads: nil), "v125.0")
     }
 
-    /// An empty queue must still clear the flag — a stuck `isUpdatingAll`
-    /// would disable the Update All button forever.
     @MainActor
     func test_update_all_with_empty_queue_clears_flag() async {
         let local = LocalHomebrewService()

--- a/CaskHubTests/ContentViewTests.swift
+++ b/CaskHubTests/ContentViewTests.swift
@@ -9,11 +9,7 @@
 import SwiftUI
 import XCTest
 
-/// Drives ResignFocusOnOutsideClick's local event monitor with a real window
-/// and synthetic clicks — the AppKit path a render smoke test can't reach.
 final class ContentViewTests: XCTestCase {
-    /// Stands in for ContentView's @FocusState: the modifier's closures
-    /// read `focused` and bump `resignCount`.
     @MainActor
     private final class FocusProbe {
         var focused = true
@@ -41,7 +37,6 @@ final class ContentViewTests: XCTestCase {
             .onAppear { probe.appeared = true })
         window.orderFrontRegardless()
 
-        // Spin the run loop until onAppear has installed the monitor.
         let deadline = Date().addingTimeInterval(2)
         while !probe.appeared, Date() < deadline {
             RunLoop.main.run(until: Date().addingTimeInterval(0.02))
@@ -49,16 +44,13 @@ final class ContentViewTests: XCTestCase {
         XCTAssertTrue(probe.appeared, "hosted view never appeared")
 
         addTeardownBlock { @MainActor in
-            window.contentView = NSView() // onDisappear removes the monitor
+            window.contentView = NSView()
             RunLoop.main.run(until: Date().addingTimeInterval(0.05))
             window.close()
         }
         return window
     }
 
-    /// Sends a left click through NSApp so local monitors observe it. The
-    /// matching mouse-up is queued first so no control can stall the test
-    /// waiting inside a mouse-tracking loop.
     @MainActor
     private func click(at point: NSPoint, in window: NSWindow) {
         NSApp.postEvent(mouseEvent(.leftMouseUp, at: point, in: window), atStart: false)
@@ -96,8 +88,6 @@ final class ContentViewTests: XCTestCase {
     func test_click_on_field_editor_keeps_focus() {
         let probe = FocusProbe()
         let window = makeWindow(probe: probe)
-        // While a field is focused its text is edited by the window's field
-        // editor, an NSTextView — clicks landing on one must keep focus.
         let fieldEditor = NSTextView(frame: NSRect(x: 50, y: 50, width: 100, height: 100))
         fieldEditor.isEditable = false
         fieldEditor.isSelectable = false
@@ -124,7 +114,7 @@ final class ContentViewTests: XCTestCase {
         let probe = FocusProbe()
         let window = makeWindow(probe: probe)
 
-        window.contentView = NSView() // onDisappear tears the monitor down
+        window.contentView = NSView()
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
         click(at: NSPoint(x: 20, y: 20), in: window)
 
@@ -132,10 +122,7 @@ final class ContentViewTests: XCTestCase {
     }
 }
 
-/// Renders TopBarView's Update All chip in both states — the chip only
-/// exists on the Updates page, which no other test visits.
 final class TopBarViewTests: XCTestCase {
-    /// Owns the @FocusState TopBarView needs; tests can't declare one.
     private struct TopBarHarness: View {
         let isUpdatingAll: Bool
         let onAppear: () -> Void

--- a/CaskHubTests/SettingsViewTests.swift
+++ b/CaskHubTests/SettingsViewTests.swift
@@ -9,9 +9,6 @@
 import SwiftUI
 import XCTest
 
-/// Render smoke tests: hosting each settings tab executes its body,
-/// which catches missing-environment crashes and init-time regressions
-/// that a compile alone can't.
 final class SettingsViewTests: XCTestCase {
     @MainActor
     private func render(_ view: some View) {
@@ -35,14 +32,11 @@ final class SettingsViewTests: XCTestCase {
     @MainActor
     func test_clear_cache_recreates_empty_icon_directory() {
         let cache = ImageCacheService()
-        // Wiping the icon cache is the feature under test; icons refetch lazily.
         cache.clearCache()
 
         let dir = FileManager.default
             .urls(for: .cachesDirectory, in: .userDomainMask).first!
             .appendingPathComponent("CaskHub/icons", isDirectory: true)
-        // The init's detached purge task may drop its marker file back in;
-        // only cached icons and their markers must be gone.
         let contents = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
         XCTAssertTrue(contents.allSatisfy { $0.hasPrefix(".") },
                       "expected no cached icons, found: \(contents)")

--- a/CaskHubTests/SharedTestHelpers.swift
+++ b/CaskHubTests/SharedTestHelpers.swift
@@ -43,18 +43,11 @@ func makeCask(
     disabled: Bool = false,
     autoUpdates: Bool? = nil
 ) -> Cask {
-    Cask(
+    .preview(
         token: token,
-        fullToken: nil,
-        tap: nil,
-        name: [name ?? token],
+        name: name,
         desc: desc,
-        homepage: "https://example.com",
-        url: nil,
         version: version,
-        bundleVersion: nil,
-        bundleShortVersion: nil,
-        outdated: false,
         deprecated: deprecated,
         disabled: disabled,
         autoUpdates: autoUpdates

--- a/CaskHubTests/SharedTestHelpers.swift
+++ b/CaskHubTests/SharedTestHelpers.swift
@@ -62,7 +62,6 @@ func makeCask(
     )
 }
 
-/// (token, count) pairs — counts as the API's comma-grouped strings.
 @MainActor
 func analyticsResponse(_ counts: [(String, String)]) -> CaskAnalyticsResponse {
     CaskAnalyticsResponse(
@@ -82,13 +81,11 @@ func installation(_ token: String, version: String) -> LocalCaskInstallation {
     LocalCaskInstallation(token: token, installedVersion: version, installedAt: nil, appBundleNames: [])
 }
 
-/// "YYYY-MM-DD" matching RecentlyAddedService's date format.
 func dateString(daysAgo: Int) -> String {
     let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: .now)!
     return date.formatted(.iso8601.year().month().day())
 }
 
-// Nil defaults: MainActor-isolated inits can't run in default-argument position.
 @MainActor
 func makeViewModel(
     api: MockBrewAPIClient,
@@ -102,13 +99,10 @@ func makeViewModel(
         categoryService: categories ?? CategoryService(),
         recentlyAdded: recentlyAdded ?? RecentlyAddedService(),
         localHomebrew: localHomebrew ?? LocalHomebrewService(),
-        // Scratch suite by default so no test ever writes the app's real prefs.
         defaults: defaults ?? makeScratchDefaults("viewmodel-scratch")
     )
 }
 
-/// A scratch UserDefaults suite, wiped before use so persistence tests
-/// never see each other's (or the real app's) values.
 func makeScratchDefaults(_ name: String = #function) -> UserDefaults {
     let suite = "test.\(name)"
     let defaults = UserDefaults(suiteName: suite)!
@@ -116,10 +110,6 @@ func makeScratchDefaults(_ name: String = #function) -> UserDefaults {
     return defaults
 }
 
-/// The arrange-and-act ritual shared by most catalog tests: a mock API
-/// pre-loaded with `casks` (plus optional year-window analytics), wrapped
-/// in a view model that has already fetched. The api is returned for
-/// call-count assertions and post-fetch stubbing.
 @MainActor
 func makeSUT(
     casks: [Cask] = [],

--- a/CaskHubTests/SharedTestHelpers.swift
+++ b/CaskHubTests/SharedTestHelpers.swift
@@ -52,7 +52,6 @@ func makeCask(
         homepage: "https://example.com",
         url: nil,
         version: version,
-        installed: nil,
         bundleVersion: nil,
         bundleShortVersion: nil,
         outdated: false,


### PR DESCRIPTION
## Summary

Two-commit cleanup from a repo-wide audit.

**Commit 1 — comments (~411 lines):** deletes comments that restate what the code already says — doc comments paraphrasing one-line bodies, step-by-step implementation narration, parameter docs duplicating signatures, and inline test annotations duplicating adjacent assertions. Comments-only diff; deliberately kept: the askpass token-sanitization guard note, both `ponytail:` debt markers, the `INSTALL_RECEIPT.json` `source.version`-freeze note (condensed), BarrelMark's canvas section labels, and the design-token section headers.

**Commit 2 — dead code and dedup (−129/+60):**
- Drop `Cask.installed` (decoded from the API, never read — the UI shows the local Caskroom version) and unused `homepageDomain`
- Delete 11 unused design tokens: `chSage`, `chAmber`, `chSurfaceSidebar`, `chSeparator`, `CHType.screenTitle`, `CHRadius.window/.icon/.badge`, `CHSpace.s1/.s2/.s6`
- `formattedDownloads`: hand-rolled K/M abbreviation → `FormatStyle` `compactName` pinned to en_US (cosmetic: "5.0K" now renders "5K")
- New `Cask.preview` fixture (`#if DEBUG`); previews stop hand-building 15-argument casks
- `TopBarView`: the duplicate sort/period popover rows merge into one `menuRow`

## Test plan

- [x] Full unit test suite run locally against the exact commit content in a clean worktree — TEST SUCCEEDED
- [ ] CI green