### PR TITLE
perf: Skip icon requests for tokens absent from the CaskFlow icon manifest

### DIFF
--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -27,7 +27,7 @@ struct CaskHubApp: App {
     @State private var categoryService: CategoryService
     @State private var recentlyAdded: RecentlyAddedService
     @State private var localHomebrew: LocalHomebrewService
-    @State private var imageCache = ImageCacheService()
+    @State private var imageCache: ImageCacheService
     @State private var catalog: CaskCatalogViewModel
 
     init() {
@@ -40,6 +40,9 @@ struct CaskHubApp: App {
         categories.loadCategories()
         let recent = RecentlyAddedService()
         let homebrew = LocalHomebrewService()
+        let images = ImageCacheService()
+        images.knownIconTokens = { categories.iconTokens }
+        _imageCache = State(initialValue: images)
         _categoryService = State(initialValue: categories)
         _recentlyAdded = State(initialValue: recent)
         _localHomebrew = State(initialValue: homebrew)

--- a/CaskHub/Services/CategoryService.swift
+++ b/CaskHub/Services/CategoryService.swift
@@ -27,6 +27,9 @@ struct CaskCategoryData: Codable {
     let totalCasks: Int
     let categories: [String: CategoryDefinition]
     let tokenToCategory: [String: TokenCategoryMapping]
+    /// Manifest of tokens with an icon on the CaskFlow icons branch, stamped
+    /// into the release asset. Absent in pre-2026.07 data → nil.
+    let iconTokens: [String]?
 }
 
 @MainActor
@@ -38,6 +41,7 @@ final class CategoryService {
     private(set) var version: Int = 0
     private(set) var generatedDate: String = ""
     private(set) var releaseTag: String?
+    private(set) var iconTokens: Set<String>?
 
     var orderedCategories: [(id: CategoryID, definition: CategoryDefinition)] {
         categoryDefinitions
@@ -83,6 +87,7 @@ final class CategoryService {
         version = catalog.version
         generatedDate = catalog.generatedDate
         releaseTag = catalog.releaseTag
+        iconTokens = catalog.iconTokens.map(Set.init)
     }
 
     func category(for token: String) -> CategoryID? {

--- a/CaskHub/Services/ImageCacheService.swift
+++ b/CaskHub/Services/ImageCacheService.swift
@@ -17,6 +17,11 @@ final class ImageCacheService {
     private var upgradeInFlight: Set<String> = []
     private let session: URLSession
 
+    /// Manifest of tokens with an icon on the CaskFlow icons branch, from
+    /// categories.json — absent tokens are guaranteed 404s, never requested.
+    /// nil = manifest unknown (old category data) → fall back to probing.
+    var knownIconTokens: () -> Set<String>? = { nil }
+
     private static let missRetryInterval: TimeInterval = 24 * 60 * 60
 
     private static let cacheDirectory: URL = {
@@ -53,6 +58,11 @@ final class ImageCacheService {
             return diskImage
         }
 
+        let inManifest = knownIconTokens()?.contains(token) ?? true
+        if cask.isCLI, !inManifest {
+            return nil
+        }
+
         if hasRecentMiss(token: token) {
             return nil
         }
@@ -69,10 +79,12 @@ final class ImageCacheService {
                 return image
             }
 
-            for url in CaskIconURL.caskFlowIconURLs(for: token) {
-                if let image = await fetch(url) {
-                    cache(image: image, token: token, fromCaskFlow: true)
-                    return image
+            if inManifest {
+                for url in CaskIconURL.caskFlowIconURLs(for: token) {
+                    if let image = await fetch(url) {
+                        cache(image: image, token: token, fromCaskFlow: true)
+                        return image
+                    }
                 }
             }
 
@@ -158,6 +170,9 @@ final class ImageCacheService {
     }
 
     private func maybeUpgradeFallbackIcon(token: String) {
+        if let known = knownIconTokens(), !known.contains(token) {
+            return
+        }
         let marker = fallbackMarkerPath(for: token)
         guard let mtime = try? FileManager.default
             .attributesOfItem(atPath: marker.path)[.modificationDate] as? Date,

--- a/CaskHubTests/CaskHubTests.swift
+++ b/CaskHubTests/CaskHubTests.swift
@@ -37,3 +37,75 @@ final class CaskHubTests: XCTestCase {
         XCTAssertEqual(CaskAction.queued.inProgressLabel, "Queued…")
     }
 }
+
+final class RequestRecordingProtocol: URLProtocol {
+    nonisolated(unsafe) static var requestedHosts: [String] = []
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        if let host = request.url?.host() {
+            Self.requestedHosts.append(host)
+        }
+        client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+    }
+
+    override func stopLoading() {}
+}
+
+final class ImageCacheManifestGateTests: XCTestCase {
+    @MainActor
+    private func makeCache() -> ImageCacheService {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RequestRecordingProtocol.self]
+        return ImageCacheService(session: URLSession(configuration: config))
+    }
+
+    @MainActor
+    private func cliCask(_ token: String) -> Cask {
+        var cask = Cask.preview(token: token)
+        cask.artifacts = try? JSONDecoder().decode(
+            [ArtifactStanza].self, from: Data(#"[{"binary": true}]"#.utf8)
+        )
+        return cask
+    }
+
+    @MainActor
+    func test_cli_cask_missing_from_manifest_makes_no_request() async {
+        let cache = makeCache()
+        cache.knownIconTokens = { [] }
+        RequestRecordingProtocol.requestedHosts = []
+
+        let image = await cache.image(for: cliCask("gate-cli-\(UUID().uuidString)"))
+
+        XCTAssertNil(image)
+        XCTAssertEqual(RequestRecordingProtocol.requestedHosts, [])
+    }
+
+    @MainActor
+    func test_app_cask_missing_from_manifest_probes_only_appfair() async {
+        let cache = makeCache()
+        cache.knownIconTokens = { [] }
+        RequestRecordingProtocol.requestedHosts = []
+
+        _ = await cache.image(for: Cask.preview(token: "gate-app-\(UUID().uuidString)"))
+
+        XCTAssertEqual(RequestRecordingProtocol.requestedHosts, ["github.com"])
+    }
+
+    @MainActor
+    func test_unknown_manifest_still_probes_caskflow() async {
+        let cache = makeCache()
+        RequestRecordingProtocol.requestedHosts = []
+
+        _ = await cache.image(for: cliCask("gate-probe-\(UUID().uuidString)"))
+
+        XCTAssertEqual(RequestRecordingProtocol.requestedHosts.first, "cdn.jsdelivr.net")
+    }
+}

--- a/CaskHubTests/SharedTestHelpers.swift
+++ b/CaskHubTests/SharedTestHelpers.swift
@@ -135,7 +135,8 @@ func seededCategories(_ tokenToCategory: [String: TokenCategoryMapping],
         releaseTag: nil,
         totalCasks: tokenToCategory.count,
         categories: categories,
-        tokenToCategory: tokenToCategory
+        tokenToCategory: tokenToCategory,
+        iconTokens: nil
     ))
     return service
 }


### PR DESCRIPTION
## Why

CaskHub probes CaskFlow icon URLs for every visible cask, but **352 of the 3,803 catalog casks have no icon on the icons branch** - each one costs up to three guaranteed-404 requests per day (jsdelivr + raw.githubusercontent, plus AppFair for app casks), clearly visible in Proxyman. On top of that, `maybeUpgradeFallbackIcon` re-probes both CaskFlow URLs daily for every AppFair-sourced icon on disk, hoping an icon appeared.

## What

`categories.json` gains an optional `iconTokens` field - the full manifest of the icons branch (~3,507 tokens), stamped into the release asset by alielsokary/CaskFlow#41. `ImageCacheService` gates on it via a closure wired to `CategoryService`:

- tokens absent from the manifest skip both CaskFlow URLs
- CLI casks bail out entirely - no other source, they keep the live `>_` tile
- app casks still probe AppFair under the existing 24h miss cooldown (third-party source, can't be manifested)
- the fallback-upgrade path only fires for tokens actually in the manifest, killing the standing daily re-probes
- `nil` manifest (old bundled/remote data, or the trees API failing at release time) → today's probe-once-per-24h behavior, unchanged; schema `version` stays 2 so the remote-refresh gate is unaffected

## Tests

`ImageCacheManifestGateTests` records which hosts get hit through a stub `URLProtocol`:
- CLI cask missing from manifest → zero requests
- app cask missing from manifest → exactly `["github.com"]` (AppFair only)
- unknown manifest → first probe is `cdn.jsdelivr.net` (old behavior preserved)

Full suite passing on this branch.