### PR TITLE
feat: Add General setting to hide Adopt Apps from sidebar

### DIFF
--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -83,6 +83,7 @@ struct GeneralSettingsView: View {
     @Environment(ImageCacheService.self) private var imageCache
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var appManagement: AppManagementPermission.Status = .unknown
+    @AppStorage(SidebarView.showAdoptKey) private var showAdoptApps = true
 
     var body: some View {
         @Bindable var updater = updater
@@ -95,6 +96,12 @@ struct GeneralSettingsView: View {
             }
             Section("Updates") {
                 Toggle("Automatically check for updates", isOn: $updater.automaticallyChecksForUpdates)
+            }
+            Section("Sidebar") {
+                Toggle("Show Adopt Apps", isOn: $showAdoptApps)
+                Text("Adopt Apps lists installed apps that Homebrew can start managing for you.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
             }
             Section("Permissions") {
                 LabeledContent("App Management") {

--- a/CaskHub/Views/Sidebar/SidebarView.swift
+++ b/CaskHub/Views/Sidebar/SidebarView.swift
@@ -8,7 +8,10 @@
 import SwiftUI
 
 struct SidebarView: View {
+    static let showAdoptKey = "showAdoptApps"
+
     @Binding var selection: SidebarSelection
+    @AppStorage(Self.showAdoptKey) private var showAdoptApps = true
     var categoryService: CategoryService
     var updatesCount: Int = 0
     var installedCount: Int = 0
@@ -32,7 +35,9 @@ struct SidebarView: View {
                     sectionHeader("LIBRARY")
                     row(.library(.installed), title: "Installed", icon: LibraryItem.installed.icon, count: installedCount)
                     row(.library(.updates), title: "Updates", icon: LibraryItem.updates.icon, badge: updatesCount)
-                    row(.library(.adopt), title: LibraryItem.adopt.rawValue, icon: LibraryItem.adopt.icon, count: adoptableCount)
+                    if showAdoptApps {
+                        row(.library(.adopt), title: LibraryItem.adopt.rawValue, icon: LibraryItem.adopt.icon, count: adoptableCount)
+                    }
 
                     sectionHeader("CATEGORIES")
                     ForEach(categoryService.orderedCategories, id: \.id) { entry in
@@ -49,6 +54,11 @@ struct SidebarView: View {
             .contentMargins(.bottom, 44, for: .scrollContent)
         }
         .ignoresSafeArea(.container, edges: .top)
+        .onChange(of: showAdoptApps) { _, shown in
+            if !shown, selection == .library(.adopt) {
+                selection = .library(.installed)
+            }
+        }
     }
 
     // MARK: - Rows

--- a/CaskHubTests/ContentViewTests.swift
+++ b/CaskHubTests/ContentViewTests.swift
@@ -122,6 +122,46 @@ final class ContentViewTests: XCTestCase {
     }
 }
 
+final class SidebarViewTests: XCTestCase {
+    @MainActor
+    private final class SelectionProbe {
+        var selection: SidebarSelection = .library(.adopt)
+    }
+
+    @MainActor
+    func test_hiding_adopt_apps_moves_adopt_selection_to_installed() {
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: SidebarView.showAdoptKey)
+        addTeardownBlock { defaults.removeObject(forKey: SidebarView.showAdoptKey) }
+
+        let probe = SelectionProbe()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 226, height: 700),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: SidebarView(
+            selection: Binding(get: { probe.selection }, set: { probe.selection = $0 }),
+            categoryService: CategoryService(),
+            adoptableCount: 3
+        ))
+        window.orderFrontRegardless()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        defaults.set(false, forKey: SidebarView.showAdoptKey)
+        let deadline = Date().addingTimeInterval(2)
+        while probe.selection == .library(.adopt), Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        }
+
+        XCTAssertEqual(probe.selection, .library(.installed))
+        window.contentView = NSView()
+        window.close()
+    }
+}
+
 final class TopBarViewTests: XCTestCase {
     private struct TopBarHarness: View {
         let isUpdatingAll: Bool


### PR DESCRIPTION
## Summary
- Add a **Sidebar** section to General settings with a "Show Adopt Apps" toggle
- Sidebar hides the Adopt Apps row when the toggle is off, backed by a shared `AppStorage` key so the change applies live across windows
- If Adopt Apps is hidden while selected, selection falls back to Installed so the detail pane never shows an unreachable page

## Test plan
- [x] Toggle off "Show Adopt Apps" in Settings → General and confirm the sidebar row disappears immediately
- [x] Select Adopt Apps, then toggle it off — selection should jump to Installed
- [x] Relaunch the app and confirm the preference persists