### PR TITLE
fix: Serializing Icon disk cache operations & Brew download failures reported on Sentry

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		41DFD4A030028F7D00608C7A /* CaskFlowReleases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD46E30028F7D00608C7A /* CaskFlowReleases.swift */; };
 		41DFD4A130028F7D00608C7A /* CategoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD46F30028F7D00608C7A /* CategoryService.swift */; };
 		41DFD4A230028F7D00608C7A /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47030028F7D00608C7A /* ImageCacheService.swift */; };
+		A1C0D0023A00000100000001 /* IconDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0D0013A00000100000001 /* IconDiskCache.swift */; };
 		41DFD4A330028F7D00608C7A /* InstallReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47130028F7D00608C7A /* InstallReceipt.swift */; };
 		7FFA89946C514C00BF5496DB /* BrewOutputCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5317A6659E48459EB3FFB7EB /* BrewOutputCollector.swift */; };
 		D62ACB1AD2BC42A29578C0DD /* AppManagementPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E09E37CC8344C699ACADDB /* AppManagementPermission.swift */; };
@@ -116,6 +117,7 @@
 		41DFD46E30028F7D00608C7A /* CaskFlowReleases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskFlowReleases.swift; sourceTree = "<group>"; };
 		41DFD46F30028F7D00608C7A /* CategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryService.swift; sourceTree = "<group>"; };
 		41DFD47030028F7D00608C7A /* ImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheService.swift; sourceTree = "<group>"; };
+		A1C0D0013A00000100000001 /* IconDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconDiskCache.swift; sourceTree = "<group>"; };
 		41DFD47130028F7D00608C7A /* InstallReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallReceipt.swift; sourceTree = "<group>"; };
 		5317A6659E48459EB3FFB7EB /* BrewOutputCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewOutputCollector.swift; sourceTree = "<group>"; };
 		41E09E37CC8344C699ACADDB /* AppManagementPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppManagementPermission.swift; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 				41DFD46D30028F7D00608C7A /* BrewAPIClient.swift */,
 				41DFD46E30028F7D00608C7A /* CaskFlowReleases.swift */,
 				41DFD46F30028F7D00608C7A /* CategoryService.swift */,
+				A1C0D0013A00000100000001 /* IconDiskCache.swift */,
 				41DFD47030028F7D00608C7A /* ImageCacheService.swift */,
 				41DFD47130028F7D00608C7A /* InstallReceipt.swift */,
 				5317A6659E48459EB3FFB7EB /* BrewOutputCollector.swift */,
@@ -532,6 +535,7 @@
 				41DFD49F30028F7D00608C7A /* BrewAPIClient.swift in Sources */,
 				41DFD4A030028F7D00608C7A /* CaskFlowReleases.swift in Sources */,
 				41DFD4A130028F7D00608C7A /* CategoryService.swift in Sources */,
+				A1C0D0023A00000100000001 /* IconDiskCache.swift in Sources */,
 				41DFD4A230028F7D00608C7A /* ImageCacheService.swift in Sources */,
 				41DFD4A330028F7D00608C7A /* InstallReceipt.swift in Sources */,
 				7FFA89946C514C00BF5496DB /* BrewOutputCollector.swift in Sources */,

--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -48,9 +48,12 @@ struct CaskActionsView: View {
         } else if localHomebrew.isMacAppStoreInstalled(cask) {
             ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
                 .help("Installed from the Mac App Store. CaskHub won't replace or adopt it.")
-        } else if localHomebrew.isExternalCLI(cask) {
+        } else if let externalPath = localHomebrew.externalCLIPath(cask) {
             ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
-                .help("Installed on this Mac outside Homebrew. CaskHub can't manage it.")
+                .help(
+                    "Installed outside Homebrew at \(externalPath.path). "
+                        + "Remove or move that file manually before installing the Homebrew version."
+                )
         } else {
             ActionCapsuleButton(action: .install, fullWidth: fullWidth) {
                 Task { try? await localHomebrew.install(token: cask.token) }

--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -45,6 +45,9 @@ struct CaskActionsView: View {
                 }
                 disabledUninstallHint
             }
+        } else if localHomebrew.isMacAppStoreInstalled(cask) {
+            ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
+                .help("Installed from the Mac App Store. CaskHub won't replace or adopt it.")
         } else if localHomebrew.isExternalCLI(cask) {
             ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
                 .help("Installed on this Mac outside Homebrew. CaskHub can't manage it.")

--- a/CaskHub/Services/CrashReporter.swift
+++ b/CaskHub/Services/CrashReporter.swift
@@ -29,6 +29,14 @@ enum CrashReporter {
 
     static var captureCounts: [String: Int] = [:]
     private static let captureLimit = 5
+    private static let ignoredURLErrorCodes: Set<Int> = [
+        URLError.notConnectedToInternet.rawValue,
+        URLError.timedOut.rawValue,
+        URLError.networkConnectionLost.rawValue,
+        URLError.cannotFindHost.rawValue,
+        URLError.cannotConnectToHost.rawValue,
+        URLError.dnsLookupFailed.rawValue
+    ]
 
     /// Unit-test runs launch the host app — without a guard their brew failures,
     /// hangs, and transactions land in Sentry looking like production events.
@@ -51,11 +59,11 @@ enum CrashReporter {
 
     static func capture(_ error: Error) {
         guard isEnabled, !isRunningTests else { return }
-        if let localError = error as? LocalHomebrewError, localError.isEnvironmental {
+        if let localError = error as? LocalHomebrewError, !localError.shouldReport {
             return
         }
         let nsError = error as NSError
-        if nsError.domain == NSURLErrorDomain, nsError.code == URLError.notConnectedToInternet.rawValue {
+        if nsError.domain == NSURLErrorDomain, ignoredURLErrorCodes.contains(nsError.code) {
             return
         }
         let signature = "\(type(of: error)):\(nsError.domain):\(nsError.code)"

--- a/CaskHub/Services/IconDiskCache.swift
+++ b/CaskHub/Services/IconDiskCache.swift
@@ -1,0 +1,171 @@
+//
+//  IconDiskCache.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 20/07/2026.
+//
+
+import Foundation
+
+actor IconDiskCache {
+    static let shared = IconDiskCache(directory: defaultDirectory)
+
+    static let defaultDirectory: URL = {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("CaskHub/icons", isDirectory: true)
+    }()
+
+    private let directory: URL
+    private var generation: UInt64 = 0
+
+    init(directory: URL) {
+        self.directory = directory
+    }
+
+    func currentGeneration() -> UInt64 {
+        generation
+    }
+
+    func isCurrent(_ expectedGeneration: UInt64) -> Bool {
+        generation == expectedGeneration
+    }
+
+    func loadData(token: String) -> Data? {
+        try? Data(contentsOf: path(token: token, fileExtension: "png"))
+    }
+
+    @discardableResult
+    func store(
+        _ data: Data,
+        token: String,
+        generation expectedGeneration: UInt64,
+        fromCaskFlow: Bool
+    ) throws -> Bool {
+        guard generation == expectedGeneration else { return false }
+        try ensureDirectory()
+        try writeAtomically(data, to: path(token: token, fileExtension: "png"))
+        try? FileManager.default.removeItem(at: path(token: token, fileExtension: "miss"))
+        if fromCaskFlow {
+            try? FileManager.default.removeItem(
+                at: path(token: token, fileExtension: "fallback")
+            )
+        } else {
+            try writeAtomically(
+                Data(),
+                to: path(token: token, fileExtension: "fallback")
+            )
+        }
+        return true
+    }
+
+    func hasRecentMiss(token: String, retryInterval: TimeInterval) -> Bool {
+        guard let modified = modificationDate(
+            for: path(token: token, fileExtension: "miss")
+        ) else {
+            return false
+        }
+        return Date().timeIntervalSince(modified) < retryInterval
+    }
+
+    func recordMiss(token: String, generation expectedGeneration: UInt64) throws {
+        guard generation == expectedGeneration else { return }
+        try ensureDirectory()
+        try writeAtomically(
+            Data(),
+            to: path(token: token, fileExtension: "miss")
+        )
+    }
+
+    func fallbackNeedsUpgrade(token: String, retryInterval: TimeInterval) -> Bool {
+        guard let modified = modificationDate(
+            for: path(token: token, fileExtension: "fallback")
+        ) else {
+            return false
+        }
+        return Date().timeIntervalSince(modified) >= retryInterval
+    }
+
+    func touchFallback(token: String, generation expectedGeneration: UInt64) throws {
+        guard generation == expectedGeneration else { return }
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date()],
+            ofItemAtPath: path(token: token, fileExtension: "fallback").path
+        )
+    }
+
+    func purgeStaleCLIIcon(token: String, before cutover: Date) -> Bool {
+        let iconPath = path(token: token, fileExtension: "png")
+        guard let modified = modificationDate(for: iconPath), modified < cutover else {
+            return false
+        }
+        try? FileManager.default.removeItem(at: iconPath)
+        try? FileManager.default.removeItem(
+            at: path(token: token, fileExtension: "fallback")
+        )
+        return true
+    }
+
+    func clear() throws {
+        generation &+= 1
+        if FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.removeItem(at: directory)
+        }
+        try ensureDirectory()
+    }
+
+    func purgeGeneratedIconsIfNeeded() throws {
+        try ensureDirectory()
+        let flag = directory.appendingPathComponent(".generated-purge-done")
+        guard !FileManager.default.fileExists(atPath: flag.path) else { return }
+        let files = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )
+        for marker in files where marker.pathExtension == "fallback" {
+            let token = marker.deletingPathExtension().lastPathComponent
+            try? FileManager.default.removeItem(
+                at: path(token: token, fileExtension: "png")
+            )
+            try? FileManager.default.removeItem(at: marker)
+        }
+        try? FileManager.default.removeItem(
+            at: directory.deletingLastPathComponent()
+                .appendingPathComponent("github_owner_types.json")
+        )
+        try? FileManager.default.removeItem(
+            at: directory.appendingPathComponent(".tier-migration-done")
+        )
+        try writeAtomically(Data(), to: flag)
+    }
+
+    func fileNames() -> [String] {
+        (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
+    }
+
+    private func ensureDirectory() throws {
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    private func writeAtomically(_ data: Data, to url: URL) throws {
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch let error as CocoaError where error.code == .fileNoSuchFile {
+            // The directory may also be removed outside the app. Repair it once
+            // before surfacing a persistent filesystem failure.
+            try ensureDirectory()
+            try data.write(to: url, options: .atomic)
+        }
+    }
+
+    private func path(token: String, fileExtension pathExtension: String) -> URL {
+        directory.appendingPathComponent("\(token).\(pathExtension)")
+    }
+
+    private func modificationDate(for url: URL) -> Date? {
+        try? FileManager.default
+            .attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+    }
+}

--- a/CaskHub/Services/ImageCacheService.swift
+++ b/CaskHub/Services/ImageCacheService.swift
@@ -16,6 +16,7 @@ final class ImageCacheService {
     private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
     private var upgradeInFlight: Set<String> = []
     private let session: URLSession
+    private let diskCache: IconDiskCache
 
     /// Manifest of tokens with an icon on the CaskFlow icons branch, from
     /// categories.json — absent tokens are guaranteed 404s, never requested.
@@ -24,21 +25,17 @@ final class ImageCacheService {
 
     private static let missRetryInterval: TimeInterval = 24 * 60 * 60
 
-    private static let cacheDirectory: URL = {
-        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-        let dir = caches.appendingPathComponent("CaskHub/icons", isDirectory: true)
-        do {
-            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        } catch {
-            CrashReporter.capture(error)
-        }
-        return dir
-    }()
-
-    init(session: URLSession = .shared) {
+    init(session: URLSession = .shared, diskCache: IconDiskCache = .shared) {
         self.session = session
+        self.diskCache = diskCache
         memoryCache.countLimit = 500
-        Self.purgeGeneratedIconsIfNeeded()
+        Task {
+            do {
+                try await diskCache.purgeGeneratedIconsIfNeeded()
+            } catch {
+                CrashReporter.capture(error)
+            }
+        }
     }
 
     func image(for cask: Cask) async -> NSImage? {
@@ -47,14 +44,17 @@ final class ImageCacheService {
         if let cached = memoryCache.object(forKey: token as NSString) {
             return cached
         }
+        let generation = await diskCache.currentGeneration()
 
         if cask.isCLI {
-            purgeStaleCLIIcon(token: token)
+            await purgeStaleCLIIcon(token: token)
         }
 
-        if let diskImage = loadFromDisk(token: token) {
+        if let data = await diskCache.loadData(token: token),
+           let diskImage = NSImage(data: data),
+           diskImage.isValid {
             memoryCache.setObject(diskImage, forKey: token as NSString)
-            maybeUpgradeFallbackIcon(token: token)
+            await maybeUpgradeFallbackIcon(token: token, generation: generation)
             return diskImage
         }
 
@@ -63,7 +63,10 @@ final class ImageCacheService {
             return nil
         }
 
-        if hasRecentMiss(token: token) {
+        if await diskCache.hasRecentMiss(
+            token: token,
+            retryInterval: Self.missRetryInterval
+        ) {
             return nil
         }
 
@@ -71,7 +74,13 @@ final class ImageCacheService {
             return await existing.value
         }
 
-        let task = Task { await fetchImage(for: cask, inManifest: inManifest) }
+        let task = Task {
+            await fetchImage(
+                for: cask,
+                inManifest: inManifest,
+                generation: generation
+            )
+        }
 
         inFlightTasks[token] = task
         let result = await task.value
@@ -79,17 +88,28 @@ final class ImageCacheService {
         return result
     }
 
-    func clearCache() {
+    func clearCache() async {
+        inFlightTasks.values.forEach { $0.cancel() }
+        inFlightTasks.removeAll()
+        upgradeInFlight.removeAll()
         memoryCache.removeAllObjects()
-        try? FileManager.default.removeItem(at: Self.cacheDirectory)
-        try? FileManager.default.createDirectory(
-            at: Self.cacheDirectory, withIntermediateDirectories: true
-        )
+        do {
+            try await diskCache.clear()
+        } catch {
+            CrashReporter.capture(error)
+        }
+        // A task already returning to the main actor may have populated memory
+        // while the disk actor was clearing. The generation check rejects its write.
+        memoryCache.removeAllObjects()
     }
 
     // MARK: - Private
 
-    private func fetchImage(for cask: Cask, inManifest: Bool) async -> NSImage? {
+    private func fetchImage(
+        for cask: Cask,
+        inManifest: Bool,
+        generation: UInt64
+    ) async -> NSImage? {
         let token = cask.token
         var sawHTTPResponse = false
         func fetch(_ url: URL) async -> NSImage? {
@@ -101,7 +121,12 @@ final class ImageCacheService {
         if inManifest {
             for url in CaskIconURL.caskFlowIconURLs(for: token) {
                 if let image = await fetch(url) {
-                    cache(image: image, token: token, fromCaskFlow: true)
+                    await cache(
+                        image: image,
+                        token: token,
+                        generation: generation,
+                        fromCaskFlow: true
+                    )
                     return image
                 }
             }
@@ -110,12 +135,16 @@ final class ImageCacheService {
         if !cask.isCLI,
            let url = CaskIconURL.appFairIconURL(for: token),
            let image = await fetch(url) {
-            cache(image: image, token: token)
+            await cache(image: image, token: token, generation: generation)
             return image
         }
 
         if sawHTTPResponse {
-            markMiss(token: token)
+            do {
+                try await diskCache.recordMiss(token: token, generation: generation)
+            } catch {
+                CrashReporter.capture(error)
+            }
         }
         return nil
     }
@@ -135,14 +164,24 @@ final class ImageCacheService {
         return (image, true)
     }
 
-    private func cache(image: NSImage, token: String, fromCaskFlow: Bool = false) {
+    private func cache(
+        image: NSImage,
+        token: String,
+        generation: UInt64,
+        fromCaskFlow: Bool = false
+    ) async {
+        guard await diskCache.isCurrent(generation) else { return }
         memoryCache.setObject(image, forKey: token as NSString)
-        saveToDisk(image: image, token: token)
-        try? FileManager.default.removeItem(at: missMarkerPath(for: token))
-        if fromCaskFlow {
-            try? FileManager.default.removeItem(at: fallbackMarkerPath(for: token))
-        } else {
-            try? Data().write(to: fallbackMarkerPath(for: token), options: .atomic)
+        guard let pngData = await Self.pngData(for: image) else { return }
+        do {
+            try await diskCache.store(
+                pngData,
+                token: token,
+                generation: generation,
+                fromCaskFlow: fromCaskFlow
+            )
+        } catch {
+            CrashReporter.capture(error)
         }
     }
 
@@ -150,16 +189,11 @@ final class ImageCacheService {
 
     private static let cliIconCutover = Date(timeIntervalSince1970: 1_783_598_400)
 
-    private func purgeStaleCLIIcon(token: String) {
-        let path = diskPath(for: token)
-        guard let mtime = try? FileManager.default
-            .attributesOfItem(atPath: path.path)[.modificationDate] as? Date,
-            mtime < Self.cliIconCutover
-        else {
-            return
-        }
-        try? FileManager.default.removeItem(at: path)
-        try? FileManager.default.removeItem(at: fallbackMarkerPath(for: token))
+    private func purgeStaleCLIIcon(token: String) async {
+        guard await diskCache.purgeStaleCLIIcon(
+            token: token,
+            before: Self.cliIconCutover
+        ) else { return }
         let urlCache = session.configuration.urlCache ?? .shared
         for url in CaskIconURL.caskFlowIconURLs(for: token) {
             urlCache.removeCachedResponse(for: URLRequest(url: url))
@@ -168,18 +202,14 @@ final class ImageCacheService {
 
     // MARK: - Fallback upgrade
 
-    private func fallbackMarkerPath(for token: String) -> URL {
-        Self.cacheDirectory.appendingPathComponent("\(token).fallback")
-    }
-
-    private func maybeUpgradeFallbackIcon(token: String) {
+    private func maybeUpgradeFallbackIcon(token: String, generation: UInt64) async {
         if let known = knownIconTokens(), !known.contains(token) {
             return
         }
-        let marker = fallbackMarkerPath(for: token)
-        guard let mtime = try? FileManager.default
-            .attributesOfItem(atPath: marker.path)[.modificationDate] as? Date,
-            Date().timeIntervalSince(mtime) >= Self.missRetryInterval,
+        guard await diskCache.fallbackNeedsUpgrade(
+            token: token,
+            retryInterval: Self.missRetryInterval
+        ),
             !upgradeInFlight.contains(token)
         else {
             return
@@ -189,93 +219,30 @@ final class ImageCacheService {
             for url in CaskIconURL.caskFlowIconURLs(for: token) {
                 let (image, _) = await downloadImage(from: url)
                 if let image {
-                    cache(image: image, token: token, fromCaskFlow: true)
+                    await cache(
+                        image: image,
+                        token: token,
+                        generation: generation,
+                        fromCaskFlow: true
+                    )
                     upgradeInFlight.remove(token)
                     return
                 }
             }
-            try? FileManager.default.setAttributes(
-                [.modificationDate: Date()], ofItemAtPath: marker.path
-            )
+            try? await diskCache.touchFallback(token: token, generation: generation)
             upgradeInFlight.remove(token)
         }
     }
 
-    private nonisolated static func purgeGeneratedIconsIfNeeded() {
-        Task.detached(priority: .utility) {
-            let dir = await Self.cacheDirectory
-            let flag = dir.appendingPathComponent(".generated-purge-done")
-            guard !FileManager.default.fileExists(atPath: flag.path) else { return }
-            let files = (try? FileManager.default.contentsOfDirectory(
-                at: dir, includingPropertiesForKeys: nil
-            )) ?? []
-            for marker in files where marker.pathExtension == "fallback" {
-                let token = marker.deletingPathExtension().lastPathComponent
-                try? FileManager.default.removeItem(
-                    at: dir.appendingPathComponent("\(token).png")
-                )
-                try? FileManager.default.removeItem(at: marker)
-            }
-            try? FileManager.default.removeItem(
-                at: dir.deletingLastPathComponent()
-                    .appendingPathComponent("github_owner_types.json")
-            )
-            try? FileManager.default.removeItem(
-                at: dir.appendingPathComponent(".tier-migration-done")
-            )
-            try? Data().write(to: flag, options: .atomic)
-        }
-    }
-
-    // MARK: - Miss cooldown
-
-    private func missMarkerPath(for token: String) -> URL {
-        Self.cacheDirectory.appendingPathComponent("\(token).miss")
-    }
-
-    private func hasRecentMiss(token: String) -> Bool {
-        let path = missMarkerPath(for: token)
-        guard let mtime = try? FileManager.default
-            .attributesOfItem(atPath: path.path)[.modificationDate] as? Date
-        else {
-            return false
-        }
-        return Date().timeIntervalSince(mtime) < Self.missRetryInterval
-    }
-
-    private func markMiss(token: String) {
-        try? Data().write(to: missMarkerPath(for: token), options: .atomic)
-    }
-
-    private func diskPath(for token: String) -> URL {
-        Self.cacheDirectory.appendingPathComponent("\(token).png")
-    }
-
-    private func loadFromDisk(token: String) -> NSImage? {
-        let path = diskPath(for: token)
-        guard FileManager.default.fileExists(atPath: path.path),
-              let image = NSImage(contentsOf: path),
-              image.isValid
-        else {
-            return nil
-        }
-        return image
-    }
-
-    private nonisolated func saveToDisk(image: NSImage, token: String) {
-        Task.detached(priority: .utility) {
+    private nonisolated static func pngData(for image: NSImage) async -> Data? {
+        await Task.detached(priority: .utility) {
             guard let tiffData = image.tiffRepresentation,
                   let bitmap = NSBitmapImageRep(data: tiffData),
                   let pngData = bitmap.representation(using: .png, properties: [:])
             else {
-                return
+                return nil
             }
-            let path = await Self.cacheDirectory.appendingPathComponent("\(token).png")
-            do {
-                try pngData.write(to: path, options: .atomic)
-            } catch {
-                await CrashReporter.capture(error)
-            }
-        }
+            return pngData
+        }.value
     }
 }

--- a/CaskHub/Services/LocalHomebrewService+Brew.swift
+++ b/CaskHub/Services/LocalHomebrewService+Brew.swift
@@ -245,13 +245,17 @@ extension LocalHomebrewService {
 
     /// Executable names in the places CLI tools commonly install to. GUI apps
     /// don't inherit the shell's PATH, so fixed locations beat consulting it.
-    nonisolated static func scanBinaryDirectories(fileManager: FileManager) -> Set<String> {
+    nonisolated static func scanBinaryDirectories(
+        fileManager: FileManager,
+        directories: [URL]? = nil
+    ) -> Set<String> {
         let home = fileManager.homeDirectoryForCurrentUser
-        let folders = [
-            URL(fileURLWithPath: "/usr/local/bin"),
-            home.appendingPathComponent(".local/bin"),
-            home.appendingPathComponent("bin")
-        ]
+        let folders = directories ?? (
+            brewPrefixCandidates("bin") + [
+                home.appendingPathComponent(".local/bin"),
+                home.appendingPathComponent("bin")
+            ]
+        )
         var names: Set<String> = []
         for folder in folders {
             guard let entries = try? fileManager.contentsOfDirectory(
@@ -266,12 +270,16 @@ extension LocalHomebrewService {
         return names
     }
 
-    nonisolated static func scanApplications(fileManager: FileManager) -> Set<String> {
-        let folders = [
+    nonisolated static func scanApplications(
+        fileManager: FileManager,
+        directories: [URL]? = nil
+    ) -> ExternalApplicationScan {
+        let folders = directories ?? [
             URL(fileURLWithPath: "/Applications"),
             fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Applications")
         ]
-        var names: Set<String> = []
+        var adoptableNames: Set<String> = []
+        var macAppStoreNames: Set<String> = []
         for folder in folders {
             guard let entries = try? fileManager.contentsOfDirectory(
                 at: folder,
@@ -281,11 +289,17 @@ extension LocalHomebrewService {
             for entry in entries where entry.pathExtension == "app" {
                 // Mac App Store apps carry a receipt; adopting those would fight MAS updates.
                 let masReceipt = entry.appendingPathComponent("Contents/_MASReceipt/receipt")
-                guard !fileManager.fileExists(atPath: masReceipt.path) else { continue }
-                names.insert(entry.lastPathComponent)
+                if fileManager.fileExists(atPath: masReceipt.path) {
+                    macAppStoreNames.insert(entry.lastPathComponent)
+                } else {
+                    adoptableNames.insert(entry.lastPathComponent)
+                }
             }
         }
-        return names
+        return ExternalApplicationScan(
+            adoptableNames: adoptableNames,
+            macAppStoreNames: macAppStoreNames
+        )
     }
 
     private nonisolated static func modificationDate(of url: URL) -> Date {

--- a/CaskHub/Services/LocalHomebrewService+Brew.swift
+++ b/CaskHub/Services/LocalHomebrewService+Brew.swift
@@ -248,7 +248,7 @@ extension LocalHomebrewService {
     nonisolated static func scanBinaryDirectories(
         fileManager: FileManager,
         directories: [URL]? = nil
-    ) -> Set<String> {
+    ) -> [String: URL] {
         let home = fileManager.homeDirectoryForCurrentUser
         let folders = directories ?? (
             brewPrefixCandidates("bin") + [
@@ -256,18 +256,25 @@ extension LocalHomebrewService {
                 home.appendingPathComponent("bin")
             ]
         )
-        var names: Set<String> = []
+        var paths: [String: URL] = [:]
         for folder in folders {
             guard let entries = try? fileManager.contentsOfDirectory(
                 at: folder,
-                includingPropertiesForKeys: nil,
+                includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey],
                 options: [.skipsHiddenFiles]
             ) else { continue }
             for entry in entries where fileManager.isExecutableFile(atPath: entry.path) {
-                names.insert(entry.lastPathComponent)
+                guard let values = try? entry.resourceValues(forKeys: [.fileSizeKey, .isDirectoryKey]),
+                      values.isDirectory != true,
+                      let fileSize = values.fileSize,
+                      fileSize > 0
+                else { continue }
+                if paths[entry.lastPathComponent] == nil {
+                    paths[entry.lastPathComponent] = entry
+                }
             }
         }
-        return names
+        return paths
     }
 
     nonisolated static func scanApplications(

--- a/CaskHub/Services/LocalHomebrewService+State.swift
+++ b/CaskHub/Services/LocalHomebrewService+State.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 extension LocalHomebrewService {
+    func clearError(for token: String) {
+        actionErrors[token] = nil
+        adoptReplaceOffers.remove(token)
+        repairOffers.remove(token)
+        appManagementDenials.remove(token)
+    }
+
     func isInstalled(token: String) -> Bool {
         installedCasks[token] != nil
     }
@@ -16,6 +23,12 @@ extension LocalHomebrewService {
     func isAdoptable(_ cask: Cask) -> Bool {
         installedCasks[cask.token] == nil
             && cask.appArtifactNames.contains(where: externalAppNames.contains)
+    }
+
+    /// Mac App Store apps are present, but adopting them would break Store updates.
+    func isMacAppStoreInstalled(_ cask: Cask) -> Bool {
+        installedCasks[cask.token] == nil
+            && cask.appArtifactNames.contains(where: macAppStoreAppNames.contains)
     }
 
     /// A CLI cask whose tool is on the device via some other installer

--- a/CaskHub/Services/LocalHomebrewService+State.swift
+++ b/CaskHub/Services/LocalHomebrewService+State.swift
@@ -33,9 +33,9 @@ extension LocalHomebrewService {
 
     /// A CLI cask whose tool is on the device via some other installer
     /// (e.g. claude-code's native install script). Detected, not managed.
-    func isExternalCLI(_ cask: Cask) -> Bool {
-        installedCasks[cask.token] == nil
-            && cask.binaryArtifactNames.contains(where: externalBinaryNames.contains)
+    func externalCLIPath(_ cask: Cask) -> URL? {
+        guard installedCasks[cask.token] == nil else { return nil }
+        return cask.binaryArtifactNames.lazy.compactMap { self.externalBinaryPaths[$0] }.first
     }
 
     func isOutdated(token: String, remoteVersion: String) -> Bool {

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -19,6 +19,9 @@ final class LocalHomebrewService {
     /// Non-Mac-App-Store bundle names found in /Applications and ~/Applications.
     var externalAppNames: Set<String> = []
 
+    /// Mac App Store bundles that must be shown as installed but never adopted.
+    var macAppStoreAppNames: Set<String> = []
+
     /// Executable names found in common install locations (~/.local/bin, /usr/local/bin, …).
     var externalBinaryNames: Set<String> = []
 
@@ -26,9 +29,9 @@ final class LocalHomebrewService {
 
     /// Casks wedged by a stranded app copy inside the Caskroom; repair =
     /// clear brew's records, then reinstall fresh.
-    private(set) var repairOffers: Set<String> = []
+    var repairOffers: Set<String> = []
 
-    private(set) var appManagementDenials: Set<String> = []
+    var appManagementDenials: Set<String> = []
 
     /// Adoptions waiting for the App Management permission; value = retry with `--force`.
     var permissionRequests: [String: Bool] = [:]
@@ -143,14 +146,15 @@ final class LocalHomebrewService {
             brewVersion = await brewVersionProvider()
         }
         let appDirs = applicationDirectories
-        let (casks, appNames, binaryNames) = await Task.detached(priority: .userInitiated) {
+        let (casks, applications, binaryNames) = await Task.detached(priority: .userInitiated) {
             (
                 Self.scanCaskroom(fileManager: fm, applicationDirectories: appDirs),
                 Self.scanApplications(fileManager: fm),
                 Self.scanBinaryDirectories(fileManager: fm)
             )
         }.value
-        externalAppNames = appNames
+        externalAppNames = applications.adoptableNames
+        macAppStoreAppNames = applications.macAppStoreNames
         externalBinaryNames = binaryNames
 
         CrashReporter.tag("brew.path", value: Self.locateBrewBinary()?.path ?? "not found")
@@ -158,13 +162,6 @@ final class LocalHomebrewService {
 
         installedCasks = casks
         lastRefresh = .now
-    }
-
-    func clearError(for token: String) {
-        actionErrors[token] = nil
-        adoptReplaceOffers.remove(token)
-        repairOffers.remove(token)
-        appManagementDenials.remove(token)
     }
 
     // MARK: - Actions

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -22,8 +22,8 @@ final class LocalHomebrewService {
     /// Mac App Store bundles that must be shown as installed but never adopted.
     var macAppStoreAppNames: Set<String> = []
 
-    /// Executable names found in common install locations (~/.local/bin, /usr/local/bin, …).
-    var externalBinaryNames: Set<String> = []
+    /// Executables found in common install locations (~/.local/bin, /usr/local/bin, …).
+    var externalBinaryPaths: [String: URL] = [:]
 
     var adoptReplaceOffers: Set<String> = []
 
@@ -146,7 +146,7 @@ final class LocalHomebrewService {
             brewVersion = await brewVersionProvider()
         }
         let appDirs = applicationDirectories
-        let (casks, applications, binaryNames) = await Task.detached(priority: .userInitiated) {
+        let (casks, applications, binaryPaths) = await Task.detached(priority: .userInitiated) {
             (
                 Self.scanCaskroom(fileManager: fm, applicationDirectories: appDirs),
                 Self.scanApplications(fileManager: fm),
@@ -155,7 +155,7 @@ final class LocalHomebrewService {
         }.value
         externalAppNames = applications.adoptableNames
         macAppStoreAppNames = applications.macAppStoreNames
-        externalBinaryNames = binaryNames
+        externalBinaryPaths = binaryPaths
 
         CrashReporter.tag("brew.path", value: Self.locateBrewBinary()?.path ?? "not found")
         CrashReporter.tag("brew.caskroom", value: Self.locateCaskroom(fileManager: fm)?.path ?? "not found")

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+nonisolated struct ExternalApplicationScan: Sendable {
+    let adoptableNames: Set<String>
+    let macAppStoreNames: Set<String>
+}
+
 struct LocalCaskInstallation: Hashable, Identifiable {
     let token: String
     let installedVersion: String
@@ -61,10 +66,16 @@ enum LocalHomebrewError: LocalizedError {
     case appBundleNotFound(token: String)
     case brewCommandFailed(args: [String], exitCode: Int32, stderr: String)
 
-    /// Machine states (no Homebrew installed), not bugs — never worth a Sentry event.
-    var isEnvironmental: Bool {
-        if case .brewBinaryNotFound = self { return true }
-        return false
+    /// Failures with a complete in-app recovery path are user state, not defects.
+    var shouldReport: Bool {
+        switch self {
+        case .brewBinaryNotFound:
+            return false
+        case .appBundleNotFound:
+            return true
+        case let .brewCommandFailed(_, _, stderr):
+            return !Self.recoverableFailureClasses.contains(Self.failureClass(stderr: stderr))
+        }
     }
 
     /// Coarse classes for Sentry grouping — one issue per way brew fails, not per cask.
@@ -83,7 +94,14 @@ enum LocalHomebrewError: LocalizedError {
         ("is not installed", "not-installed"),
         ("reports different checksum", "checksum-mismatch"),
         ("SHA256 mismatch", "checksum-mismatch"),
+        ("already a Binary at", "binary-conflict"),
         ("already an App at", "app-conflict")
+    ]
+
+    private static let recoverableFailureClasses: Set<String> = [
+        "adopt-version-mismatch",
+        "checksum-mismatch",
+        "permission-denied"
     ]
 
     /// A previous interrupted operation parked the real .app inside the Caskroom

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -81,6 +81,7 @@ enum LocalHomebrewError: LocalizedError {
     /// Coarse classes for Sentry grouping — one issue per way brew fails, not per cask.
     static func failureClass(stderr: String) -> String {
         if isStrandedApp(stderr: stderr) { return "stranded-caskroom-app" }
+        if isAppManagementDenial(stderr: stderr) { return "permission-denied" }
         return failurePatterns.first { stderr.contains($0.fragment) }?.classification
             ?? "uncategorized"
     }
@@ -88,7 +89,6 @@ enum LocalHomebrewError: LocalizedError {
     private static let failurePatterns: [(fragment: String, classification: String)] = [
         ("is not there", "missing-artifact-source"),
         ("different from the one being installed", "adopt-version-mismatch"),
-        ("Operation not permitted", "permission-denied"),
         ("No Cask with this name exists", "unknown-cask"),
         ("No casks found", "unknown-cask"),
         ("is not installed", "not-installed"),
@@ -154,7 +154,11 @@ enum LocalHomebrewError: LocalizedError {
 
     /// The App Management (TCC) permission gating modification of other apps' bundles.
     static func isAppManagementDenial(stderr: String) -> Bool {
-        stderr.contains("Operation not permitted")
+        stderr.components(separatedBy: .newlines).contains { line in
+            line.contains("Operation not permitted")
+                && line.contains("/Applications/")
+                && line.contains(".app")
+        }
     }
 
     /// `brew install --adopt` refuses when the on-disk app differs from the cask's version.

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -94,6 +94,10 @@ enum LocalHomebrewError: LocalizedError {
         ("is not installed", "not-installed"),
         ("reports different checksum", "checksum-mismatch"),
         ("SHA256 mismatch", "checksum-mismatch"),
+        ("curl: (5)", "network-failure"),
+        ("curl: (6)", "network-failure"),
+        ("curl: (7)", "network-failure"),
+        ("curl: (28)", "network-failure"),
         ("already a Binary at", "binary-conflict"),
         ("already an App at", "app-conflict")
     ]
@@ -101,6 +105,7 @@ enum LocalHomebrewError: LocalizedError {
     private static let recoverableFailureClasses: Set<String> = [
         "adopt-version-mismatch",
         "checksum-mismatch",
+        "network-failure",
         "permission-denied"
     ]
 

--- a/CaskHub/Services/UpdaterService.swift
+++ b/CaskHub/Services/UpdaterService.swift
@@ -9,6 +9,13 @@ import Combine
 import Sparkle
 import SwiftUI
 
+protocol BackgroundUpdateChecking {
+    var automaticallyChecksForUpdates: Bool { get }
+    func checkForUpdatesInBackground()
+}
+
+extension SPUUpdater: BackgroundUpdateChecking {}
+
 @Observable
 final class UpdaterService {
     private let controller: SPUStandardUpdaterController
@@ -21,10 +28,17 @@ final class UpdaterService {
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
+        // Sparkle allows a forced launch check here, before its scheduled cycle starts.
+        Self.checkForUpdatesOnLaunch(using: controller.updater)
         cancellable = controller.updater.publisher(for: \.canCheckForUpdates)
             .sink { [weak self] canCheck in
                 self?.canCheckForUpdates = canCheck
             }
+    }
+
+    static func checkForUpdatesOnLaunch(using updater: some BackgroundUpdateChecking) {
+        guard updater.automaticallyChecksForUpdates else { return }
+        updater.checkForUpdatesInBackground()
     }
 
     func checkForUpdates() {

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -277,18 +277,23 @@ private extension ContentView {
     // MARK: - List View
 
     var listView: some View {
-        List {
-            ForEach(viewModel.filteredCasks) { cask in
-                CaskRowView(
-                    cask: cask,
-                    downloads: viewModel.formattedDownloads(for: cask.token)
-                )
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.filteredCasks) { cask in
+                    CaskRowView(
+                        cask: cask,
+                        downloads: viewModel.formattedDownloads(for: cask.token)
+                    )
+                    .padding(.vertical, 6)
+
+                    Color.chHairline
+                        .frame(height: 1)
+                }
             }
-            Color.clear
-                .frame(height: 30)
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
+            .frame(width: CHSize.contentWidth)
+            .frame(maxWidth: .infinity)
         }
+        .contentMargins(.bottom, 44, for: .scrollContent)
         .scrollContentBackground(.hidden)
         .id(selectedSidebar)
     }

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -124,7 +124,9 @@ struct GeneralSettingsView: View {
             }
             Section("Storage") {
                 LabeledContent("Clear cached app icons") {
-                    Button("Clear Cache") { imageCache.clearCache() }
+                    Button("Clear Cache") {
+                        Task { await imageCache.clearCache() }
+                    }
                 }
                 Text("Removes cached app icons. They re-download the next time each app is shown.")
                     .font(.callout)

--- a/CaskHubTests/AdoptionTests.swift
+++ b/CaskHubTests/AdoptionTests.swift
@@ -307,7 +307,7 @@ final class AdoptionViewRenderTests: XCTestCase {
     func test_cask_actions_render_every_external_state() {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("render-actions"))
         service.externalAppNames = ["Chrome.app"]
-        service.externalBinaryNames = ["claude"]
+        service.externalBinaryPaths = ["claude": URL(fileURLWithPath: "/usr/local/bin/claude")]
         service.installedCasks["managed"] = LocalCaskInstallation(
             token: "managed", installedVersion: "1.0", installedAt: nil, appBundleNames: ["Managed.app"]
         )

--- a/CaskHubTests/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/CaskCatalogViewModelTests.swift
@@ -341,8 +341,8 @@ final class CaskCatalogViewModelTests: XCTestCase {
         CrashReporter.captureCounts = [:]
 
         let api = MockBrewAPIClient()
-        // Not .notConnectedToInternet: offline errors are deliberately never captured.
-        api.casksError = URLError(.timedOut)
+        // Transport failures are deliberately ignored; malformed server responses are reportable.
+        api.casksError = URLError(.badServerResponse)
         let vm = makeViewModel(api: api)
 
         await vm.fetchCasks()

--- a/CaskHubTests/CaskHubTests.swift
+++ b/CaskHubTests/CaskHubTests.swift
@@ -131,16 +131,17 @@ final class CaskHubTests: XCTestCase {
     @MainActor
     func test_external_cli_detection_requires_binary_on_disk_and_no_brew_install() {
         let service = LocalHomebrewService()
-        service.externalBinaryNames = ["claude"]
+        let externalPath = URL(fileURLWithPath: "/usr/local/bin/claude")
+        service.externalBinaryPaths = ["claude": externalPath]
 
         let claudeCode = makeCask("claude-code", binaryNames: ["claude"])
-        XCTAssertTrue(service.isExternalCLI(claudeCode))
+        XCTAssertEqual(service.externalCLIPath(claudeCode), externalPath)
 
         service.installedCasks["claude-code"] = installation("claude-code", version: "2.0")
-        XCTAssertFalse(service.isExternalCLI(claudeCode), "brew-installed wins over external detection")
+        XCTAssertNil(service.externalCLIPath(claudeCode), "brew-installed wins over external detection")
 
         let other = makeCask("some-tool", binaryNames: ["some-tool"])
-        XCTAssertFalse(service.isExternalCLI(other))
+        XCTAssertNil(service.externalCLIPath(other))
     }
 
     func test_binary_scan_detects_executables_in_homebrew_prefix() throws {
@@ -150,18 +151,20 @@ final class CaskHubTests: XCTestCase {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
 
         let executable = root.appendingPathComponent("copilot")
-        FileManager.default.createFile(atPath: executable.path, contents: Data())
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755], ofItemAtPath: executable.path
-        )
+        FileManager.default.createFile(atPath: executable.path, contents: Data("#!/bin/sh\n".utf8))
+        let emptyExecutable = root.appendingPathComponent("stale-tool")
+        FileManager.default.createFile(atPath: emptyExecutable.path, contents: Data())
+        for path in [executable.path, emptyExecutable.path] {
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        }
 
-        XCTAssertEqual(
-            LocalHomebrewService.scanBinaryDirectories(
-                fileManager: FileManager.default,
-                directories: [root]
-            ),
-            ["copilot"]
+        let scan = LocalHomebrewService.scanBinaryDirectories(
+            fileManager: FileManager.default,
+            directories: [root]
         )
+        XCTAssertEqual(Set(scan.keys), ["copilot"])
+        XCTAssertEqual(scan["copilot"]?.lastPathComponent, executable.lastPathComponent)
+        XCTAssertNil(scan["stale-tool"], "zero-byte executable artifacts must be ignored")
     }
 
     func test_apple_silicon_detection_matches_native_build_arch() {
@@ -232,6 +235,19 @@ final class CaskHubTests: XCTestCase {
         )
         XCTAssertTrue(error.errorDescription?.contains("App Management") == true)
 
+        let unrelated = "chmod: /opt/homebrew/bin/tool: Operation not permitted"
+        XCTAssertFalse(LocalHomebrewError.isAppManagementDenial(stderr: unrelated))
+        XCTAssertFalse(
+            LocalHomebrewError.isAppManagementDenial(
+                stderr: "Inspecting /Applications/Example.app\n\(unrelated)"
+            )
+        )
+        XCTAssertEqual(LocalHomebrewError.failureClass(stderr: unrelated), "uncategorized")
+        XCTAssertTrue(
+            LocalHomebrewError.brewCommandFailed(
+                args: ["install", "--cask", "tool"], exitCode: 1, stderr: unrelated
+            ).shouldReport
+        )
         XCTAssertFalse(LocalHomebrewError.isAppManagementDenial(stderr: "curl: (6) Could not resolve host"))
     }
 

--- a/CaskHubTests/CaskHubTests.swift
+++ b/CaskHubTests/CaskHubTests.swift
@@ -87,6 +87,37 @@ final class CaskHubTests: XCTestCase {
         XCTAssertFalse(service.isAdoptable(cli))
     }
 
+    @MainActor
+    func test_mac_app_store_app_is_installed_but_not_adoptable() {
+        let service = LocalHomebrewService()
+        service.macAppStoreAppNames = ["Canva.app"]
+        let canva = makeCask("canva", appNames: ["Canva.app"])
+
+        XCTAssertTrue(service.isMacAppStoreInstalled(canva))
+        XCTAssertFalse(service.isAdoptable(canva))
+    }
+
+    func test_application_scan_separates_mac_app_store_bundles() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("application-scan-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let directApp = root.appendingPathComponent("Direct.app")
+        let storeReceipt = root.appendingPathComponent("Store.app/Contents/_MASReceipt/receipt")
+        try FileManager.default.createDirectory(at: directApp, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: storeReceipt.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: storeReceipt.path, contents: Data())
+
+        let scan = LocalHomebrewService.scanApplications(
+            fileManager: FileManager.default,
+            directories: [root]
+        )
+        XCTAssertEqual(scan.adoptableNames, ["Direct.app"])
+        XCTAssertEqual(scan.macAppStoreNames, ["Store.app"])
+    }
+
     func test_artifact_stanza_decodes_binary_names_from_paths() throws {
         let json = """
         [{"binary": ["claude"], "target": "/opt/homebrew/bin/claude"},
@@ -110,6 +141,27 @@ final class CaskHubTests: XCTestCase {
 
         let other = makeCask("some-tool", binaryNames: ["some-tool"])
         XCTAssertFalse(service.isExternalCLI(other))
+    }
+
+    func test_binary_scan_detects_executables_in_homebrew_prefix() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("binary-scan-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let executable = root.appendingPathComponent("copilot")
+        FileManager.default.createFile(atPath: executable.path, contents: Data())
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: executable.path
+        )
+
+        XCTAssertEqual(
+            LocalHomebrewService.scanBinaryDirectories(
+                fileManager: FileManager.default,
+                directories: [root]
+            ),
+            ["copilot"]
+        )
     }
 
     func test_apple_silicon_detection_matches_native_build_arch() {

--- a/CaskHubTests/CrashReporterTests.swift
+++ b/CaskHubTests/CrashReporterTests.swift
@@ -128,7 +128,7 @@ final class CrashReporterTests: XCTestCase {
     func test_recoverable_brew_failures_are_never_captured() {
         let failures = [
             "It seems the existing App is different from the one being installed.",
-            "chmod: Operation not permitted",
+            "chmod: /Applications/Example.app/Contents/MacOS/example: Operation not permitted",
             "SHA256 mismatch",
             "Download failed: curl: (6) Could not resolve host: example.com"
         ]
@@ -181,7 +181,10 @@ final class CrashReporterTests: XCTestCase {
         }
         XCTAssertEqual(cls("Warning: Cask 'x' is unavailable: No Cask with this name exists."), "unknown-cask")
         XCTAssertEqual(cls("Error: Cask 'sequel-ace' is not installed."), "not-installed")
-        XCTAssertEqual(cls("chmod: Unable to change file mode: Operation not permitted"), "permission-denied")
+        XCTAssertEqual(
+            cls("chmod: /Applications/Example.app: Unable to change file mode: Operation not permitted"),
+            "permission-denied"
+        )
         XCTAssertEqual(cls("It seems the existing App is different from the one being installed."), "adopt-version-mismatch")
         XCTAssertEqual(cls("SHA256 mismatch"), "checksum-mismatch")
         XCTAssertEqual(cls("curl: (6) Could not resolve host: example.com"), "network-failure")

--- a/CaskHubTests/CrashReporterTests.swift
+++ b/CaskHubTests/CrashReporterTests.swift
@@ -58,13 +58,13 @@ final class CrashReporterTests: XCTestCase {
     // MARK: - Capture + consent
 
     func test_capture_forwards_error_when_enabled() {
-        CrashReporter.capture(URLError(.timedOut))
+        CrashReporter.capture(URLError(.badServerResponse))
         XCTAssertEqual(spy.capturedErrors.count, 1)
     }
 
     func test_capture_is_suppressed_when_opted_out() {
         UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
-        CrashReporter.capture(URLError(.timedOut))
+        CrashReporter.capture(URLError(.badServerResponse))
         XCTAssertTrue(spy.capturedErrors.isEmpty)
     }
 
@@ -72,21 +72,31 @@ final class CrashReporterTests: XCTestCase {
 
     func test_capture_stops_after_five_identical_errors() {
         for _ in 1...6 {
-            CrashReporter.capture(URLError(.timedOut))
+            CrashReporter.capture(URLError(.badServerResponse))
         }
         XCTAssertEqual(spy.capturedErrors.count, 5)
     }
 
     func test_distinct_error_signatures_are_limited_independently() {
         for _ in 1...6 {
-            CrashReporter.capture(URLError(.timedOut))
-            CrashReporter.capture(URLError(.cannotFindHost))
+            CrashReporter.capture(URLError(.badServerResponse))
+            CrashReporter.capture(URLError(.cannotDecodeRawData))
         }
         XCTAssertEqual(spy.capturedErrors.count, 10)
     }
 
-    func test_offline_errors_are_never_captured() {
-        CrashReporter.capture(URLError(.notConnectedToInternet))
+    func test_transient_network_errors_are_never_captured() {
+        let codes: [URLError.Code] = [
+            .notConnectedToInternet,
+            .timedOut,
+            .networkConnectionLost,
+            .cannotFindHost,
+            .cannotConnectToHost,
+            .dnsLookupFailed
+        ]
+        for code in codes {
+            CrashReporter.capture(URLError(code))
+        }
         XCTAssertTrue(spy.capturedErrors.isEmpty)
     }
 
@@ -113,6 +123,31 @@ final class CrashReporterTests: XCTestCase {
     func test_environmental_errors_are_never_captured() {
         CrashReporter.capture(LocalHomebrewError.brewBinaryNotFound)
         XCTAssertTrue(spy.capturedErrors.isEmpty)
+    }
+
+    func test_recoverable_brew_failures_are_never_captured() {
+        let failures = [
+            "It seems the existing App is different from the one being installed.",
+            "chmod: Operation not permitted",
+            "SHA256 mismatch"
+        ]
+        for stderr in failures {
+            CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
+                args: ["install", "--cask", "x", "--adopt"],
+                exitCode: 1,
+                stderr: stderr
+            ))
+        }
+        XCTAssertTrue(spy.capturedErrors.isEmpty)
+    }
+
+    func test_unexpected_brew_conflicts_remain_reportable() {
+        CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "x"],
+            exitCode: 1,
+            stderr: "It seems there is already a Binary at '/opt/homebrew/bin/x'."
+        ))
+        XCTAssertEqual(spy.capturedErrors.count, 1)
     }
 
     // MARK: - Fingerprinting
@@ -148,6 +183,7 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertEqual(cls("chmod: Unable to change file mode: Operation not permitted"), "permission-denied")
         XCTAssertEqual(cls("It seems the existing App is different from the one being installed."), "adopt-version-mismatch")
         XCTAssertEqual(cls("SHA256 mismatch"), "checksum-mismatch")
+        XCTAssertEqual(cls("It seems there is already a Binary at '/opt/homebrew/bin/x'."), "binary-conflict")
         XCTAssertEqual(cls("It seems there is already an App at '/Applications/X.app'."), "app-conflict")
         XCTAssertEqual(cls("something novel"), "uncategorized")
     }

--- a/CaskHubTests/CrashReporterTests.swift
+++ b/CaskHubTests/CrashReporterTests.swift
@@ -129,7 +129,8 @@ final class CrashReporterTests: XCTestCase {
         let failures = [
             "It seems the existing App is different from the one being installed.",
             "chmod: Operation not permitted",
-            "SHA256 mismatch"
+            "SHA256 mismatch",
+            "Download failed: curl: (6) Could not resolve host: example.com"
         ]
         for stderr in failures {
             CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
@@ -183,6 +184,7 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertEqual(cls("chmod: Unable to change file mode: Operation not permitted"), "permission-denied")
         XCTAssertEqual(cls("It seems the existing App is different from the one being installed."), "adopt-version-mismatch")
         XCTAssertEqual(cls("SHA256 mismatch"), "checksum-mismatch")
+        XCTAssertEqual(cls("curl: (6) Could not resolve host: example.com"), "network-failure")
         XCTAssertEqual(cls("It seems there is already a Binary at '/opt/homebrew/bin/x'."), "binary-conflict")
         XCTAssertEqual(cls("It seems there is already an App at '/Applications/X.app'."), "app-conflict")
         XCTAssertEqual(cls("something novel"), "uncategorized")

--- a/CaskHubTests/SettingsViewTests.swift
+++ b/CaskHubTests/SettingsViewTests.swift
@@ -34,16 +34,74 @@ final class SettingsViewTests: XCTestCase {
     }
 
     @MainActor
-    func test_clear_cache_recreates_empty_icon_directory() {
-        let cache = ImageCacheService()
-        cache.clearCache()
+    func test_clear_cache_recreates_empty_icon_directory() async {
+        let directory = temporaryCacheDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let diskCache = IconDiskCache(directory: directory)
+        let cache = ImageCacheService(diskCache: diskCache)
 
-        let dir = FileManager.default
-            .urls(for: .cachesDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("CaskHub/icons", isDirectory: true)
-        let contents = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+        await cache.clearCache()
+
+        let contents = await diskCache.fileNames()
         XCTAssertTrue(contents.allSatisfy { $0.hasPrefix(".") },
                       "expected no cached icons, found: \(contents)")
+    }
+
+    func test_clear_serializes_with_pending_write_and_removes_result() async throws {
+        let directory = temporaryCacheDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let diskCache = IconDiskCache(directory: directory)
+        let generation = await diskCache.currentGeneration()
+
+        async let stored = diskCache.store(
+            Data("icon".utf8),
+            token: "pending",
+            generation: generation,
+            fromCaskFlow: true
+        )
+        async let cleared: Void = diskCache.clear()
+        _ = try await(stored, cleared)
+
+        let data = await diskCache.loadData(token: "pending")
+        XCTAssertNil(data)
+    }
+
+    func test_write_from_before_clear_is_rejected() async throws {
+        let directory = temporaryCacheDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let diskCache = IconDiskCache(directory: directory)
+        let staleGeneration = await diskCache.currentGeneration()
+
+        try await diskCache.clear()
+        let stored = try await diskCache.store(
+            Data("stale".utf8),
+            token: "stale",
+            generation: staleGeneration,
+            fromCaskFlow: true
+        )
+
+        XCTAssertFalse(stored)
+        let data = await diskCache.loadData(token: "stale")
+        XCTAssertNil(data)
+    }
+
+    func test_store_recreates_externally_removed_directory() async throws {
+        let directory = temporaryCacheDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let diskCache = IconDiskCache(directory: directory)
+        let generation = await diskCache.currentGeneration()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try FileManager.default.removeItem(at: directory)
+
+        let stored = try await diskCache.store(
+            Data("icon".utf8),
+            token: "recreated",
+            generation: generation,
+            fromCaskFlow: true
+        )
+
+        XCTAssertTrue(stored)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
     }
 
     @MainActor
@@ -51,5 +109,10 @@ final class SettingsViewTests: XCTestCase {
         for theme in AppTheme.allCases {
             XCTAssertNotNil(theme.previewImage, "missing theme preview for \(theme.rawValue)")
         }
+    }
+
+    private func temporaryCacheDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("icon-disk-cache-\(UUID().uuidString)", isDirectory: true)
     }
 }

--- a/CaskHubTests/SettingsViewTests.swift
+++ b/CaskHubTests/SettingsViewTests.swift
@@ -9,7 +9,33 @@
 import SwiftUI
 import XCTest
 
+@MainActor
+private final class BackgroundUpdateCheckerSpy: BackgroundUpdateChecking {
+    let automaticallyChecksForUpdates: Bool
+    private(set) var checkCount = 0
+
+    init(automaticallyChecksForUpdates: Bool) {
+        self.automaticallyChecksForUpdates = automaticallyChecksForUpdates
+    }
+
+    func checkForUpdatesInBackground() {
+        checkCount += 1
+    }
+}
+
 final class SettingsViewTests: XCTestCase {
+    @MainActor
+    func test_launch_check_respects_automatic_update_preference() {
+        let enabled = BackgroundUpdateCheckerSpy(automaticallyChecksForUpdates: true)
+        let disabled = BackgroundUpdateCheckerSpy(automaticallyChecksForUpdates: false)
+
+        UpdaterService.checkForUpdatesOnLaunch(using: enabled)
+        UpdaterService.checkForUpdatesOnLaunch(using: disabled)
+
+        XCTAssertEqual(enabled.checkCount, 1)
+        XCTAssertEqual(disabled.checkCount, 0)
+    }
+
     @MainActor
     private func render(_ view: some View) {
         let hosting = NSHostingView(rootView: AnyView(view))

--- a/CaskHubTests/ZombieDetectionTests.swift
+++ b/CaskHubTests/ZombieDetectionTests.swift
@@ -109,7 +109,7 @@ final class ZombieDetectionTests: XCTestCase {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("tcc-note"))
         let error = LocalHomebrewError.brewCommandFailed(
             args: ["install", "--cask", "sourcetree", "--adopt"], exitCode: 1,
-            stderr: "chmod: Unable to change file mode: Operation not permitted"
+            stderr: "chmod: /Applications/SourceTree.app: Unable to change file mode: Operation not permitted"
         )
         service.noteFailure(token: "sourcetree", error: error)
         XCTAssertTrue(service.appManagementDenials.contains("sourcetree"))


### PR DESCRIPTION
## Summary

- Harden Homebrew state detection for externally installed apps and command-line tools.
- Treat Mac App Store applications as installed without offering unsafe adoption or replacement.
- Prevent external CLI conflicts while ignoring invalid zero-byte executable artifacts.
- Show the detected external CLI path so users can resolve conflicts manually.
- Narrow App Management recovery to permission failures that target application bundles.
- Suppress expected recovery and transient network failures from Sentry while preserving unexpected errors.
- Replace the problematic macOS list layout with a lazy scroll stack to avoid row-height hangs.
- Serialize icon disk-cache operations and prevent stale writes after the cache is cleared.
- Check for app updates silently on launch when automatic checks are enabled.

## Sentry coverage

Addresses the following observed issues:

- CASKHUB-B
- CASKHUB-C
- CASKHUB-D
- CASKHUB-E
- CASKHUB-F
- CASKHUB-G
- CASKHUB-H

The changes also prevent recurrence noise for CASKHUB-4. CASKHUB-5 is an older modal hang with no recent recurrence and remains covered by the existing XCTest telemetry guard.

## Compatibility and safety

- Existing Homebrew-managed installations continue to take precedence.
- No external binaries or applications are automatically removed or modified.
- No persisted-state migration is required.
- Unexpected permission failures remain reportable to Sentry instead of being misclassified as App Management denials.
- Launch-time update checks respect the existing automatic-check preference and never run when it is disabled.

## Verification

- Full CaskHub macOS test suite passed.
- Focused permission and external-install regression tests passed.
- Automatic update preference regression test passed.
- SwiftLint passed with zero violations.
- Codacy static analysis passed.
- GitHub Actions test and coverage checks passed.
- Git diff validation passed.
