### PR TITLE
fix: add connect/max timeouts to categories sync curl

### DIFF
--- a/Scripts/sync_bundled_categories.sh
+++ b/Scripts/sync_bundled_categories.sh
@@ -16,7 +16,7 @@ for asset in categories.json added_dates.json; do
     destination="$RESOURCE_DIR/$asset"
     temporary="$destination.download"
     echo "Fetching $BASE_URL/$asset"
-    curl -fsSL "$BASE_URL/$asset" -o "$temporary"
+    curl -fsSL --connect-timeout 20 --max-time 120 "$BASE_URL/$asset" -o "$temporary"
     mv "$temporary" "$destination"
     echo "Updated $destination"
 done


### PR DESCRIPTION
`sync_bundled_categories.sh` fetched with a bare `curl -fsSL` and no timeout, so a stalled GitHub release redirect wedged the script indefinitely (hit twice while cutting 0.6.3 locally; macOS has no `timeout` to wrap it). Adds `--connect-timeout 20 --max-time 120` so a hung fetch fails fast instead of hanging. No behavior change on the happy path; CI unaffected.