### PR TITLE
fix: Harden Homebrew repair recovery and diagnostics

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000001 /* LocalHomebrewTypes.swift */; };
 		A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000002 /* LocalHomebrewService+State.swift */; };
 		A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */; };
+		C13000000000000000000001 /* LocalHomebrewService+Mutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */; };
+		C13000000000000000000002 /* MutationRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13000000000000000000002 /* MutationRecoveryTests.swift */; };
 		41DFD4A630028F7D00608C7A /* RecentlyAddedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47430028F7D00608C7A /* RecentlyAddedService.swift */; };
 		41DFD4A730028F7D00608C7A /* CaskCatalogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47630028F7D00608C7A /* CaskCatalogViewModel.swift */; };
 		41DFD4A830028F7D00608C7A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47830028F7D00608C7A /* SettingsView.swift */; };
@@ -126,6 +128,8 @@
 		B12000000000000000000001 /* LocalHomebrewTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewTypes.swift; sourceTree = "<group>"; };
 		B12000000000000000000002 /* LocalHomebrewService+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+State.swift"; sourceTree = "<group>"; };
 		B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Adoption.swift"; sourceTree = "<group>"; };
+		D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Mutations.swift"; sourceTree = "<group>"; };
+		D13000000000000000000002 /* MutationRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRecoveryTests.swift; sourceTree = "<group>"; };
 		41DFD47430028F7D00608C7A /* RecentlyAddedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyAddedService.swift; sourceTree = "<group>"; };
 		41DFD47630028F7D00608C7A /* CaskCatalogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogViewModel.swift; sourceTree = "<group>"; };
 		41DFD47830028F7D00608C7A /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -268,6 +272,7 @@
 				B12000000000000000000001 /* LocalHomebrewTypes.swift */,
 				B12000000000000000000002 /* LocalHomebrewService+State.swift */,
 				B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */,
+				D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */,
 				41DFD47430028F7D00608C7A /* RecentlyAddedService.swift */,
 				41AD10302F68D00100BEABB8 /* UpdaterService.swift */,
 			);
@@ -347,6 +352,7 @@
 				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
 				ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */,
 				8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */,
+				D13000000000000000000002 /* MutationRecoveryTests.swift */,
 				B12000000000000000000004 /* ZombieDetectionTests.swift */,
 				41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */,
 			);
@@ -546,6 +552,7 @@
 				A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */,
 				A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */,
 				A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */,
+				C13000000000000000000001 /* LocalHomebrewService+Mutations.swift in Sources */,
 				41DFD4A630028F7D00608C7A /* RecentlyAddedService.swift in Sources */,
 				41AD10312F68D00200BEABB8 /* UpdaterService.swift in Sources */,
 				41DFD4A730028F7D00608C7A /* CaskCatalogViewModel.swift in Sources */,
@@ -572,6 +579,7 @@
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,
 				FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */,
+				C13000000000000000000002 /* MutationRecoveryTests.swift in Sources */,
 				A12000000000000000000004 /* ZombieDetectionTests.swift in Sources */,
 				41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */,
 			);

--- a/CaskHub/Services/Analytics+Events.swift
+++ b/CaskHub/Services/Analytics+Events.swift
@@ -14,20 +14,60 @@ import Foundation
 extension Analytics {
     // MARK: - Cask actions
 
-    static func caskActionCompleted(_ action: CaskAction, token: String) {
+    static func caskActionStarted(
+        _ action: CaskAction,
+        token: String,
+        origin: CaskActionOrigin
+    ) {
         guard let verb = action.analyticsVerb else { return }
-        send("Cask.\(verb.past)", parameters: ["cask": token])
+        send("Cask.actionStarted", parameters: actionParameters(
+            verb: verb.base, token: token, origin: origin
+        ))
     }
 
-    static func caskActionFailed(_ action: CaskAction, token: String) {
+    static func caskActionCompleted(
+        _ action: CaskAction,
+        token: String,
+        origin: CaskActionOrigin = .individual
+    ) {
         guard let verb = action.analyticsVerb else { return }
-        send("Cask.actionFailed", parameters: ["action": verb.base, "cask": token])
+        send("Cask.\(verb.past)", parameters: ["cask": token, "origin": origin.rawValue])
+    }
+
+    static func caskActionFailed(
+        _ action: CaskAction,
+        token: String,
+        origin: CaskActionOrigin = .individual
+    ) {
+        guard let verb = action.analyticsVerb else { return }
+        send("Cask.actionFailed", parameters: actionParameters(
+            verb: verb.base, token: token, origin: origin
+        ))
+    }
+
+    static func caskActionRecovered(
+        _ action: CaskAction,
+        token: String,
+        origin: CaskActionOrigin
+    ) {
+        guard let verb = action.analyticsVerb else { return }
+        send("Cask.actionRecovered", parameters: actionParameters(
+            verb: verb.base, token: token, origin: origin
+        ))
     }
 
     /// The Updates page "Update All" tap; each cask in the queue then emits
     /// its own `Cask.updated` / `Cask.actionFailed` signal as usual.
     static func updateAllTapped(count: Int) {
         send("Cask.updateAllTapped", parameters: ["count": "\(count)"])
+    }
+
+    private static func actionParameters(
+        verb: String,
+        token: String,
+        origin: CaskActionOrigin
+    ) -> [String: String] {
+        ["action": verb, "cask": token, "origin": origin.rawValue]
     }
 
     // MARK: - Navigation
@@ -109,6 +149,7 @@ private extension CaskAction {
         case .adopting: return ("adopt", "adopted")
         case .uninstalling: return ("uninstall", "uninstalled")
         case .updating: return ("update", "updated")
+        case .repairing: return ("repair", "repaired")
         case .opening, .queued: return nil
         }
     }

--- a/CaskHub/Services/LocalHomebrewService+Mutations.swift
+++ b/CaskHub/Services/LocalHomebrewService+Mutations.swift
@@ -1,0 +1,166 @@
+//
+//  LocalHomebrewService+Mutations.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 20/07/2026.
+//
+
+import Foundation
+
+extension LocalHomebrewService {
+    /// Classifies a brew failure into the offer sets the alert UI reads.
+    /// Stranded detection also consults the filesystem — brew can reword its
+    /// errors, but a real .app parked in the Caskroom can't be misread.
+    func noteFailure(token: String, error: Error) {
+        guard case let LocalHomebrewError.brewCommandFailed(args, _, stderr) = error else { return }
+        if LocalHomebrewError.isAppManagementDenial(stderr: stderr) {
+            appManagementDenials.insert(token)
+        }
+        if LocalHomebrewError.isStrandedApp(stderr: stderr)
+            || (args.first == "upgrade" && hasStrandedCopy(token: token)) {
+            repairOffers.insert(token)
+        }
+    }
+
+    func runMutation(
+        _ action: CaskAction,
+        token: String,
+        args: [String],
+        origin: CaskActionOrigin = .individual,
+        environmentOverrides: [String: String] = [:],
+        recoverIf: (() -> Bool)? = nil
+    ) async throws {
+        guard inFlightActions[token] == nil || inFlightActions[token] == .queued else { return }
+        inFlightActions[token] = action
+        actionErrors[token] = nil
+        Analytics.caskActionStarted(action, token: token, origin: origin)
+        defer {
+            inFlightActions[token] = nil
+            cancellableDownloads.remove(token)
+            runningProcesses[token] = nil
+        }
+
+        let span = CrashReporter.span(name: args.first ?? "brew", operation: "brew")
+        do {
+            try await runBrewStreaming(
+                token: token,
+                args: args,
+                cancellable: action == .installing,
+                environmentOverrides: environmentOverrides
+            )
+            span.finish()
+            cancelRequested.remove(token)
+            Analytics.caskActionCompleted(action, token: token, origin: origin)
+            await refresh()
+        } catch {
+            if await finishCancelledMutationIfNeeded(token: token, span: span) { return }
+            if let localError = error as? LocalHomebrewError,
+               case .brewCommandFailed = localError,
+               recoverIf?() == true {
+                span.finish()
+                cancelRequested.remove(token)
+                Analytics.caskActionRecovered(action, token: token, origin: origin)
+                await refresh()
+                return
+            }
+            span.finish(error: error)
+            CrashReporter.capture(error)
+            Analytics.caskActionFailed(action, token: token, origin: origin)
+            noteFailure(token: token, error: error)
+            actionErrors[token] = (error as? LocalHomebrewError)?.errorDescription
+                ?? error.localizedDescription
+            throw error
+        }
+    }
+
+    private func finishCancelledMutationIfNeeded(token: String, span: CrashSpan) async -> Bool {
+        guard cancelRequested.contains(token) else { return false }
+        span.finish()
+        cancelRequested.remove(token)
+        // Homebrew owns its cache and safely resumes partial downloads.
+        // Never sweep the shared cache: another brew process may be using it.
+        await refresh()
+        return true
+    }
+
+    private func hasStrandedCopy(token: String) -> Bool {
+        guard let caskroom = Self.locateCaskroom(fileManager: fileManager) else { return false }
+        return Self.strandedCopyExists(in: caskroom, token: token, fileManager: fileManager)
+    }
+
+    func runBrewStreaming(
+        token: String,
+        args: [String],
+        cancellable: Bool,
+        environmentOverrides: [String: String] = [:]
+    ) async throws {
+        guard let brewURL = brewBinaryProvider() else {
+            throw LocalHomebrewError.brewBinaryNotFound
+        }
+
+        let askpass = Self.ensureAskpassScript(token: token)
+        defer {
+            if let askpass { Self.removeAskpassScript(at: askpass) }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment.merge(environmentOverrides) { _, override in override }
+        if let askpass {
+            environment["SUDO_ASKPASS"] = askpass.path
+        }
+
+        let result = try await processRunner.run(
+            executableURL: brewURL,
+            arguments: args,
+            environment: environment,
+            onStart: { [weak self] process in
+                self?.runningProcesses[token] = process
+                if cancellable { self?.cancellableDownloads.insert(token) }
+            },
+            onChunk: { [weak self] text in
+                guard text.contains("==> Installing Cask") else { return }
+                guard let self else { return }
+                Task { @MainActor in self.cancellableDownloads.remove(token) }
+            }
+        )
+
+        if result.exitCode != 0 {
+            throw LocalHomebrewError.brewCommandFailed(
+                args: args,
+                exitCode: result.exitCode,
+                stderr: Self.diagnosticOutput(from: result.output)
+            )
+        }
+    }
+
+    func repairRemovalSatisfied(
+        caskroomEntry: URL?,
+        appBundleNames: [String]
+    ) -> Bool {
+        guard let caskroomEntry,
+              !fileManager.fileExists(atPath: caskroomEntry.path)
+        else { return false }
+        return appBundleNames.allSatisfy { name in
+            applicationDirectories.allSatisfy { directory in
+                !fileManager.fileExists(atPath: directory.appendingPathComponent(name).path)
+            }
+        }
+    }
+
+    private static func diagnosticOutput(from output: String) -> String {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let limit = 8_192
+        guard trimmed.count > limit else { return trimmed }
+
+        let important = trimmed.components(separatedBy: .newlines).filter { line in
+            let lowercase = line.lowercased()
+            return line.contains("Error:")
+                || line.contains("Warning:")
+                || lowercase.contains("failed")
+                || line.contains("Operation not permitted")
+        }
+        let importantText = String(important.joined(separator: "\n").prefix(2_000))
+        let tail = String(trimmed.suffix(limit - 2_100))
+        return importantText.isEmpty ? String(trimmed.suffix(limit)) : importantText + "\n…\n" + tail
+    }
+}

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -52,16 +52,16 @@ final class LocalHomebrewService {
 
     @ObservationIgnored private var activationObserver: (any NSObjectProtocol)?
 
-    private(set) var inFlightActions: [String: CaskAction] = [:]
+    var inFlightActions: [String: CaskAction] = [:]
 
-    private(set) var cancellableDownloads: Set<String> = []
+    var cancellableDownloads: Set<String> = []
 
-    private(set) var cancelRequested: Set<String> = []
+    var cancelRequested: Set<String> = []
 
-    @ObservationIgnored private var runningProcesses: [String: Process] = [:]
+    @ObservationIgnored var runningProcesses: [String: Process] = [:]
 
-    @ObservationIgnored private let processRunner: any BrewProcessRunning
-    @ObservationIgnored private let brewBinaryProvider: () -> URL?
+    @ObservationIgnored let processRunner: any BrewProcessRunning
+    @ObservationIgnored let brewBinaryProvider: () -> URL?
     @ObservationIgnored private let brewVersionProvider: () async -> String?
 
     var actionErrors: [String: String] = [:]
@@ -166,19 +166,26 @@ final class LocalHomebrewService {
 
     // MARK: - Actions
 
-    func install(token: String) async throws {
-        try await runMutation(.installing, token: token, args: ["install", "--cask", token])
+    func install(token: String, origin: CaskActionOrigin = .individual) async throws {
+        try await runMutation(
+            .installing, token: token, args: ["install", "--cask", token], origin: origin
+        )
     }
 
-    func uninstall(token: String) async throws {
-        try await runMutation(.uninstalling, token: token, args: ["uninstall", "--cask", token])
+    func uninstall(token: String, origin: CaskActionOrigin = .individual) async throws {
+        try await runMutation(
+            .uninstalling, token: token, args: ["uninstall", "--cask", token], origin: origin
+        )
     }
 
     /// Clears a zombie Caskroom entry — the app is already gone, `--force`
     /// removes the leftover brew bookkeeping without complaining about it.
     func repair(token: String) async throws {
         try await runMutation(
-            .uninstalling, token: token, args: ["uninstall", "--cask", token, "--force"]
+            .uninstalling,
+            token: token,
+            args: ["uninstall", "--cask", token, "--force"],
+            origin: .repair
         )
     }
 
@@ -191,7 +198,11 @@ final class LocalHomebrewService {
     func repairReinstalling(token: String) async throws {
         guard inFlightActions[token] == nil else { return }
         repairOffers.remove(token)
-        inFlightActions[token] = .queued
+        let caskroomEntry = Self.locateCaskroom(fileManager: fileManager)?
+            .appendingPathComponent(token)
+        let appBundleNames = installedCasks[token]?.appBundleNames ?? []
+        Analytics.caskActionStarted(.repairing, token: token, origin: .repair)
+        inFlightActions[token] = .repairing
         do {
             try await runBrewStreaming(token: token, args: ["fetch", "--cask", token], cancellable: false)
             inFlightActions[token] = nil
@@ -200,19 +211,41 @@ final class LocalHomebrewService {
             inFlightActions[token] = nil
             runningProcesses[token] = nil
             CrashReporter.capture(error)
+            Analytics.caskActionFailed(.repairing, token: token, origin: .repair)
             actionErrors[token] = (error as? LocalHomebrewError)?.errorDescription
                 ?? error.localizedDescription
             throw error
         }
-        try await runMutation(
-            .uninstalling, token: token, args: ["uninstall", "--cask", token, "--force"]
-        )
-        try await runMutation(.installing, token: token, args: ["install", "--cask", token])
+        do {
+            try await runMutation(
+                .uninstalling,
+                token: token,
+                args: ["uninstall", "--cask", token, "--force"],
+                origin: .repair,
+                environmentOverrides: ["HOMEBREW_NO_AUTOREMOVE": "1"],
+                recoverIf: { [self] in
+                    repairRemovalSatisfied(
+                        caskroomEntry: caskroomEntry,
+                        appBundleNames: appBundleNames
+                    )
+                }
+            )
+            try await runMutation(
+                .installing,
+                token: token,
+                args: ["install", "--cask", token],
+                origin: .repair
+            )
+            Analytics.caskActionCompleted(.repairing, token: token, origin: .repair)
+        } catch {
+            Analytics.caskActionFailed(.repairing, token: token, origin: .repair)
+            throw error
+        }
     }
 
-    func upgrade(token: String) async throws {
+    func upgrade(token: String, origin: CaskActionOrigin = .individual) async throws {
         let args = ["upgrade", "--cask", token] + (greedyUpdates ? ["--greedy"] : [])
-        try await runMutation(.updating, token: token, args: args)
+        try await runMutation(.updating, token: token, args: args, origin: origin)
     }
 
     func updateAll(tokens: [String]) async {
@@ -223,7 +256,7 @@ final class LocalHomebrewService {
             inFlightActions[token] = .queued
         }
         for token in tokens {
-            try? await upgrade(token: token)
+            try? await upgrade(token: token, origin: .updateAll)
         }
     }
 
@@ -241,102 +274,4 @@ final class LocalHomebrewService {
         }
     }
 
-    // MARK: - Mutation Plumbing
-
-    /// Classifies a brew failure into the offer sets the alert UI reads.
-    /// Stranded detection also consults the filesystem — brew can reword its
-    /// errors, but a real .app parked in the Caskroom can't be misread.
-    func noteFailure(token: String, error: Error) {
-        guard case let LocalHomebrewError.brewCommandFailed(args, _, stderr) = error else { return }
-        if LocalHomebrewError.isAppManagementDenial(stderr: stderr) {
-            appManagementDenials.insert(token)
-        }
-        if LocalHomebrewError.isStrandedApp(stderr: stderr)
-            || (args.first == "upgrade" && hasStrandedCopy(token: token)) {
-            repairOffers.insert(token)
-        }
-    }
-
-    private func hasStrandedCopy(token: String) -> Bool {
-        guard let caskroom = Self.locateCaskroom(fileManager: fileManager) else { return false }
-        return Self.strandedCopyExists(in: caskroom, token: token, fileManager: fileManager)
-    }
-
-    func runMutation(_ action: CaskAction, token: String, args: [String]) async throws {
-        guard inFlightActions[token] == nil || inFlightActions[token] == .queued else { return }
-        inFlightActions[token] = action
-        actionErrors[token] = nil
-        defer {
-            inFlightActions[token] = nil
-            cancellableDownloads.remove(token)
-            runningProcesses[token] = nil
-        }
-
-        let span = CrashReporter.span(name: args.first ?? "brew", operation: "brew")
-        do {
-            try await runBrewStreaming(token: token, args: args, cancellable: action == .installing)
-            span.finish()
-            cancelRequested.remove(token)
-            Analytics.caskActionCompleted(action, token: token)
-            await refresh()
-        } catch {
-            if cancelRequested.contains(token) {
-                span.finish()
-                cancelRequested.remove(token)
-                // Homebrew owns its cache and safely resumes partial downloads.
-                // Never sweep the shared cache: another brew process may be using it.
-                await refresh()
-                return
-            }
-            span.finish(error: error)
-            CrashReporter.capture(error)
-            Analytics.caskActionFailed(action, token: token)
-            noteFailure(token: token, error: error)
-            if let error = error as? LocalHomebrewError {
-                actionErrors[token] = error.errorDescription
-            } else {
-                actionErrors[token] = error.localizedDescription
-            }
-            throw error
-        }
-    }
-
-    private func runBrewStreaming(token: String, args: [String], cancellable: Bool) async throws {
-        guard let brewURL = brewBinaryProvider() else {
-            throw LocalHomebrewError.brewBinaryNotFound
-        }
-
-        let askpass = Self.ensureAskpassScript(token: token)
-        defer {
-            if let askpass { Self.removeAskpassScript(at: askpass) }
-        }
-
-        var environment = ProcessInfo.processInfo.environment
-        if let askpass {
-            environment["SUDO_ASKPASS"] = askpass.path
-        }
-
-        let result = try await processRunner.run(
-            executableURL: brewURL,
-            arguments: args,
-            environment: environment,
-            onStart: { [weak self] process in
-                self?.runningProcesses[token] = process
-                if cancellable { self?.cancellableDownloads.insert(token) }
-            },
-            onChunk: { [weak self] text in
-                guard text.contains("==> Installing Cask") else { return }
-                guard let self else { return }
-                Task { @MainActor in self.cancellableDownloads.remove(token) }
-            }
-        )
-
-        if result.exitCode != 0 {
-            throw LocalHomebrewError.brewCommandFailed(
-                args: args,
-                exitCode: result.exitCode,
-                stderr: result.output.components(separatedBy: "\n").suffix(6).joined(separator: "\n")
-            )
-        }
-    }
 }

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -47,6 +47,7 @@ enum CaskAction: Equatable {
     case adopting
     case updating
     case uninstalling
+    case repairing
     case queued
 
     var inProgressLabel: String {
@@ -56,9 +57,16 @@ enum CaskAction: Equatable {
         case .adopting: return "Adopting…"
         case .updating: return "Updating…"
         case .uninstalling: return "Uninstalling…"
+        case .repairing: return "Repairing…"
         case .queued: return "Queued…"
         }
     }
+}
+
+enum CaskActionOrigin: String {
+    case individual
+    case updateAll
+    case repair
 }
 
 enum LocalHomebrewError: LocalizedError {
@@ -106,7 +114,8 @@ enum LocalHomebrewError: LocalizedError {
         "adopt-version-mismatch",
         "checksum-mismatch",
         "network-failure",
-        "permission-denied"
+        "permission-denied",
+        "stranded-caskroom-app"
     ]
 
     /// A previous interrupted operation parked the real .app inside the Caskroom

--- a/CaskHubTests/AdoptionTests.swift
+++ b/CaskHubTests/AdoptionTests.swift
@@ -25,6 +25,7 @@ final class StubBrewProcessRunner: BrewProcessRunning {
 
     var queuedResults: [BrewProcessResult] = []
     var thrownError: Error?
+    var onRequest: ((Request) throws -> Void)?
     private(set) var requests: [Request] = []
 
     func run(
@@ -37,12 +38,14 @@ final class StubBrewProcessRunner: BrewProcessRunning {
         let askpassContents = environment["SUDO_ASKPASS"].flatMap {
             try? String(contentsOfFile: $0, encoding: .utf8)
         }
-        requests.append(Request(
+        let request = Request(
             executableURL: executableURL,
             arguments: arguments,
             environment: environment,
             askpassContents: askpassContents
-        ))
+        )
+        requests.append(request)
+        try onRequest?(request)
         if let thrownError { throw thrownError }
         return queuedResults.isEmpty
             ? BrewProcessResult(exitCode: 0, output: "")
@@ -155,6 +158,12 @@ final class AdoptionSurfaceTests: XCTestCase {
             ["install", "--cask", "firefox"]
         ])
         XCTAssertTrue(runner.requests.allSatisfy { $0.executableURL.path == "/test/bin/brew" })
+        XCTAssertEqual(
+            runner.requests[1].environment["HOMEBREW_NO_AUTOREMOVE"], "1",
+            "repair must not remove unrelated orphaned formulae"
+        )
+        XCTAssertNil(runner.requests[0].environment["HOMEBREW_NO_AUTOREMOVE"])
+        XCTAssertNil(runner.requests[2].environment["HOMEBREW_NO_AUTOREMOVE"])
     }
 
     func test_askpass_scripts_are_unique_shell_safe_and_removable() throws {

--- a/CaskHubTests/AnalyticsTests.swift
+++ b/CaskHubTests/AnalyticsTests.swift
@@ -88,7 +88,18 @@ final class AnalyticsTests: XCTestCase {
             spy.signals.map(\.name),
             ["Cask.installed", "Cask.uninstalled", "Cask.updated"]
         )
-        XCTAssertEqual(lastSignal?.parameters, ["cask": "firefox"])
+        XCTAssertEqual(lastSignal?.parameters, ["cask": "firefox", "origin": "individual"])
+    }
+
+    func test_cask_action_started_records_action_token_and_origin() {
+        Analytics.caskActionStarted(.updating, token: "zoom", origin: .updateAll)
+
+        XCTAssertEqual(lastSignal?.name, "Cask.actionStarted")
+        XCTAssertEqual(lastSignal?.parameters, [
+            "action": "update",
+            "cask": "zoom",
+            "origin": "updateAll"
+        ])
     }
 
     func test_cask_action_completed_ignores_app_launches() {
@@ -99,7 +110,22 @@ final class AnalyticsTests: XCTestCase {
     func test_cask_action_failed_sends_base_verb_and_token() {
         Analytics.caskActionFailed(.updating, token: "iterm2")
         XCTAssertEqual(lastSignal?.name, "Cask.actionFailed")
-        XCTAssertEqual(lastSignal?.parameters, ["action": "update", "cask": "iterm2"])
+        XCTAssertEqual(lastSignal?.parameters, [
+            "action": "update",
+            "cask": "iterm2",
+            "origin": "individual"
+        ])
+    }
+
+    func test_cask_action_recovered_records_repair_postcondition() {
+        Analytics.caskActionRecovered(.uninstalling, token: "zed", origin: .repair)
+
+        XCTAssertEqual(lastSignal?.name, "Cask.actionRecovered")
+        XCTAssertEqual(lastSignal?.parameters, [
+            "action": "uninstall",
+            "cask": "zed",
+            "origin": "repair"
+        ])
     }
 
     func test_cask_action_failed_ignores_app_launches() {
@@ -108,6 +134,7 @@ final class AnalyticsTests: XCTestCase {
     }
 
     func test_cask_action_events_ignore_queued_state() {
+        Analytics.caskActionStarted(.queued, token: "firefox", origin: .updateAll)
         Analytics.caskActionCompleted(.queued, token: "firefox")
         Analytics.caskActionFailed(.queued, token: "firefox")
         XCTAssertTrue(spy.signals.isEmpty)

--- a/CaskHubTests/CrashReporterTests.swift
+++ b/CaskHubTests/CrashReporterTests.swift
@@ -128,6 +128,8 @@ final class CrashReporterTests: XCTestCase {
     func test_recoverable_brew_failures_are_never_captured() {
         let failures = [
             "It seems the existing App is different from the one being installed.",
+            "Error: zed: It seems there is already an App at "
+                + "'/opt/homebrew/Caskroom/zed/1.10.3/Zed.app'.",
             "chmod: /Applications/Example.app/Contents/MacOS/example: Operation not permitted",
             "SHA256 mismatch",
             "Download failed: curl: (6) Could not resolve host: example.com"

--- a/CaskHubTests/MutationRecoveryTests.swift
+++ b/CaskHubTests/MutationRecoveryTests.swift
@@ -1,0 +1,103 @@
+//
+//  MutationRecoveryTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 20/07/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+@MainActor
+final class MutationRecoveryTests: XCTestCase {
+    private let fileManager = FileManager.default
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = fileManager.temporaryDirectory
+            .appendingPathComponent("mutation-recovery-\(UUID().uuidString)")
+        try fileManager.createDirectory(
+            at: root.appendingPathComponent("Caskroom/zed/1.10.3"),
+            withIntermediateDirectories: true
+        )
+        UserDefaults.standard.set(root.path, forKey: LocalHomebrewService.customBrewPrefixKey)
+    }
+
+    override func tearDownWithError() throws {
+        UserDefaults.standard.removeObject(forKey: LocalHomebrewService.customBrewPrefixKey)
+        try? fileManager.removeItem(at: root)
+        try super.tearDownWithError()
+    }
+
+    private func makeService(runner: StubBrewProcessRunner) -> LocalHomebrewService {
+        LocalHomebrewService(
+            fileManager: fileManager,
+            defaults: makeScratchDefaults("repair-recovery"),
+            applicationDirectories: [root.appendingPathComponent("Applications")],
+            processRunner: runner,
+            brewBinaryProvider: { URL(fileURLWithPath: "/test/bin/brew") },
+            brewVersionProvider: { "test" }
+        )
+    }
+
+    func test_repair_reinstalls_when_uninstall_returns_nonzero_after_removing_cask() async throws {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [
+            BrewProcessResult(exitCode: 0, output: "fetched"),
+            BrewProcessResult(exitCode: 1, output: "Error: cleanup failed\nlibxaw\nlibxmu"),
+            BrewProcessResult(exitCode: 0, output: "installed")
+        ]
+        let caskroomEntry = root.appendingPathComponent("Caskroom/zed")
+        runner.onRequest = { [fileManager, caskroomEntry] request in
+            if request.arguments.first == "uninstall" {
+                try fileManager.removeItem(at: caskroomEntry)
+            }
+        }
+
+        try await makeService(runner: runner).repairReinstalling(token: "zed")
+
+        XCTAssertEqual(runner.requests.map(\.arguments), [
+            ["fetch", "--cask", "zed"],
+            ["uninstall", "--cask", "zed", "--force"],
+            ["install", "--cask", "zed"]
+        ])
+    }
+
+    func test_repair_stops_when_failed_uninstall_leaves_caskroom_entry() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [
+            BrewProcessResult(exitCode: 0, output: "fetched"),
+            BrewProcessResult(exitCode: 1, output: "Error: uninstall failed")
+        ]
+
+        do {
+            try await makeService(runner: runner).repairReinstalling(token: "zed")
+            XCTFail("repair must stop while the broken cask entry remains")
+        } catch {
+            XCTAssertEqual(runner.requests.map(\.arguments), [
+                ["fetch", "--cask", "zed"],
+                ["uninstall", "--cask", "zed", "--force"]
+            ])
+        }
+    }
+
+    func test_brew_error_diagnostics_keep_error_before_long_cleanup_tail() async {
+        let runner = StubBrewProcessRunner()
+        let cleanupTail = (1...30).map { "formula-\($0)" }.joined(separator: "\n")
+        runner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "Error: the meaningful failure\n" + cleanupTail
+        )]
+
+        do {
+            try await makeService(runner: runner).install(token: "zed")
+            XCTFail("expected failure")
+        } catch let LocalHomebrewError.brewCommandFailed(_, _, stderr) {
+            XCTAssertTrue(stderr.contains("Error: the meaningful failure"))
+            XCTAssertTrue(stderr.contains("formula-30"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- trace every Homebrew mutation from start to completion or failure, including whether it came from an individual action, Update All, or Repair
- recover safely when Homebrew exits nonzero after the uninstall postcondition has already succeeded
- prevent repair uninstalls from autoremove-cleaning unrelated dependencies
- preserve useful Homebrew diagnostics and stop reporting the expected stranded-Caskroom state as an application error

## Root cause

Homebrew can remove a cask successfully and then exit nonzero during a later cleanup or autoremove step. CaskHub treated every nonzero exit as a complete uninstall failure, so Repair stopped before reinstalling even when the old cask and app bundle were already gone. The previous six-line output suffix could also discard the original error and leave only cleanup output, making the failure misleading in Sentry.

## Safety and compatibility

- Repair still fetches the replacement artifact before any destructive step.
- A nonzero uninstall continues only when the Caskroom entry and receipt-known app bundles are confirmed absent.
- If any old state remains, Repair stops and reports the failure as before.
- Normal install, update, uninstall, and Update All behavior is unchanged apart from richer telemetry.
- Existing users with stranded Caskroom state still receive the Repair action; the expected detection event is simply no longer sent as an application failure.

## Validation

- full macOS unit test suite passes
- Release configuration builds successfully
- strict SwiftLint reports zero violations
- focused recovery, analytics, adoption, and crash-reporting tests pass

## Sentry

- CASKHUB-J: expected stranded-Caskroom detection is no longer reported as an application error
- CASKHUB-K: Repair can recover from a nonzero uninstall only after verifying the uninstall postcondition
