### PR TITLE
feat: Standardize release notes for GitHub releases and Sparkle

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: release-notes
+description: Use when cutting a CaskHub release, writing or reviewing RELEASE_NOTES.md, or drafting the GitHub release body / Sparkle appcast description
+---
+
+# CaskHub Release Notes
+
+## Overview
+
+One file — `RELEASE_NOTES.md` at the repo root — is the single source for both
+the GitHub release body and the Sparkle update dialog. `Scripts/release.sh`
+embeds it into `appcast.xml` (Sparkle renders the markdown) and passes it to
+`gh release create --notes-file`. PR descriptions are NOT covered by this
+standard: keep them as detailed as you like.
+
+## Format
+
+```markdown
+<!-- release: x.y.z -->
+## What's New
+
+- Bullet per user-visible feature
+
+## Improvements
+
+- Bullet per enhancement to something that already existed
+
+## Bug Fixes
+
+- Bullet per user-visible fix
+```
+
+- The first line MUST be `<!-- release: x.y.z -->` with the exact version being
+  cut — `release.sh` greps for it and aborts on mismatch, so a stale file from
+  the previous release fails loudly. The comment is invisible on GitHub and is
+  stripped before the appcast embed.
+- Omit any section that would be empty. A patch release may be Bug Fixes only.
+
+## Writing the bullets
+
+Source material: `git log --oneline --first-parent <prev-tag>..HEAD` and the
+merged PR titles/descriptions since the last release.
+
+- User-facing language: say what changed for the user, not how it was built
+  ("Faster search results", not "Refactored CaskRepository query path").
+- Start each bullet with a verb (Added / Fixed / Improved…), sentence case,
+  no trailing period, one line each.
+- Collapse related minor fixes into one bullet; aim for ≤6 bullets a section.
+- Never include: back-merge PRs ("master to develop"), version-bump/appcast
+  commits ("release: x.y.z"), CI/workflow changes, test-only changes, refactors
+  or dependency bumps with no user-visible effect, PR numbers, commit hashes.
+- If literally everything in the range is internal, write one honest bullet
+  under Improvements ("Under-the-hood stability improvements") rather than
+  padding.
+
+## Example
+
+```markdown
+<!-- release: 0.7.0 -->
+## What's New
+
+- Added import and export for your installed app list
+
+## Improvements
+
+- Faster cask search while typing
+
+## Bug Fixes
+
+- Fixed Homebrew repair getting stuck after relaunch
+- Fixed update badge showing for already-updated casks
+```

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -33,7 +33,7 @@ Each release adds one entry at the top of `CHANGELOG.md`:
 - Bullet per user-visible fix
 ```
 
-- The top `## ` header MUST be the version being cut — `release.sh` aborts on
+- The top `##` header MUST be the version being cut — `release.sh` aborts on
   mismatch, so forgetting to add the new entry fails loudly.
 - Omit any section that would be empty. A patch release may be Bug Fixes only.
 - Never rewrite past entries; only add the new one on top.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,40 +1,42 @@
 ---
 name: release-notes
-description: Use when cutting a CaskHub release, writing or reviewing RELEASE_NOTES.md, or drafting the GitHub release body / Sparkle appcast description
+description: Use when cutting a CaskHub release, adding a CHANGELOG.md entry, or drafting the GitHub release body / Sparkle appcast description
 ---
 
 # CaskHub Release Notes
 
 ## Overview
 
-One file — `RELEASE_NOTES.md` at the repo root — is the single source for both
-the GitHub release body and the Sparkle update dialog. `Scripts/release.sh`
-embeds it into `appcast.xml` (Sparkle renders the markdown) and passes it to
-`gh release create --notes-file`. PR descriptions are NOT covered by this
-standard: keep them as detailed as you like.
+`CHANGELOG.md` at the repo root (Keep a Changelog style: cumulative, newest
+first) is the single source. `Scripts/release.sh` extracts the TOP entry and
+uses it as both the GitHub release body and the Sparkle update dialog notes
+(embedded into `appcast.xml`, rendered as markdown). PR descriptions are NOT
+covered by this standard: keep them as detailed as you like.
 
 ## Format
 
+Each release adds one entry at the top of `CHANGELOG.md`:
+
 ```markdown
-<!-- release: x.y.z -->
-## What's New
+## x.y.z — YYYY-MM-DD
+
+### What's New
 
 - Bullet per user-visible feature
 
-## Improvements
+### Improvements
 
 - Bullet per enhancement to something that already existed
 
-## Bug Fixes
+### Bug Fixes
 
 - Bullet per user-visible fix
 ```
 
-- The first line MUST be `<!-- release: x.y.z -->` with the exact version being
-  cut — `release.sh` greps for it and aborts on mismatch, so a stale file from
-  the previous release fails loudly. The comment is invisible on GitHub and is
-  stripped before the appcast embed.
+- The top `## ` header MUST be the version being cut — `release.sh` aborts on
+  mismatch, so forgetting to add the new entry fails loudly.
 - Omit any section that would be empty. A patch release may be Bug Fixes only.
+- Never rewrite past entries; only add the new one on top.
 
 ## Writing the bullets
 
@@ -53,19 +55,20 @@ merged PR titles/descriptions since the last release.
   under Improvements ("Under-the-hood stability improvements") rather than
   padding.
 
-## Example
+## Example entry
 
 ```markdown
-<!-- release: 0.7.0 -->
-## What's New
+## 0.7.0 — 2026-08-02
+
+### What's New
 
 - Added import and export for your installed app list
 
-## Improvements
+### Improvements
 
 - Faster cask search while typing
 
-## Bug Fixes
+### Bug Fixes
 
 - Fixed Homebrew repair getting stuck after relaunch
 - Fixed update badge showing for already-updated casks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+User-facing changes to CaskHub, newest first. The top entry becomes the GitHub
+release body and the Sparkle update dialog notes (see `.claude/skills/release-notes`).
+Releases before 0.6.4 are on the [releases page](https://github.com/alielsokary/CaskHub/releases).
+
+## 0.6.4 — 2026-07-21
+
+### Bug Fixes
+
+- Fixed Repair stopping before reinstalling when Homebrew failed during cleanup after the app was already removed
+- Fixed Repair uninstalls removing unrelated dependencies

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+<!-- release: 0.6.4 -->
+## Bug Fixes
+
+- Fixed Repair stopping before reinstalling when Homebrew failed during cleanup after the app was already removed
+- Fixed Repair uninstalls removing unrelated dependencies

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,0 @@
-<!-- release: 0.6.4 -->
-## Bug Fixes
-
-- Fixed Repair stopping before reinstalling when Homebrew failed during cleanup after the app was already removed
-- Fixed Repair uninstalls removing unrelated dependencies

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -32,12 +32,13 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
-# Stale-notes guard: the file must be written for THIS version.
-NOTES="$REPO_ROOT/RELEASE_NOTES.md"
-if ! head -1 "$NOTES" 2>/dev/null | grep -qF "<!-- release: $VERSION -->"; then
-    echo "error: RELEASE_NOTES.md first line must be '<!-- release: $VERSION -->' — see .claude/skills/release-notes" >&2
-    exit 1
-fi
+# Stale-notes guard: CHANGELOG.md's top entry must be for THIS version.
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+case "$(grep -m1 '^## ' "$CHANGELOG" 2>/dev/null)" in
+    "## $VERSION"|"## $VERSION "*) ;;
+    *) echo "error: CHANGELOG.md top entry is not $VERSION — add '## $VERSION — $(date +%Y-%m-%d)' (see .claude/skills/release-notes)" >&2
+       exit 1 ;;
+esac
 
 echo "==> Syncing bundled categories"
 Scripts/sync_bundled_categories.sh
@@ -121,8 +122,11 @@ if [[ -z "$GENERATE_APPCAST" ]]; then
 fi
 
 echo "==> Generating appcast"
-# Guard line stripped: Sparkle renders the rest as markdown in the update dialog
-tail -n +2 "$NOTES" > "$WORK/updates/CaskHub-$VERSION.md"
+# Top changelog entry, sans its version header: becomes the Sparkle dialog
+# notes (embedded markdown) and the GitHub release body.
+NOTES="$WORK/release-notes.md"
+awk '/^## /{n++} n==1' "$CHANGELOG" | tail -n +2 > "$NOTES"
+cp "$NOTES" "$WORK/updates/CaskHub-$VERSION.md"
 APPCAST_ARGS=(--download-url-prefix "$DOWNLOAD_URL_PREFIX" --embed-release-notes)
 if [[ -n "${SPARKLE_ED_KEY_FILE:-}" ]]; then
     APPCAST_ARGS+=(--ed-key-file "$SPARKLE_ED_KEY_FILE")

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -32,6 +32,13 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
+# Stale-notes guard: the file must be written for THIS version.
+NOTES="$REPO_ROOT/RELEASE_NOTES.md"
+if ! head -1 "$NOTES" 2>/dev/null | grep -qF "<!-- release: $VERSION -->"; then
+    echo "error: RELEASE_NOTES.md first line must be '<!-- release: $VERSION -->' — see .claude/skills/release-notes" >&2
+    exit 1
+fi
+
 echo "==> Syncing bundled categories"
 Scripts/sync_bundled_categories.sh
 if [[ -n "$(git status --porcelain CaskHub/Resources/categories.json CaskHub/Resources/added_dates.json)" ]]; then
@@ -114,7 +121,9 @@ if [[ -z "$GENERATE_APPCAST" ]]; then
 fi
 
 echo "==> Generating appcast"
-APPCAST_ARGS=(--download-url-prefix "$DOWNLOAD_URL_PREFIX")
+# Guard line stripped: Sparkle renders the rest as markdown in the update dialog
+tail -n +2 "$NOTES" > "$WORK/updates/CaskHub-$VERSION.md"
+APPCAST_ARGS=(--download-url-prefix "$DOWNLOAD_URL_PREFIX" --embed-release-notes)
 if [[ -n "${SPARKLE_ED_KEY_FILE:-}" ]]; then
     APPCAST_ARGS+=(--ed-key-file "$SPARKLE_ED_KEY_FILE")
 fi
@@ -125,7 +134,7 @@ cp "$WORK/updates/appcast.xml" "$REPO_ROOT/appcast.xml"
 # Draft: nothing is public (no release, no tag) until the release PR merges to
 # master and .github/workflows/publish-release.yml flips the draft live.
 echo "==> Creating draft GitHub release $VERSION"
-gh release create "$VERSION" "$ZIP" --title "$VERSION" --generate-notes \
+gh release create "$VERSION" "$ZIP" --title "$VERSION" --notes-file "$NOTES" \
     --draft --target "$(git rev-parse HEAD)"
 
 echo "==> Committing appcast"


### PR DESCRIPTION
## Summary

- Add a release-notes standard (`.claude/skills/release-notes/SKILL.md`): a cumulative root `CHANGELOG.md` ([Keep a Changelog](https://keepachangelog.com) style, newest first) is the single source. Each release adds one top entry in a fixed **What's New / Improvements / Bug Fixes** format with user-facing bullets only — no back-merge PRs, version-bump commits, or internal chores. PR descriptions stay detailed as before.
- `Scripts/release.sh` now:
  - hard-fails unless `CHANGELOG.md`'s top `## ` header is the version being cut, so forgetting the new entry can't ship stale notes
  - extracts the top entry and embeds it into `appcast.xml` via `generate_appcast --embed-release-notes`, so the Sparkle update dialog shows release notes instead of the bare alert
  - uses the same extracted entry as the GitHub release body (`--notes-file`) instead of `--generate-notes`
- Seed `CHANGELOG.md` with the upcoming 0.6.4 entry (Repair recovery fixes from #87); older releases stay on the releases page.

## Validation

- `bash -n Scripts/release.sh` passes
- Guard tested: accepts the exact top version, rejects previous version and prefix collisions (0.6.4 vs 0.6.40)
- Extraction tested against a multi-entry changelog: only the top entry is taken, version header stripped
- Verified end-to-end with Sparkle 2.9.4's `generate_appcast` against the real released zip: notes land in `<description sparkle:format="markdown">` as CDATA; the app's resolved Sparkle (2.9.4) renders markdown natively