### PR TITLE
feat: Detect App Store and package-installed apps

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		D62ACB1AD2BC42A29578C0DD /* AppManagementPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E09E37CC8344C699ACADDB /* AppManagementPermission.swift */; };
 		41DFD4A430028F7D00608C7A /* LocalHomebrewService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47230028F7D00608C7A /* LocalHomebrewService.swift */; };
 		41DFD4A530028F7D00608C7A /* LocalHomebrewService+Brew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47330028F7D00608C7A /* LocalHomebrewService+Brew.swift */; };
+		C15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift */; };
 		A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000001 /* LocalHomebrewTypes.swift */; };
 		A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000002 /* LocalHomebrewService+State.swift */; };
 		A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */; };
@@ -66,6 +67,7 @@
 		41DFD4AF30028F7D00608C7A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD48230028F7D00608C7A /* ContentView.swift */; };
 		41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */; };
 		41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B130028F9F00608C7A /* CaskHubTests.swift */; };
+		C15000000000000000000001 /* ExternalInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15000000000000000000001 /* ExternalInstallationTests.swift */; };
 		41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */; };
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
 		ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */; };
@@ -125,6 +127,7 @@
 		41E09E37CC8344C699ACADDB /* AppManagementPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppManagementPermission.swift; sourceTree = "<group>"; };
 		41DFD47230028F7D00608C7A /* LocalHomebrewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewService.swift; sourceTree = "<group>"; };
 		41DFD47330028F7D00608C7A /* LocalHomebrewService+Brew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Brew.swift"; sourceTree = "<group>"; };
+		D15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+ExternalApps.swift"; sourceTree = "<group>"; };
 		B12000000000000000000001 /* LocalHomebrewTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewTypes.swift; sourceTree = "<group>"; };
 		B12000000000000000000002 /* LocalHomebrewService+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+State.swift"; sourceTree = "<group>"; };
 		B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Adoption.swift"; sourceTree = "<group>"; };
@@ -144,6 +147,7 @@
 		41DFD48430028F7D00608C7A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
 		41DFD4B130028F9F00608C7A /* CaskHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubTests.swift; sourceTree = "<group>"; };
+		D15000000000000000000001 /* ExternalInstallationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalInstallationTests.swift; sourceTree = "<group>"; };
 		41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogViewModelTests.swift; sourceTree = "<group>"; };
 		41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		41EBDCE12F37FD8B00BEABB8 /* CaskHub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaskHub.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -269,6 +273,7 @@
 				41E09E37CC8344C699ACADDB /* AppManagementPermission.swift */,
 				41DFD47230028F7D00608C7A /* LocalHomebrewService.swift */,
 				41DFD47330028F7D00608C7A /* LocalHomebrewService+Brew.swift */,
+				D15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift */,
 				B12000000000000000000001 /* LocalHomebrewTypes.swift */,
 				B12000000000000000000002 /* LocalHomebrewService+State.swift */,
 				B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */,
@@ -348,6 +353,7 @@
 				41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */,
 				41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */,
 				41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */,
+				D15000000000000000000001 /* ExternalInstallationTests.swift */,
 				41DFD4B130028F9F00608C7A /* CaskHubTests.swift */,
 				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
 				ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */,
@@ -549,6 +555,7 @@
 				D62ACB1AD2BC42A29578C0DD /* AppManagementPermission.swift in Sources */,
 				41DFD4A430028F7D00608C7A /* LocalHomebrewService.swift in Sources */,
 				41DFD4A530028F7D00608C7A /* LocalHomebrewService+Brew.swift in Sources */,
+				C15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift in Sources */,
 				A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */,
 				A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */,
 				A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */,
@@ -575,6 +582,7 @@
 				41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */,
 				41AD10162F68B00700BEABB8 /* CrashReporterTests.swift in Sources */,
 				41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */,
+				C15000000000000000000001 /* ExternalInstallationTests.swift in Sources */,
 				41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */,
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,

--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -30,24 +30,36 @@ struct CaskActionsView: View {
     var body: some View {
         if let inFlight = localHomebrew.inFlightActions[cask.token] {
             inFlightCapsule(for: inFlight)
-        } else if let installation = localHomebrew.installedCasks[cask.token] {
-            installedActions(for: installation)
+        } else if localHomebrew.installedCasks[cask.token] != nil {
+            installedActions
         } else if localHomebrew.isAdoptable(cask) {
             HStack(spacing: 8) {
                 if isAdoptPage {
                     ActionCapsuleButton(action: .adopt, fullWidth: fullWidth) {
-                        Task { try? await localHomebrew.adopt(cask) }
+                        if localHomebrew.isExternalPackageInstalled(cask) {
+                            localHomebrew.requestPackageAdoption(token: cask.token)
+                        } else {
+                            Task { try? await localHomebrew.adopt(cask) }
+                        }
                     }
                 } else {
                     ActionCapsuleButton(action: .open, fullWidth: fullWidth) {
                         localHomebrew.openExternalApp(cask: cask)
                     }
                 }
-                disabledUninstallHint
+                DisabledUninstallControl(
+                    message: "Adopt this app first so CaskHub can manage/uninstall it."
+                )
             }
         } else if localHomebrew.isMacAppStoreInstalled(cask) {
-            ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
-                .help("Installed from the Mac App Store. CaskHub won't replace or adopt it.")
+            HStack(spacing: 8) {
+                ActionCapsuleButton(action: .open, fullWidth: fullWidth) {
+                    localHomebrew.openExternalApp(cask: cask)
+                }
+                DisabledUninstallControl(
+                    message: "Installed from the Mac App Store. Uninstall it from Finder or Launchpad."
+                )
+            }
         } else if let externalPath = localHomebrew.externalCLIPath(cask) {
             ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
                 .help(
@@ -61,19 +73,8 @@ struct CaskActionsView: View {
         }
     }
 
-    /// Plain image, not a disabled Button — macOS suppresses tooltips on disabled controls.
-    private var disabledUninstallHint: some View {
-        Image(systemName: "trash")
-            .font(.caption)
-            .foregroundStyle(Color.chTextFaint)
-            .padding(7)
-            .background(Circle().fill(Color.chSurfaceField.opacity(0.5)))
-            .overlay(Circle().strokeBorder(Color.chHairline, lineWidth: 1))
-            .help("Adopt this app first so CaskHub can manage/uninstall it.")
-    }
-
     @ViewBuilder
-    private func installedActions(for installation: LocalCaskInstallation) -> some View {
+    private var installedActions: some View {
         if localHomebrew.isZombie(cask) {
             ActionCapsuleButton(action: .cleanup, fullWidth: fullWidth) {
                 Task { try? await localHomebrew.repair(token: cask.token) }
@@ -83,16 +84,16 @@ struct CaskActionsView: View {
             has records for it. Clean Up removes the leftover data.
             """)
         } else {
-            managedActions(for: installation)
+            managedActions
         }
     }
 
     @ViewBuilder
-    private func managedActions(for installation: LocalCaskInstallation) -> some View {
+    private var managedActions: some View {
         let showUpdate = localHomebrew.hasAvailableUpdate(
             token: cask.token, remoteVersion: cask.version, autoUpdates: cask.autoUpdates
         )
-        let canOpen = !installation.appBundleNames.isEmpty
+        let canOpen = localHomebrew.canOpen(cask)
 
         HStack(spacing: 8) {
             if canOpen {
@@ -159,5 +160,51 @@ struct CaskActionsView: View {
         .padding(.horizontal, 16)
         .background(Capsule().fill(Color.chSurfaceField))
         .overlay(Capsule().strokeBorder(Color.chHairline, lineWidth: 1))
+    }
+}
+
+/// SwiftUI's native `.help` tooltip is dismissed by a click even while the
+/// pointer remains over the view. This hint follows hover state directly, so it
+/// stays visible until the pointer actually leaves the disabled control.
+private struct DisabledUninstallControl: View {
+    let message: String
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Image(systemName: "trash")
+            .font(.caption)
+            .foregroundStyle(Color.chTextFaint)
+            .padding(7)
+            .background(Circle().fill(Color.chSurfaceField.opacity(0.5)))
+            .overlay(Circle().strokeBorder(Color.chHairline, lineWidth: 1))
+            .contentShape(Circle())
+            .onHover { isHovering = $0 }
+            .overlay(alignment: .topTrailing) {
+                if isHovering {
+                    Text(message)
+                        .font(CHType.bodySm)
+                        .foregroundStyle(Color.chTextTitle)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(width: 220, alignment: .leading)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color.chSurfaceToolbar)
+                                .shadow(color: Color.chShadowCard, radius: 8, y: 3)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .strokeBorder(Color.chHairlineStrong, lineWidth: 1)
+                        )
+                        .offset(y: -48)
+                        .allowsHitTesting(false)
+                }
+            }
+            .zIndex(isHovering ? 10 : 0)
+            .accessibilityLabel("Uninstall")
+            .accessibilityHint(message)
     }
 }

--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -11,6 +11,9 @@ struct ArtifactStanza: Codable, Hashable {
     let keys: Set<String>
     let appNames: [String]
     let binaryNames: [String]
+    let packageIdentifiers: [String]
+    let deletedAppNames: [String]
+    let applicationBundleIdentifiers: [String]
 
     /// Raw source paths of `binary` entries (e.g. a path inside the .app bundle).
     /// Needed to verify a bundle actually contains what the cask declares.
@@ -20,12 +23,18 @@ struct ArtifactStanza: Codable, Hashable {
         keys: Set<String>,
         appNames: [String] = [],
         binaryNames: [String] = [],
-        binarySourcePaths: [String] = []
+        binarySourcePaths: [String] = [],
+        packageIdentifiers: [String] = [],
+        deletedAppNames: [String] = [],
+        applicationBundleIdentifiers: [String] = []
     ) {
         self.keys = keys
         self.appNames = appNames
         self.binaryNames = binaryNames
         self.binarySourcePaths = binarySourcePaths
+        self.packageIdentifiers = packageIdentifiers
+        self.deletedAppNames = deletedAppNames
+        self.applicationBundleIdentifiers = applicationBundleIdentifiers
     }
 
     private struct AnyKey: CodingKey {
@@ -61,12 +70,43 @@ struct ArtifactStanza: Codable, Hashable {
         }
     }
 
+    private struct UninstallEntry: Decodable {
+        let packageIdentifiers: [String]
+        let deletedPaths: [String]
+        let applicationBundleIdentifiers: [String]
+
+        init(from decoder: Decoder) throws {
+            guard let container = try? decoder.container(keyedBy: AnyKey.self) else {
+                packageIdentifiers = []
+                deletedPaths = []
+                applicationBundleIdentifiers = []
+                return
+            }
+            packageIdentifiers = Self.strings(in: container, key: "pkgutil")
+            deletedPaths = Self.strings(in: container, key: "delete")
+            applicationBundleIdentifiers = Self.strings(in: container, key: "quit")
+        }
+
+        private static func strings(
+            in container: KeyedDecodingContainer<AnyKey>, key: String
+        ) -> [String] {
+            guard let codingKey = AnyKey(stringValue: key) else { return [] }
+            if let value = try? container.decode(String.self, forKey: codingKey) {
+                return [value]
+            }
+            return (try? container.decode([String].self, forKey: codingKey)) ?? []
+        }
+    }
+
     init(from decoder: Decoder) throws {
         guard let container = try? decoder.container(keyedBy: AnyKey.self) else {
             keys = []
             appNames = []
             binaryNames = []
             binarySourcePaths = []
+            packageIdentifiers = []
+            deletedAppNames = []
+            applicationBundleIdentifiers = []
             return
         }
         keys = Set(container.allKeys.map(\.stringValue))
@@ -76,6 +116,15 @@ struct ArtifactStanza: Codable, Hashable {
             .flatMap { try? container.decode([AppEntry].self, forKey: $0) } ?? [])
             .compactMap(\.name)
             .filter { $0.contains("/") }
+        let uninstallEntries = (AnyKey(stringValue: "uninstall")
+            .flatMap { try? container.decode([UninstallEntry].self, forKey: $0) } ?? [])
+        packageIdentifiers = uninstallEntries.flatMap(\.packageIdentifiers)
+        applicationBundleIdentifiers = uninstallEntries
+            .flatMap(\.applicationBundleIdentifiers)
+        deletedAppNames = uninstallEntries
+            .flatMap(\.deletedPaths)
+            .map { URL(fileURLWithPath: $0).lastPathComponent }
+            .filter { $0.hasSuffix(".app") }
     }
 
     /// Entries can be names or staged paths, with `{"target": …}` rename dicts
@@ -140,6 +189,37 @@ struct Cask: Codable, Identifiable, Hashable {
         artifacts?.flatMap(\.binarySourcePaths) ?? []
     }
 
+    /// Package receipts removed by the cask's uninstall stanza.
+    var packageIdentifiers: [String] {
+        artifacts?.flatMap(\.packageIdentifiers) ?? []
+    }
+
+    /// Bundle IDs Homebrew asks to quit before uninstalling. Unlike pkgutil
+    /// receipts, these identify the application itself and can safely relate
+    /// App Store and direct-download variants of the same product family.
+    var applicationBundleIdentifiers: [String] {
+        artifacts?.flatMap(\.applicationBundleIdentifiers) ?? []
+    }
+
+    /// Application bundles installed indirectly by a package artifact.
+    var deletedAppNames: [String] {
+        artifacts?.flatMap(\.deletedAppNames) ?? []
+    }
+
+    var hasPackageArtifact: Bool {
+        artifacts?.contains { $0.keys.contains("pkg") } == true
+    }
+
+    /// Conservative bundle-name candidates for package casks whose API metadata
+    /// does not expose a normal `app` artifact.
+    var packageAppNameCandidates: [String] {
+        guard hasPackageArtifact else { return [] }
+        var seen: Set<String> = []
+        return (appArtifactNames + deletedAppNames + ["\(displayName).app"]).filter {
+            seen.insert($0).inserted
+        }
+    }
+
     var isCLI: Bool {
         guard let artifacts, !artifacts.isEmpty else { return false }
         return artifacts.contains { !$0.keys.isDisjoint(with: ["binary", "stageOnly", "stage_only"]) }
@@ -168,32 +248,32 @@ struct Cask: Codable, Identifiable, Hashable {
 }
 
 #if DEBUG
-extension Cask {
-    static func preview(
-        token: String,
-        name: String? = nil,
-        desc: String? = nil,
-        version: String = "1.0",
-        deprecated: Bool = false,
-        disabled: Bool = false,
-        autoUpdates: Bool? = nil
-    ) -> Cask {
-        Cask(
-            token: token,
-            fullToken: nil,
-            tap: nil,
-            name: [name ?? token],
-            desc: desc,
-            homepage: "https://example.com",
-            url: nil,
-            version: version,
-            bundleVersion: nil,
-            bundleShortVersion: nil,
-            outdated: false,
-            deprecated: deprecated,
-            disabled: disabled,
-            autoUpdates: autoUpdates
-        )
+    extension Cask {
+        static func preview(
+            token: String,
+            name: String? = nil,
+            desc: String? = nil,
+            version: String = "1.0",
+            deprecated: Bool = false,
+            disabled: Bool = false,
+            autoUpdates: Bool? = nil
+        ) -> Cask {
+            Cask(
+                token: token,
+                fullToken: nil,
+                tap: nil,
+                name: [name ?? token],
+                desc: desc,
+                homepage: "https://example.com",
+                url: nil,
+                version: version,
+                bundleVersion: nil,
+                bundleShortVersion: nil,
+                outdated: false,
+                deprecated: deprecated,
+                disabled: disabled,
+                autoUpdates: autoUpdates
+            )
+        }
     }
-}
 #endif

--- a/CaskHub/Services/LocalHomebrewService+Adoption.swift
+++ b/CaskHub/Services/LocalHomebrewService+Adoption.swift
@@ -8,6 +8,26 @@
 import Foundation
 
 extension LocalHomebrewService {
+    func requestPackageAdoption(token: String) {
+        packageAdoptionRequests.insert(token)
+    }
+
+    func cancelPackageAdoptionRequest(token: String) {
+        packageAdoptionRequests.remove(token)
+    }
+
+    /// Package artifacts do not support Homebrew's `--adopt` semantics. Running
+    /// the package installer again is the supported path that creates Homebrew's
+    /// Caskroom records and transfers future management to Homebrew.
+    func adoptPackage(token: String) async throws {
+        packageAdoptionRequests.remove(token)
+        try await runMutation(
+            .adopting,
+            token: token,
+            args: ["install", "--cask", token]
+        )
+    }
+
     /// Preflight before `--adopt`: a declared binary missing from the on-disk
     /// bundle makes brew fail *after* it has moved the app aside — and brew's
     /// rollback then deletes the app entirely. Refuse locally and offer the

--- a/CaskHub/Services/LocalHomebrewService+Brew.swift
+++ b/CaskHub/Services/LocalHomebrewService+Brew.swift
@@ -277,38 +277,6 @@ extension LocalHomebrewService {
         return paths
     }
 
-    nonisolated static func scanApplications(
-        fileManager: FileManager,
-        directories: [URL]? = nil
-    ) -> ExternalApplicationScan {
-        let folders = directories ?? [
-            URL(fileURLWithPath: "/Applications"),
-            fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Applications")
-        ]
-        var adoptableNames: Set<String> = []
-        var macAppStoreNames: Set<String> = []
-        for folder in folders {
-            guard let entries = try? fileManager.contentsOfDirectory(
-                at: folder,
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            ) else { continue }
-            for entry in entries where entry.pathExtension == "app" {
-                // Mac App Store apps carry a receipt; adopting those would fight MAS updates.
-                let masReceipt = entry.appendingPathComponent("Contents/_MASReceipt/receipt")
-                if fileManager.fileExists(atPath: masReceipt.path) {
-                    macAppStoreNames.insert(entry.lastPathComponent)
-                } else {
-                    adoptableNames.insert(entry.lastPathComponent)
-                }
-            }
-        }
-        return ExternalApplicationScan(
-            adoptableNames: adoptableNames,
-            macAppStoreNames: macAppStoreNames
-        )
-    }
-
     private nonisolated static func modificationDate(of url: URL) -> Date {
         (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
             ?? .distantPast

--- a/CaskHub/Services/LocalHomebrewService+ExternalApps.swift
+++ b/CaskHub/Services/LocalHomebrewService+ExternalApps.swift
@@ -1,0 +1,230 @@
+//
+//  LocalHomebrewService+ExternalApps.swift
+//  CaskHub
+//
+
+import Foundation
+
+extension LocalHomebrewService {
+    nonisolated static func scanApplications(
+        fileManager: FileManager,
+        directories: [URL]? = nil
+    ) -> ExternalApplicationScan {
+        let folders = directories ?? [
+            URL(fileURLWithPath: "/Applications"),
+            fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Applications")
+        ]
+        var applications: [DetectedApplication] = []
+        for folder in folders {
+            guard let enumerator = fileManager.enumerator(
+                at: folder,
+                includingPropertiesForKeys: [.isDirectoryKey, .isPackageKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+            ) else { continue }
+
+            for case let entry as URL in enumerator {
+                guard entry.pathExtension.caseInsensitiveCompare("app") == .orderedSame else {
+                    continue
+                }
+                // Never mistake helper apps embedded inside a top-level app for
+                // independently installed software, even if package metadata is odd.
+                enumerator.skipDescendants()
+                guard let metadata = applicationBundleMetadata(
+                    at: entry, fileManager: fileManager
+                ) else { continue }
+
+                let masReceipt = entry.appendingPathComponent("Contents/_MASReceipt/receipt")
+                applications.append(DetectedApplication(
+                    url: entry.standardizedFileURL,
+                    bundleName: entry.lastPathComponent,
+                    bundleIdentifier: metadata.bundleIdentifier,
+                    isMacAppStore: fileManager.fileExists(atPath: masReceipt.path),
+                    isDirectlyInApplicationDirectory:
+                        entry.deletingLastPathComponent().standardizedFileURL
+                        == folder.standardizedFileURL
+                ))
+            }
+        }
+        return ExternalApplicationScan(applications: applications)
+    }
+
+    /// A directory ending in `.app` is not necessarily launchable. Partial
+    /// installer leftovers can retain that shape after their executable and
+    /// Info.plist are removed, so validate both before exposing Open/Adopt.
+    nonisolated static func applicationBundleMetadata(
+        at appURL: URL,
+        fileManager: FileManager
+    ) -> ApplicationBundleMetadata? {
+        let infoURL = appURL.appendingPathComponent("Contents/Info.plist")
+        guard let data = try? Data(contentsOf: infoURL),
+              let info = try? PropertyListSerialization.propertyList(
+                  from: data, options: [], format: nil
+              ) as? [String: Any],
+              let executable = info["CFBundleExecutable"] as? String,
+              !executable.isEmpty
+        else { return nil }
+
+        let executableURL = appURL.appendingPathComponent("Contents/MacOS/\(executable)")
+        guard fileManager.isExecutableFile(atPath: executableURL.path) else { return nil }
+        return ApplicationBundleMetadata(bundleIdentifier: info["CFBundleIdentifier"] as? String)
+    }
+
+    /// Matches installed package receipts to package-based casks, then confirms
+    /// that at least one application from the package payload still exists.
+    /// Package receipts alone are insufficient because macOS keeps stale receipts
+    /// after an application is manually removed.
+    nonisolated static func scanExternalPackageInstallations(
+        signatures: [PackageCaskSignature],
+        availableAppNames: Set<String>
+    ) -> [String: ExternalPackageInstallation] {
+        guard !signatures.isEmpty,
+              let receiptOutput = pkgutilOutput(arguments: ["--pkgs"])
+        else { return [:] }
+
+        let installedReceipts = Set(receiptOutput.split(whereSeparator: \.isNewline).map(String.init))
+        let relevantReceipts = installedReceipts.filter { receipt in
+            signatures.contains { signature in
+                signature.receiptPatterns.contains { packageIdentifier(receipt, matches: $0) }
+            }
+        }
+        var fileLists: [String: String] = [:]
+        for receipt in relevantReceipts {
+            fileLists[receipt] = pkgutilOutput(arguments: ["--files", receipt])
+        }
+        return resolveExternalPackageInstallations(
+            signatures: signatures,
+            installedReceipts: installedReceipts,
+            packageFileLists: fileLists,
+            availableAppNames: availableAppNames
+        )
+    }
+
+    /// Resolves ambiguous package metadata to one cask per physical app. Some
+    /// casks (notably both Zoom variants) intentionally share the same receipt
+    /// and installed bundle, so showing both would double-count one installation.
+    nonisolated static func resolveExternalPackageInstallations(
+        signatures: [PackageCaskSignature],
+        installedReceipts: Set<String>,
+        packageFileLists: [String: String],
+        availableAppNames: Set<String>
+    ) -> [String: ExternalPackageInstallation] {
+        var candidates: [PackageInstallationCandidate] = []
+
+        for signature in signatures {
+            let matchingReceipts = Set(installedReceipts.filter { receipt in
+                signature.receiptPatterns.contains { packageIdentifier(receipt, matches: $0) }
+            })
+            guard !matchingReceipts.isEmpty else { continue }
+
+            let declaredApps = Set(signature.appNameCandidates).intersection(availableAppNames)
+            let payloadApps = Set(matchingReceipts.flatMap { receipt in
+                packageFileLists[receipt].map(appBundleNames(inPackageFileList:)) ?? []
+            })
+            .intersection(availableAppNames)
+            .filter { packagePayloadAppName($0, matches: signature.appNameCandidates) }
+            let existingApps = declaredApps.union(payloadApps)
+            guard !existingApps.isEmpty else { continue }
+
+            let score = existingApps.map { appName in
+                (declaredApps.contains(appName) ? 1000 : 0)
+                    + packageNameMatchScore(appName, displayName: signature.displayName)
+            }.max() ?? 0
+            candidates.append(PackageInstallationCandidate(
+                signature: signature,
+                receiptIdentifiers: matchingReceipts,
+                appBundleNames: existingApps,
+                score: score
+            ))
+        }
+
+        candidates.sort {
+            if $0.score != $1.score { return $0.score > $1.score }
+            if $0.signature.token.count != $1.signature.token.count {
+                return $0.signature.token.count < $1.signature.token.count
+            }
+            return $0.signature.token < $1.signature.token
+        }
+
+        var claimedApps: Set<String> = []
+        var result: [String: ExternalPackageInstallation] = [:]
+        for candidate in candidates {
+            let unclaimedApps = candidate.appBundleNames.subtracting(claimedApps)
+            guard !unclaimedApps.isEmpty else { continue }
+            result[candidate.signature.token] = ExternalPackageInstallation(
+                receiptIdentifiers: candidate.receiptIdentifiers,
+                appBundleNames: unclaimedApps.sorted()
+            )
+            claimedApps.formUnion(unclaimedApps)
+        }
+        return result
+    }
+
+    nonisolated static func packagePayloadAppName(
+        _ appName: String,
+        matches candidates: [String]
+    ) -> Bool {
+        let actualTokens = appNameTokens(appName)
+        let variantTokens: Set = [
+            "alpha", "beta", "canary", "dev", "developer", "nightly", "preview", "rc"
+        ]
+        return candidates.contains { candidate in
+            let candidateTokens = appNameTokens(candidate)
+            guard actualTokens.intersection(variantTokens)
+                == candidateTokens.intersection(variantTokens)
+            else { return false }
+            return actualTokens.isSubset(of: candidateTokens)
+                || candidateTokens.isSubset(of: actualTokens)
+        }
+    }
+
+    private nonisolated static func packageNameMatchScore(
+        _ appName: String,
+        displayName: String
+    ) -> Int {
+        let actual = appNameTokens(appName)
+        let expected = appNameTokens(displayName)
+        if actual == expected { return 100 }
+        if expected.isSubset(of: actual) { return 80 - (actual.count - expected.count) }
+        if actual.isSubset(of: expected) { return 60 - (expected.count - actual.count) }
+        return actual.intersection(expected).count * 10
+    }
+
+    private nonisolated static func appNameTokens(_ name: String) -> Set<String> {
+        Set(name.lowercased().split { !$0.isLetter && !$0.isNumber }.map(String.init))
+    }
+
+    nonisolated static func packageIdentifier(_ identifier: String, matches pattern: String) -> Bool {
+        guard pattern.contains("*") || pattern.contains("?") else { return identifier == pattern }
+        var expression = NSRegularExpression.escapedPattern(for: pattern)
+        expression = expression
+            .replacingOccurrences(of: "\\*", with: ".*")
+            .replacingOccurrences(of: "\\?", with: ".")
+        guard let regex = try? NSRegularExpression(pattern: "^\(expression)$") else { return false }
+        let range = NSRange(identifier.startIndex..., in: identifier)
+        return regex.firstMatch(in: identifier, range: range) != nil
+    }
+
+    nonisolated static func appBundleNames(inPackageFileList output: String) -> Set<String> {
+        Set(output.split(whereSeparator: \.isNewline).compactMap { line in
+            line.split(separator: "/").first { $0.hasSuffix(".app") }.map(String.init)
+        })
+    }
+
+    private nonisolated static func pkgutilOutput(arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/pkgutil")
+        process.arguments = arguments
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/CaskHub/Services/LocalHomebrewService+State.swift
+++ b/CaskHub/Services/LocalHomebrewService+State.swift
@@ -19,16 +19,46 @@ extension LocalHomebrewService {
         installedCasks[token] != nil
     }
 
-    /// The cask isn't brew-managed, but its app already sits in /Applications.
+    /// The cask is present on this Mac, regardless of which installer owns it.
+    func isPresent(_ cask: Cask) -> Bool {
+        installedCasks[cask.token] != nil
+            || isMacAppStoreInstalled(cask)
+            || isAdoptable(cask)
+            || externalCLIPath(cask) != nil
+    }
+
+    /// The cask isn't brew-managed, but its app already sits in /Applications
+    /// or was installed by a package that Homebrew can reinstall and manage.
     func isAdoptable(_ cask: Cask) -> Bool {
+        isAdoptableApplication(cask) || isExternalPackageInstalled(cask)
+    }
+
+    func isAdoptableApplication(_ cask: Cask) -> Bool {
         installedCasks[cask.token] == nil
             && cask.appArtifactNames.contains(where: externalAppNames.contains)
     }
 
+    func isExternalPackageInstalled(_ cask: Cask) -> Bool {
+        installedCasks[cask.token] == nil
+            && externalPackageInstallations[cask.token] != nil
+    }
+
     /// Mac App Store apps are present, but adopting them would break Store updates.
     func isMacAppStoreInstalled(_ cask: Cask) -> Bool {
-        installedCasks[cask.token] == nil
-            && cask.appArtifactNames.contains(where: macAppStoreAppNames.contains)
+        guard installedCasks[cask.token] == nil else { return false }
+        if macAppStoreApplication(for: cask) != nil { return true }
+
+        // Keep the name-indexed fallback for state injected by previews and tests.
+        let matchingNames = Set(cask.appArtifactNames + cask.packageAppNameCandidates)
+            .intersection(macAppStoreAppNames)
+        guard !matchingNames.isEmpty else { return false }
+
+        guard cask.hasPackageArtifact else { return true }
+        return matchingNames.contains { appName in
+            macAppStoreBundleIdentifiers[appName]?.contains { bundleIdentifier in
+                storeBundleIdentifier(bundleIdentifier, matches: cask)
+            } == true
+        }
     }
 
     /// A CLI cask whose tool is on the device via some other installer
@@ -36,6 +66,15 @@ extension LocalHomebrewService {
     func externalCLIPath(_ cask: Cask) -> URL? {
         guard installedCasks[cask.token] == nil else { return nil }
         return cask.binaryArtifactNames.lazy.compactMap { self.externalBinaryPaths[$0] }.first
+    }
+
+    func installationSource(for cask: Cask) -> CaskInstallationSource? {
+        if installedCasks[cask.token] != nil { return .homebrew }
+        if isMacAppStoreInstalled(cask) { return .macAppStore }
+        if isExternalPackageInstalled(cask) { return .packageInstaller }
+        if isAdoptableApplication(cask) { return .externalApplication }
+        if externalCLIPath(cask) != nil { return .externalExecutable }
+        return nil
     }
 
     func isOutdated(token: String, remoteVersion: String) -> Bool {
@@ -68,8 +107,17 @@ extension LocalHomebrewService {
     /// artifact names — receipts go stale when apps rename themselves.
     func open(_ cask: Cask) {
         actionErrors[cask.token] = nil
-        let receiptNames = installedCasks[cask.token]?.appBundleNames ?? []
-        openBundle(named: receiptNames + cask.appArtifactNames, token: cask.token)
+        openBundle(named: launchableBundleNames(for: cask), token: cask.token)
+    }
+
+    func canOpen(_ cask: Cask) -> Bool {
+        if installedCasks[cask.token] == nil,
+           let application = macAppStoreApplication(for: cask) {
+            return Self.applicationBundleMetadata(
+                at: application.url, fileManager: fileManager
+            ) != nil
+        }
+        return existingBundleURL(named: launchableBundleNames(for: cask)) != nil
     }
 
     func openApp(token: String) {
@@ -85,13 +133,19 @@ extension LocalHomebrewService {
     /// Launches a not-yet-adopted app straight from its on-disk bundle.
     func openExternalApp(cask: Cask) {
         actionErrors[cask.token] = nil
-        openBundle(named: cask.appArtifactNames, token: cask.token)
+        if let application = macAppStoreApplication(for: cask) {
+            appLauncher(application.url)
+            return
+        }
+        openBundle(named: externalBundleNameCandidates(for: cask), token: cask.token)
     }
 
     /// Version of a not-yet-adopted app, read from its bundle's Info.plist.
     func externalAppVersion(for cask: Cask) -> String? {
         guard installedCasks[cask.token] == nil,
-              let appURL = existingBundleURL(named: cask.appArtifactNames),
+              installationSource(for: cask) != nil,
+              let appURL = macAppStoreApplication(for: cask)?.url
+                ?? existingBundleURL(named: externalBundleNameCandidates(for: cask)),
               let info = Bundle(url: appURL)?.infoDictionary
         else { return nil }
         return info["CFBundleShortVersionString"] as? String
@@ -106,10 +160,84 @@ extension LocalHomebrewService {
         appLauncher(appURL)
     }
 
+    private func launchableBundleNames(for cask: Cask) -> [String] {
+        let receiptNames = installedCasks[cask.token]?.appBundleNames ?? []
+        return receiptNames + externalBundleNameCandidates(for: cask)
+    }
+
+    private func externalBundleNameCandidates(for cask: Cask) -> [String] {
+        let packageNames = externalPackageInstallations[cask.token]?.appBundleNames ?? []
+        return packageNames + cask.appArtifactNames + cask.packageAppNameCandidates
+    }
+
+    private func macAppStoreApplication(for cask: Cask) -> DetectedApplication? {
+        let matchingNames = Set(cask.appArtifactNames + cask.packageAppNameCandidates)
+        return detectedApplications.first { application in
+            guard application.isMacAppStore,
+                  matchingNames.contains(application.bundleName)
+            else { return false }
+            guard cask.hasPackageArtifact else { return true }
+            guard let bundleIdentifier = application.bundleIdentifier else { return false }
+            return storeBundleIdentifier(bundleIdentifier, matches: cask)
+        }
+    }
+
+    /// App bundle IDs are stronger identity evidence than installer receipt IDs.
+    /// Direct and App Store variants commonly keep the product prefix and vary
+    /// only their final channel/platform component (macsys versus macos).
+    private func storeBundleIdentifier(_ identifier: String, matches cask: Cask) -> Bool {
+        if !cask.applicationBundleIdentifiers.isEmpty {
+            return Self.applicationBundleIdentifier(
+                identifier, matchesAny: cask.applicationBundleIdentifiers
+            )
+        }
+        return Self.bundleIdentifier(
+            identifier, matchesPackageIdentifiers: cask.packageIdentifiers
+        )
+    }
+
+    nonisolated static func applicationBundleIdentifier(
+        _ identifier: String,
+        matchesAny candidates: [String]
+    ) -> Bool {
+        let actual = identifier.lowercased().split(separator: ".").map(String.init)
+        return candidates.contains { candidate in
+            let expected = candidate.lowercased().split(separator: ".").map(String.init)
+            if actual == expected { return true }
+            return zip(actual, expected).prefix { pair in
+                pair.0 == pair.1
+            }.count >= 3
+        }
+    }
+
+    nonisolated static func bundleIdentifier(
+        _ bundleIdentifier: String,
+        matchesPackageIdentifiers packageIdentifiers: [String]
+    ) -> Bool {
+        guard let bundleVendor = reverseDNSVendorPrefix(bundleIdentifier) else { return false }
+        return packageIdentifiers.contains {
+            reverseDNSVendorPrefix($0) == bundleVendor
+        }
+    }
+
+    private nonisolated static func reverseDNSVendorPrefix(_ identifier: String) -> String? {
+        let components = identifier.lowercased().split(separator: ".")
+        guard components.count >= 2 else { return nil }
+        return components.prefix(2).joined(separator: ".")
+    }
+
     func existingBundleURL(named names: [String]) -> URL? {
-        names.flatMap { name in
+        let nameSet = Set(names)
+        if let detected = detectedApplications.first(where: {
+            nameSet.contains($0.bundleName)
+                && Self.applicationBundleMetadata(at: $0.url, fileManager: fileManager) != nil
+        }) {
+            return detected.url
+        }
+
+        return names.flatMap { name in
             applicationDirectories.map { $0.appendingPathComponent(name) }
         }
-        .first { fileManager.fileExists(atPath: $0.path) }
+        .first { Self.applicationBundleMetadata(at: $0, fileManager: fileManager) != nil }
     }
 }

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -22,8 +22,24 @@ final class LocalHomebrewService {
     /// Mac App Store bundles that must be shown as installed but never adopted.
     var macAppStoreAppNames: Set<String> = []
 
+    /// Bundle identifiers disambiguate Store apps that reuse another product's name.
+    var macAppStoreBundleIdentifiers: [String: Set<String>] = [:]
+
+    /// Valid app bundles found under the application roots, including nested
+    /// bundles such as /Applications/WhatsApp.localized/WhatsApp.app.
+    var detectedApplications: [DetectedApplication] = []
+
     /// Executables found in common install locations (~/.local/bin, /usr/local/bin, …).
     var externalBinaryPaths: [String: URL] = [:]
+
+    /// Package-installed apps matched to cask receipt metadata.
+    var externalPackageInstallations: [String: ExternalPackageInstallation] = [:]
+
+    /// Package adoptions awaiting the user's reinstall confirmation.
+    var packageAdoptionRequests: Set<String> = []
+
+    @ObservationIgnored var packageCaskSignatures: [PackageCaskSignature] = []
+    @ObservationIgnored private var packageCatalogGeneration = 0
 
     var adoptReplaceOffers: Set<String> = []
 
@@ -146,22 +162,74 @@ final class LocalHomebrewService {
             brewVersion = await brewVersionProvider()
         }
         let appDirs = applicationDirectories
-        let (casks, applications, binaryPaths) = await Task.detached(priority: .userInitiated) {
-            (
+        let packageSignatures = packageCaskSignatures
+        let packageGeneration = packageCatalogGeneration
+        let (casks, applications, binaryPaths, packages) = await Task.detached(priority: .userInitiated) {
+            let applications = Self.scanApplications(fileManager: fm, directories: appDirs)
+            return (
                 Self.scanCaskroom(fileManager: fm, applicationDirectories: appDirs),
-                Self.scanApplications(fileManager: fm),
-                Self.scanBinaryDirectories(fileManager: fm)
+                applications,
+                Self.scanBinaryDirectories(fileManager: fm),
+                Self.scanExternalPackageInstallations(
+                    signatures: packageSignatures,
+                    availableAppNames: applications.nonStoreNames
+                )
             )
         }.value
         externalAppNames = applications.adoptableNames
         macAppStoreAppNames = applications.macAppStoreNames
+        macAppStoreBundleIdentifiers = applications.macAppStoreBundleIdentifiers
+        detectedApplications = applications.applications
         externalBinaryPaths = binaryPaths
+        if packageGeneration == packageCatalogGeneration {
+            externalPackageInstallations = packages
+        }
 
         CrashReporter.tag("brew.path", value: Self.locateBrewBinary()?.path ?? "not found")
         CrashReporter.tag("brew.caskroom", value: Self.locateCaskroom(fileManager: fm)?.path ?? "not found")
 
         installedCasks = casks
         lastRefresh = .now
+    }
+
+    /// The catalog provides the package receipt identifiers needed to associate
+    /// system package records with Homebrew casks.
+    func updatePackageCatalog(_ casks: [Cask]) async {
+        packageCaskSignatures = casks.compactMap { cask in
+            guard cask.hasPackageArtifact, !cask.packageIdentifiers.isEmpty else { return nil }
+            return PackageCaskSignature(
+                token: cask.token,
+                displayName: cask.displayName,
+                receiptPatterns: cask.packageIdentifiers,
+                appNameCandidates: cask.packageAppNameCandidates
+            )
+        }
+        packageCatalogGeneration &+= 1
+        let packageGeneration = packageCatalogGeneration
+        guard !packageCaskSignatures.isEmpty else {
+            externalPackageInstallations = [:]
+            return
+        }
+
+        let signatures = packageCaskSignatures
+        let fm = fileManager
+        let appDirs = applicationDirectories
+        let applications = await Task.detached(priority: .userInitiated) {
+            Self.scanApplications(fileManager: fm, directories: appDirs)
+        }.value
+        externalAppNames = applications.adoptableNames
+        macAppStoreAppNames = applications.macAppStoreNames
+        macAppStoreBundleIdentifiers = applications.macAppStoreBundleIdentifiers
+        detectedApplications = applications.applications
+        let packages = await Task.detached(priority: .userInitiated) {
+            Self.scanExternalPackageInstallations(
+                signatures: signatures,
+                availableAppNames: applications.nonStoreNames
+            )
+        }.value
+        if packageGeneration == packageCatalogGeneration {
+            externalPackageInstallations = packages
+        }
     }
 
     // MARK: - Actions
@@ -273,5 +341,4 @@ final class LocalHomebrewService {
             if process.isRunning { process.terminate() }
         }
     }
-
 }

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -7,9 +7,68 @@
 
 import Foundation
 
-nonisolated struct ExternalApplicationScan: Sendable {
-    let adoptableNames: Set<String>
-    let macAppStoreNames: Set<String>
+nonisolated struct ApplicationBundleMetadata {
+    let bundleIdentifier: String?
+}
+
+nonisolated struct DetectedApplication: Hashable, Sendable {
+    let url: URL
+    let bundleName: String
+    let bundleIdentifier: String?
+    let isMacAppStore: Bool
+    let isDirectlyInApplicationDirectory: Bool
+}
+
+nonisolated struct ExternalApplicationScan {
+    let applications: [DetectedApplication]
+
+    var adoptableNames: Set<String> {
+        Set(applications.lazy.filter {
+            !$0.isMacAppStore && $0.isDirectlyInApplicationDirectory
+        }.map(\.bundleName))
+    }
+
+    var nonStoreNames: Set<String> {
+        Set(applications.lazy.filter { !$0.isMacAppStore }.map(\.bundleName))
+    }
+
+    var macAppStoreNames: Set<String> {
+        Set(applications.lazy.filter(\.isMacAppStore).map(\.bundleName))
+    }
+
+    var macAppStoreBundleIdentifiers: [String: Set<String>] {
+        applications.lazy.filter(\.isMacAppStore).reduce(into: [:]) { result, application in
+            guard let bundleIdentifier = application.bundleIdentifier else { return }
+            result[application.bundleName, default: []].insert(bundleIdentifier)
+        }
+    }
+}
+
+nonisolated struct PackageCaskSignature {
+    let token: String
+    let displayName: String
+    let receiptPatterns: [String]
+    let appNameCandidates: [String]
+}
+
+nonisolated struct PackageInstallationCandidate {
+    let signature: PackageCaskSignature
+    let receiptIdentifiers: Set<String>
+    let appBundleNames: Set<String>
+    let score: Int
+}
+
+struct ExternalPackageInstallation: Hashable {
+    let receiptIdentifiers: Set<String>
+    let appBundleNames: [String]
+}
+
+enum CaskInstallationSource: String, Equatable {
+    case homebrew = "Homebrew"
+    case macAppStore = "Mac App Store"
+    case externalApplication = "External application"
+    case packageInstaller = "Package installer"
+    case externalExecutable = "External executable"
 }
 
 struct LocalCaskInstallation: Hashable, Identifiable {

--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -99,6 +99,14 @@ final class CaskCatalogViewModel {
         updatableCasks.count
     }
 
+    var installedCasks: [Cask] {
+        casks.filter { [localHomebrew] in localHomebrew.isPresent($0) }
+    }
+
+    var installedCount: Int {
+        installedCasks.count
+    }
+
     var adoptableCasks: [Cask] {
         casks.filter { [localHomebrew] in localHomebrew.isAdoptable($0) }
     }
@@ -168,7 +176,7 @@ final class CaskCatalogViewModel {
             return casks.filter { recentTokens.contains($0.token) }
 
         case .library(.installed):
-            return casks.filter { localHomebrew.isInstalled(token: $0.token) }
+            return installedCasks
 
         case .library(.updates):
             return updatableCasks
@@ -233,6 +241,7 @@ final class CaskCatalogViewModel {
                     && !cask.token.contains("@")
                     && !cask.token.hasPrefix("font-")
             }
+            await localHomebrew.updatePackageCatalog(casks)
 
             if let analytics = try? await analyticsRequest {
                 analyticsByPeriod[.days365] = Self.countsByToken(from: analytics)

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -33,7 +33,7 @@ struct ContentView: View {
                 selection: $selectedSidebar,
                 categoryService: categoryService,
                 updatesCount: viewModel.updatesCount,
-                installedCount: localHomebrew.installedCasks.count,
+                installedCount: viewModel.installedCount,
                 adoptableCount: viewModel.adoptableCasks.count,
                 categoryCounts: viewModel.categoryCounts
             )

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -17,6 +17,9 @@ private struct CaskActionAlerts: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .caskPackageAdoptionAlert(
+                cask: cask, service: localHomebrew, isPresented: hasPackageAdoptionRequest
+            )
             .caskPermissionAlert(
                 cask: cask, service: localHomebrew, isPresented: $showPermissionRequest
             )
@@ -40,6 +43,15 @@ private struct CaskActionAlerts: ViewModifier {
         )
     }
 
+    private var hasPackageAdoptionRequest: Binding<Bool> {
+        Binding(
+            get: { localHomebrew.packageAdoptionRequests.contains(cask.token) },
+            set: {
+                if !$0 { localHomebrew.cancelPackageAdoptionRequest(token: cask.token) }
+            }
+        )
+    }
+
     private var hasActionError: Binding<Bool> {
         Binding(
             get: { localHomebrew.actionErrors[cask.token] != nil && !brewIsMissing },
@@ -49,6 +61,28 @@ private struct CaskActionAlerts: ViewModifier {
 }
 
 private extension View {
+    func caskPackageAdoptionAlert(
+        cask: Cask,
+        service: LocalHomebrewService,
+        isPresented: Binding<Bool>
+    ) -> some View {
+        alert("Adopt \(cask.displayName)?", isPresented: isPresented) {
+            Button("Cancel", role: .cancel) {
+                service.cancelPackageAdoptionRequest(token: cask.token)
+            }
+            Button("Adopt") {
+                Task { try? await service.adoptPackage(token: cask.token) }
+            }
+        } message: {
+            Text("""
+            \(cask.displayName) was installed using a package outside Homebrew. \
+            Adopting it will download and run Homebrew's package installer again, \
+            which may replace the existing application. After it finishes, \
+            Homebrew will manage the installation.
+            """)
+        }
+    }
+
     func caskPermissionAlert(
         cask: Cask,
         service: LocalHomebrewService,

--- a/CaskHub/Views/Shared/CaskInfoPopover.swift
+++ b/CaskHub/Views/Shared/CaskInfoPopover.swift
@@ -92,16 +92,22 @@ struct CaskInfoPopover: View {
         }
 
         let localInstallation = localHomebrew.installedCasks[cask.token]
+        let installationSource = localHomebrew.installationSource(for: cask)
 
         let installedValue: String
         if let version = localInstallation?.installedVersion {
             installedValue = version
         } else if let external = localHomebrew.externalAppVersion(for: cask) {
-            installedValue = "\(external) (not adopted)"
+            installedValue = external
+        } else if installationSource != nil {
+            installedValue = "Installed"
         } else {
             installedValue = "Not installed"
         }
         result.append(InfoRow(property: "Installed Version", value: installedValue))
+        if let installationSource {
+            result.append(InfoRow(property: "Installed Via", value: installationSource.rawValue))
+        }
 
         if let bundleVersion = cask.bundleVersion {
             result.append(InfoRow(property: "Bundle Version", value: bundleVersion))

--- a/CaskHubTests/AdoptionTests.swift
+++ b/CaskHubTests/AdoptionTests.swift
@@ -10,8 +10,13 @@ import SwiftUI
 import XCTest
 
 final class NoFilesFileManager: FileManager {
-    override func fileExists(atPath _: String) -> Bool { false }
-    override func fileExists(atPath _: String, isDirectory _: UnsafeMutablePointer<ObjCBool>?) -> Bool { false }
+    override func fileExists(atPath _: String) -> Bool {
+        false
+    }
+
+    override func fileExists(atPath _: String, isDirectory _: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+        false
+    }
 }
 
 @MainActor
@@ -146,6 +151,21 @@ final class AdoptionSurfaceTests: XCTestCase {
     }
 
     @MainActor
+    func test_package_adoption_confirms_then_reinstalls_without_adopt_flag() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(runner: runner)
+
+        service.requestPackageAdoption(token: "zoom")
+        XCTAssertTrue(service.packageAdoptionRequests.contains("zoom"))
+
+        try await service.adoptPackage(token: "zoom")
+
+        XCTAssertEqual(runner.requests.map(\.arguments), [["install", "--cask", "zoom"]])
+        XCTAssertFalse(service.packageAdoptionRequests.contains("zoom"))
+        XCTAssertNil(service.inFlightActions["zoom"])
+    }
+
+    @MainActor
     func test_repair_reinstall_runs_fetch_uninstall_and_install_through_runner() async throws {
         let runner = StubBrewProcessRunner()
         let service = makeMutationService(runner: runner)
@@ -246,8 +266,10 @@ final class AdoptionSurfaceTests: XCTestCase {
     func test_adopt_refuses_when_bundle_lacks_declared_binary() async throws {
         let appsDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("adopt-preflight-\(UUID().uuidString)")
-        let macOSDir = appsDir.appendingPathComponent("Fake.app/Contents/MacOS")
-        try FileManager.default.createDirectory(at: macOSDir, withIntermediateDirectories: true)
+        let app = try makeApplicationBundle(
+            in: appsDir, named: "Fake.app", bundleIdentifier: "com.example.fake"
+        )
+        let macOSDir = app.appendingPathComponent("Contents/MacOS")
         defer { try? FileManager.default.removeItem(at: appsDir) }
 
         let service = LocalHomebrewService(
@@ -302,6 +324,7 @@ final class AdoptionSurfaceTests: XCTestCase {
         XCTAssertEqual(decoded[0].keys, ["app", "zap"])
     }
 }
+
 // MARK: - View render smoke tests
 
 final class AdoptionViewRenderTests: XCTestCase {
@@ -316,6 +339,7 @@ final class AdoptionViewRenderTests: XCTestCase {
     func test_cask_actions_render_every_external_state() {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("render-actions"))
         service.externalAppNames = ["Chrome.app"]
+        service.macAppStoreAppNames = ["Store.app"]
         service.externalBinaryPaths = ["claude": URL(fileURLWithPath: "/usr/local/bin/claude")]
         service.installedCasks["managed"] = LocalCaskInstallation(
             token: "managed", installedVersion: "1.0", installedAt: nil, appBundleNames: ["Managed.app"]
@@ -324,6 +348,7 @@ final class AdoptionViewRenderTests: XCTestCase {
         let adoptable = makeCask("chrome", appNames: ["Chrome.app"])
         render(CaskActionsView(cask: adoptable).environment(service).environment(\.isAdoptPage, true))
         render(CaskActionsView(cask: adoptable).environment(service))
+        render(CaskActionsView(cask: makeCask("store", appNames: ["Store.app"])).environment(service))
         render(CaskActionsView(cask: makeCask("claude-code", binaryNames: ["claude"])).environment(service))
         render(CaskActionsView(cask: makeCask("plain")).environment(service))
         render(

--- a/CaskHubTests/CaskHubTests.swift
+++ b/CaskHubTests/CaskHubTests.swift
@@ -87,37 +87,6 @@ final class CaskHubTests: XCTestCase {
         XCTAssertFalse(service.isAdoptable(cli))
     }
 
-    @MainActor
-    func test_mac_app_store_app_is_installed_but_not_adoptable() {
-        let service = LocalHomebrewService()
-        service.macAppStoreAppNames = ["Canva.app"]
-        let canva = makeCask("canva", appNames: ["Canva.app"])
-
-        XCTAssertTrue(service.isMacAppStoreInstalled(canva))
-        XCTAssertFalse(service.isAdoptable(canva))
-    }
-
-    func test_application_scan_separates_mac_app_store_bundles() throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("application-scan-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        let directApp = root.appendingPathComponent("Direct.app")
-        let storeReceipt = root.appendingPathComponent("Store.app/Contents/_MASReceipt/receipt")
-        try FileManager.default.createDirectory(at: directApp, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(
-            at: storeReceipt.deletingLastPathComponent(), withIntermediateDirectories: true
-        )
-        FileManager.default.createFile(atPath: storeReceipt.path, contents: Data())
-
-        let scan = LocalHomebrewService.scanApplications(
-            fileManager: FileManager.default,
-            directories: [root]
-        )
-        XCTAssertEqual(scan.adoptableNames, ["Direct.app"])
-        XCTAssertEqual(scan.macAppStoreNames, ["Store.app"])
-    }
-
     func test_artifact_stanza_decodes_binary_names_from_paths() throws {
         let json = """
         [{"binary": ["claude"], "target": "/opt/homebrew/bin/claude"},
@@ -169,7 +138,7 @@ final class CaskHubTests: XCTestCase {
 
     func test_apple_silicon_detection_matches_native_build_arch() {
         #if arch(arm64)
-        XCTAssertTrue(LocalHomebrewService.isAppleSilicon)
+            XCTAssertTrue(LocalHomebrewService.isAppleSilicon)
         #endif
         // An x86_64 build can run on either machine (Rosetta), so no assertion there.
     }

--- a/CaskHubTests/ExternalInstallationTests.swift
+++ b/CaskHubTests/ExternalInstallationTests.swift
@@ -1,0 +1,376 @@
+//
+//  ExternalInstallationTests.swift
+//  CaskHubTests
+//
+
+@testable import CaskHub
+import XCTest
+
+final class ExternalInstallationTests: XCTestCase {
+    @MainActor
+    func test_mac_app_store_app_is_installed_but_not_adoptable() {
+        let service = LocalHomebrewService()
+        service.macAppStoreAppNames = ["Canva.app"]
+        let canva = makeCask("canva", appNames: ["Canva.app"])
+
+        XCTAssertTrue(service.isMacAppStoreInstalled(canva))
+        XCTAssertTrue(service.isPresent(canva))
+        XCTAssertEqual(service.installationSource(for: canva), .macAppStore)
+        XCTAssertFalse(service.isAdoptable(canva))
+    }
+
+    @MainActor
+    func test_package_cask_matches_store_app_by_exact_display_name_but_is_not_adoptable() {
+        let service = LocalHomebrewService()
+        service.macAppStoreAppNames = ["Microsoft Outlook.app"]
+        service.macAppStoreBundleIdentifiers = [
+            "Microsoft Outlook.app": ["com.microsoft.Outlook"]
+        ]
+        let outlook = makeCask(
+            "microsoft-outlook",
+            name: "Microsoft Outlook",
+            packageIdentifiers: ["com.microsoft.package.Microsoft_Outlook.app"]
+        )
+
+        XCTAssertTrue(service.isMacAppStoreInstalled(outlook))
+        XCTAssertTrue(service.isPresent(outlook))
+        XCTAssertFalse(service.isAdoptable(outlook))
+    }
+
+    @MainActor
+    func test_external_package_app_is_present_launchable_and_adoptable() throws {
+        let apps = FileManager.default.temporaryDirectory
+            .appendingPathComponent("external-package-\(UUID().uuidString)")
+        let app = try makeApplicationBundle(
+            in: apps, named: "zoom.us.app", bundleIdentifier: "us.zoom.xos"
+        )
+        defer { try? FileManager.default.removeItem(at: apps) }
+
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("external-package"),
+            applicationDirectories: [apps]
+        )
+        service.externalPackageInstallations["zoom"] = ExternalPackageInstallation(
+            receiptIdentifiers: ["us.zoom.pkg.videomeeting"],
+            appBundleNames: ["zoom.us.app"]
+        )
+        var openedURL: URL?
+        service.appLauncher = { openedURL = $0 }
+        let zoom = makeCask(
+            "zoom",
+            name: "Zoom",
+            packageIdentifiers: ["us.zoom.pkg.videomeeting"],
+            packageAppNames: ["zoom.us.app"]
+        )
+
+        XCTAssertTrue(service.isPresent(zoom))
+        XCTAssertTrue(service.isAdoptable(zoom))
+        XCTAssertTrue(service.canOpen(zoom))
+        XCTAssertEqual(service.installationSource(for: zoom), .packageInstaller)
+
+        service.openExternalApp(cask: zoom)
+        XCTAssertEqual(openedURL?.standardizedFileURL.path, app.standardizedFileURL.path)
+    }
+
+    func test_application_scan_separates_mac_app_store_bundles() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("application-scan-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try makeApplicationBundle(
+            in: root, named: "Direct.app", bundleIdentifier: "com.example.direct"
+        )
+        try makeApplicationBundle(
+            in: root,
+            named: "Store.app",
+            bundleIdentifier: "com.example.store",
+            macAppStoreReceipt: true
+        )
+
+        let scan = LocalHomebrewService.scanApplications(
+            fileManager: FileManager.default,
+            directories: [root]
+        )
+        XCTAssertEqual(scan.adoptableNames, ["Direct.app"])
+        XCTAssertEqual(scan.macAppStoreNames, ["Store.app"])
+        XCTAssertEqual(scan.macAppStoreBundleIdentifiers, [
+            "Store.app": ["com.example.store"]
+        ])
+    }
+
+    func test_application_scan_finds_store_app_inside_localized_wrapper() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("localized-application-scan-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let wrapper = root.appendingPathComponent("WhatsApp.localized")
+        let whatsapp = try makeApplicationBundle(
+            in: wrapper,
+            named: "WhatsApp.app",
+            bundleIdentifier: "net.whatsapp.WhatsApp",
+            macAppStoreReceipt: true
+        )
+
+        let scan = LocalHomebrewService.scanApplications(
+            fileManager: .default, directories: [root]
+        )
+
+        XCTAssertEqual(scan.macAppStoreNames, ["WhatsApp.app"])
+        XCTAssertEqual(scan.applications.map(\.url), [whatsapp.standardizedFileURL])
+    }
+
+    @MainActor
+    func test_nested_store_app_is_present_and_opens_using_its_real_url() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("localized-store-open-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let whatsapp = try makeApplicationBundle(
+            in: root.appendingPathComponent("WhatsApp.localized"),
+            named: "WhatsApp.app",
+            bundleIdentifier: "net.whatsapp.WhatsApp",
+            macAppStoreReceipt: true
+        )
+        let scan = LocalHomebrewService.scanApplications(
+            fileManager: .default, directories: [root]
+        )
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("localized-store-open"),
+            applicationDirectories: [root]
+        )
+        service.detectedApplications = scan.applications
+        service.macAppStoreAppNames = scan.macAppStoreNames
+        service.macAppStoreBundleIdentifiers = scan.macAppStoreBundleIdentifiers
+        var openedURL: URL?
+        service.appLauncher = { openedURL = $0 }
+        let cask = makeCask("whatsapp", name: "WhatsApp", appNames: ["WhatsApp.app"])
+
+        XCTAssertTrue(service.isMacAppStoreInstalled(cask))
+        XCTAssertTrue(service.isPresent(cask))
+        XCTAssertTrue(service.canOpen(cask))
+        XCTAssertFalse(service.isAdoptable(cask))
+
+        service.openExternalApp(cask: cask)
+        XCTAssertEqual(openedURL?.standardizedFileURL, whatsapp.standardizedFileURL)
+    }
+
+    func test_package_metadata_decodes_receipts_and_deleted_apps() throws {
+        let json = Data("""
+        [{"uninstall": [{
+          "pkgutil": ["com.microsoft.teams2", "com.microsoft.audio"],
+          "delete": ["/Applications/Microsoft Teams.app", "/Library/Logs/Teams"],
+          "quit": "com.microsoft.teams2"
+        }]}, {"pkg": ["MicrosoftTeams.pkg"]}]
+        """.utf8)
+        let stanzas = try JSONDecoder().decode([ArtifactStanza].self, from: json)
+
+        XCTAssertEqual(
+            stanzas[0].packageIdentifiers,
+            ["com.microsoft.teams2", "com.microsoft.audio"]
+        )
+        XCTAssertEqual(stanzas[0].deletedAppNames, ["Microsoft Teams.app"])
+        XCTAssertEqual(stanzas[0].applicationBundleIdentifiers, ["com.microsoft.teams2"])
+        XCTAssertTrue(stanzas[1].keys.contains("pkg"))
+    }
+
+    func test_package_receipt_patterns_and_payload_app_names() {
+        XCTAssertTrue(LocalHomebrewService.packageIdentifier(
+            "org.virtualbox.pkg.virtualbox", matches: "org.virtualbox.pkg.*"
+        ))
+        XCTAssertFalse(LocalHomebrewService.packageIdentifier(
+            "org.virtualbox.extension", matches: "org.virtualbox.pkg.*"
+        ))
+        XCTAssertEqual(
+            LocalHomebrewService.appBundleNames(inPackageFileList: """
+            Applications/VirtualBox.app
+            Applications/VirtualBox.app/Contents/MacOS/VirtualBox
+            Library/Extensions/VBoxDrv.kext
+            """),
+            ["VirtualBox.app"]
+        )
+    }
+
+    @MainActor
+    func test_installed_includes_store_and_package_apps_while_adopt_only_includes_package() async {
+        let local = LocalHomebrewService(defaults: makeScratchDefaults("external-installed"))
+        let store = makeCask("store-app", name: "Store App", appNames: ["Store App.app"])
+        let package = makeCask(
+            "package-app",
+            name: "Package App",
+            packageIdentifiers: ["com.example.package"],
+            packageAppNames: ["Package App.app"]
+        )
+        let (vm, _) = await makeSUT(casks: [store, package], localHomebrew: local)
+        local.macAppStoreAppNames = ["Store App.app"]
+        local.externalPackageInstallations[package.token] = ExternalPackageInstallation(
+            receiptIdentifiers: ["com.example.package"],
+            appBundleNames: ["Package App.app"]
+        )
+
+        vm.selectedSidebar = .library(.installed)
+        XCTAssertEqual(Set(vm.filteredCasks.map(\.token)), [store.token, package.token])
+        XCTAssertEqual(vm.installedCount, 2)
+
+        vm.selectedSidebar = .library(.adopt)
+        XCTAssertEqual(vm.filteredCasks.map(\.token), [package.token])
+    }
+
+    func test_partial_sf_symbols_bundle_is_not_launchable_or_scanned() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("partial-sf-symbols-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let stable = root.appendingPathComponent("SF Symbols.app")
+        try FileManager.default.createDirectory(
+            at: stable.appendingPathComponent("Contents/Resources"),
+            withIntermediateDirectories: true
+        )
+        try makeApplicationBundle(
+            in: root,
+            named: "SF Symbols Beta.app",
+            bundleIdentifier: "com.apple.SFSymbols-beta"
+        )
+
+        let scan = LocalHomebrewService.scanApplications(
+            fileManager: .default, directories: [root]
+        )
+        XCTAssertEqual(scan.adoptableNames, ["SF Symbols Beta.app"])
+        XCTAssertNil(LocalHomebrewService.applicationBundleMetadata(
+            at: stable, fileManager: .default
+        ))
+    }
+
+    @MainActor
+    func test_partial_sf_symbols_bundle_cannot_be_opened() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("unlaunchable-sf-symbols-\(UUID().uuidString)")
+        let stable = root.appendingPathComponent("SF Symbols.app")
+        try FileManager.default.createDirectory(at: stable, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("unlaunchable-sf-symbols"),
+            applicationDirectories: [root]
+        )
+        let cask = makeCask(
+            "sf-symbols",
+            name: "SF Symbols",
+            packageIdentifiers: ["com.apple.pkg.SFSymbols"],
+            packageAppNames: ["SF Symbols.app"]
+        )
+        service.installedCasks[cask.token] = LocalCaskInstallation(
+            token: cask.token,
+            installedVersion: "8.0",
+            installedAt: nil,
+            appBundleNames: []
+        )
+
+        XCTAssertFalse(service.canOpen(cask))
+        XCTAssertFalse(service.isZombie(cask))
+    }
+
+    func test_stable_sf_symbols_cask_does_not_claim_beta_payload() {
+        let signature = PackageCaskSignature(
+            token: "sf-symbols",
+            displayName: "SF Symbols",
+            receiptPatterns: ["com.apple.pkg.SFSymbols"],
+            appNameCandidates: ["SF Symbols.app"]
+        )
+
+        let result = LocalHomebrewService.resolveExternalPackageInstallations(
+            signatures: [signature],
+            installedReceipts: ["com.apple.pkg.SFSymbols"],
+            packageFileLists: [
+                "com.apple.pkg.SFSymbols": "Applications/SF Symbols Beta.app"
+            ],
+            availableAppNames: ["SF Symbols Beta.app"]
+        )
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_shared_zoom_receipt_resolves_to_one_canonical_cask() {
+        let receipt = "us.zoom.pkg.videomeeting"
+        let signatures = [
+            PackageCaskSignature(
+                token: "zoom",
+                displayName: "Zoom",
+                receiptPatterns: [receipt],
+                appNameCandidates: ["Zoom.app", "zoom.us.app"]
+            ),
+            PackageCaskSignature(
+                token: "zoom-for-it-admins",
+                displayName: "Zoom for IT Admins",
+                receiptPatterns: [receipt],
+                appNameCandidates: ["Zoom for IT Admins.app", "zoom.us.app"]
+            )
+        ]
+
+        let result = LocalHomebrewService.resolveExternalPackageInstallations(
+            signatures: signatures,
+            installedReceipts: [receipt],
+            packageFileLists: [:],
+            availableAppNames: ["zoom.us.app"]
+        )
+
+        XCTAssertEqual(Set(result.keys), ["zoom"])
+        XCTAssertEqual(result["zoom"]?.appBundleNames, ["zoom.us.app"])
+    }
+
+    @MainActor
+    func test_store_app_with_same_name_but_different_vendor_is_not_the_cask() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("store-shade"))
+        service.macAppStoreAppNames = ["Shade.app"]
+        service.macAppStoreBundleIdentifiers = [
+            "Shade.app": ["com.limit-point.Shade"]
+        ]
+        let shade = makeCask(
+            "shade",
+            name: "Shade",
+            packageIdentifiers: ["com.shade.shade"]
+        )
+
+        XCTAssertFalse(service.isMacAppStoreInstalled(shade))
+        XCTAssertFalse(service.isPresent(shade))
+    }
+
+    @MainActor
+    func test_store_tailscale_matches_package_cask_by_application_bundle_family() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("store-tailscale-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let tailscaleApp = try makeApplicationBundle(
+            in: root,
+            named: "Tailscale.app",
+            bundleIdentifier: "io.tailscale.ipn.macos",
+            macAppStoreReceipt: true
+        )
+        let scan = LocalHomebrewService.scanApplications(
+            fileManager: .default, directories: [root]
+        )
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("store-tailscale"),
+            applicationDirectories: [root]
+        )
+        service.detectedApplications = scan.applications
+        service.macAppStoreAppNames = scan.macAppStoreNames
+        service.macAppStoreBundleIdentifiers = scan.macAppStoreBundleIdentifiers
+        var openedURL: URL?
+        service.appLauncher = { openedURL = $0 }
+        let tailscale = makeCask(
+            "tailscale-app",
+            name: "Tailscale",
+            packageIdentifiers: ["com.tailscale.ipn.macsys"],
+            applicationBundleIdentifiers: ["io.tailscale.ipn.macsys"]
+        )
+
+        XCTAssertTrue(service.isMacAppStoreInstalled(tailscale))
+        XCTAssertTrue(service.isPresent(tailscale))
+        XCTAssertFalse(service.isAdoptable(tailscale))
+        XCTAssertTrue(service.canOpen(tailscale))
+
+        service.openExternalApp(cask: tailscale)
+        XCTAssertEqual(openedURL?.standardizedFileURL, tailscaleApp.standardizedFileURL)
+    }
+}

--- a/CaskHubTests/SharedTestHelpers.swift
+++ b/CaskHubTests/SharedTestHelpers.swift
@@ -53,7 +53,10 @@ func makeCask(
     lifecycle: TestCaskLifecycle = .current,
     appNames: [String]? = nil,
     binaryNames: [String]? = nil,
-    binarySourcePaths: [String]? = nil
+    binarySourcePaths: [String]? = nil,
+    packageIdentifiers: [String]? = nil,
+    packageAppNames: [String]? = nil,
+    applicationBundleIdentifiers: [String]? = nil
 ) -> Cask {
     var cask = Cask.preview(
         token: token,
@@ -71,6 +74,15 @@ func makeCask(
             keys: ["binary"],
             binaryNames: binaryNames ?? [],
             binarySourcePaths: binarySourcePaths ?? []
+        ))
+    }
+    if packageIdentifiers != nil || packageAppNames != nil
+        || applicationBundleIdentifiers != nil {
+        artifacts.append(ArtifactStanza(
+            keys: ["pkg", "uninstall"],
+            packageIdentifiers: packageIdentifiers ?? [],
+            deletedAppNames: packageAppNames ?? [],
+            applicationBundleIdentifiers: applicationBundleIdentifiers ?? []
         ))
     }
     cask.artifacts = artifacts.isEmpty ? nil : artifacts
@@ -99,6 +111,44 @@ func installation(_ token: String, version: String) -> LocalCaskInstallation {
 func dateString(daysAgo: Int) -> String {
     let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: .now)!
     return date.formatted(.iso8601.year().month().day())
+}
+
+@discardableResult
+func makeApplicationBundle(
+    in directory: URL,
+    named name: String,
+    bundleIdentifier: String,
+    macAppStoreReceipt: Bool = false
+) throws -> URL {
+    let fileManager = FileManager.default
+    let appURL = directory.appendingPathComponent(name)
+    let executableName = URL(fileURLWithPath: name).deletingPathExtension().lastPathComponent
+    let contentsURL = appURL.appendingPathComponent("Contents")
+    let executableURL = contentsURL.appendingPathComponent("MacOS/\(executableName)")
+    try fileManager.createDirectory(
+        at: executableURL.deletingLastPathComponent(), withIntermediateDirectories: true
+    )
+    let info: [String: Any] = [
+        "CFBundleIdentifier": bundleIdentifier,
+        "CFBundleExecutable": executableName,
+        "CFBundleName": executableName,
+        "CFBundlePackageType": "APPL"
+    ]
+    let infoData = try PropertyListSerialization.data(
+        fromPropertyList: info, format: .xml, options: 0
+    )
+    try infoData.write(to: contentsURL.appendingPathComponent("Info.plist"))
+    try Data("#!/bin/sh\nexit 0\n".utf8).write(to: executableURL)
+    try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executableURL.path)
+
+    if macAppStoreReceipt {
+        let receiptURL = contentsURL.appendingPathComponent("_MASReceipt/receipt")
+        try fileManager.createDirectory(
+            at: receiptURL.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try Data().write(to: receiptURL)
+    }
+    return appURL
 }
 
 @MainActor
@@ -169,7 +219,10 @@ func seededCategories(_ tokenToCategory: [String: TokenCategoryMapping],
 final class SpyCrashSpan: CrashSpan {
     var finished = false
     var finishedError: Error?
-    func finish() { finished = true }
+    func finish() {
+        finished = true
+    }
+
     func finish(error: Error) {
         finished = true
         finishedError = error
@@ -190,13 +243,26 @@ final class SpyCrashReporterProvider: CrashReporterProvider {
     var tags: [String: String] = [:]
     var spans: [SpanRecord] = []
 
-    func start(enabled: Bool) { startedWith.append(enabled) }
-    func setEnabled(_ enabled: Bool) { enabledChanges.append(enabled) }
-    func capture(_ error: Error) { capturedErrors.append(error) }
-    func setTag(_ key: String, value: String) { tags[key] = value }
+    func start(enabled: Bool) {
+        startedWith.append(enabled)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        enabledChanges.append(enabled)
+    }
+
+    func capture(_ error: Error) {
+        capturedErrors.append(error)
+    }
+
+    func setTag(_ key: String, value: String) {
+        tags[key] = value
+    }
+
     func addBreadcrumb(_ message: String, data: [String: String]) {
         breadcrumbs.append((message, data))
     }
+
     func startSpan(name: String, operation: String) -> CrashSpan {
         let span = SpyCrashSpan()
         spans.append(SpanRecord(name: name, operation: operation, span: span))

--- a/CaskHubTests/ZombieDetectionTests.swift
+++ b/CaskHubTests/ZombieDetectionTests.swift
@@ -188,8 +188,8 @@ final class ZombieDetectionTests: XCTestCase {
     /// current artifact ChatGPT.app is alive on disk. Never offer deletion then.
     @MainActor
     func test_zombie_verdict_clears_when_current_cask_app_exists() throws {
-        try fm.createDirectory(
-            at: appsDir.appendingPathComponent("ChatGPT.app"), withIntermediateDirectories: true
+        try makeApplicationBundle(
+            in: appsDir, named: "ChatGPT.app", bundleIdentifier: "com.openai.chat"
         )
         let service = LocalHomebrewService(
             defaults: makeScratchDefaults("zombie-crosscheck"),
@@ -233,8 +233,8 @@ final class ZombieDetectionTests: XCTestCase {
 
     @MainActor
     func test_open_falls_back_to_current_cask_artifact_name() throws {
-        try fm.createDirectory(
-            at: appsDir.appendingPathComponent("ChatGPT.app"), withIntermediateDirectories: true
+        try makeApplicationBundle(
+            in: appsDir, named: "ChatGPT.app", bundleIdentifier: "com.openai.chat"
         )
         let service = LocalHomebrewService(
             defaults: makeScratchDefaults("open-fallback"),


### PR DESCRIPTION
## Summary

- Detect Mac App Store, package-installed, and externally installed applications
- Preserve real application URLs, including nested `.localized` bundles such as WhatsApp
- Match package casks using app bundle identity while avoiding false positives and duplicate package matches
- Support opening external apps, package adoption confirmation, and disabled uninstall affordances for App Store apps

## Testing

- `xcodebuild test -project CaskHub.xcodeproj -scheme CaskHub -destination 'platform=macOS' -derivedDataPath /private/tmp/CaskHubDerivedData-codex CODE_SIGNING_ALLOWED=NO`
