### PR TITLE
feat: Improve cask download progress

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -70,7 +70,9 @@
 		41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */; };
 		41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B130028F9F00608C7A /* CaskHubTests.swift */; };
 		C15000000000000000000001 /* ExternalInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15000000000000000000001 /* ExternalInstallationTests.swift */; };
+		C26000000000000000000001 /* ExternalApplicationOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26000000000000000000001 /* ExternalApplicationOwnershipTests.swift */; };
 		41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */; };
+		F25000000000000000000001 /* CaskCatalogSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25000000000000000000001 /* CaskCatalogSortTests.swift */; };
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
 		ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */; };
 		FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */; };
@@ -154,7 +156,9 @@
 		41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
 		41DFD4B130028F9F00608C7A /* CaskHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubTests.swift; sourceTree = "<group>"; };
 		D15000000000000000000001 /* ExternalInstallationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalInstallationTests.swift; sourceTree = "<group>"; };
+		D26000000000000000000001 /* ExternalApplicationOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalApplicationOwnershipTests.swift; sourceTree = "<group>"; };
 		41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogViewModelTests.swift; sourceTree = "<group>"; };
+		E25000000000000000000001 /* CaskCatalogSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogSortTests.swift; sourceTree = "<group>"; };
 		41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		41EBDCE12F37FD8B00BEABB8 /* CaskHub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaskHub.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41EBDCEE2F37FD8C00BEABB8 /* CaskHubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaskHubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -363,6 +367,8 @@
 				41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */,
 				41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */,
 				41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */,
+				E25000000000000000000001 /* CaskCatalogSortTests.swift */,
+				D26000000000000000000001 /* ExternalApplicationOwnershipTests.swift */,
 				D15000000000000000000001 /* ExternalInstallationTests.swift */,
 				41DFD4B130028F9F00608C7A /* CaskHubTests.swift */,
 				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
@@ -596,6 +602,8 @@
 				41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */,
 				41AD10162F68B00700BEABB8 /* CrashReporterTests.swift in Sources */,
 				41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */,
+				F25000000000000000000001 /* CaskCatalogSortTests.swift in Sources */,
+				C26000000000000000000001 /* ExternalApplicationOwnershipTests.swift in Sources */,
 				C15000000000000000000001 /* ExternalInstallationTests.swift in Sources */,
 				41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */,
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,

--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		41DFD48C30028F7D00608C7A /* CaskHubApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD44F30028F7D00608C7A /* CaskHubApp.swift */; };
 		41DFD48D30028F7D00608C7A /* BarrelMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45130028F7D00608C7A /* BarrelMark.swift */; };
 		41DFD48E30028F7D00608C7A /* CaskActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45230028F7D00608C7A /* CaskActionsView.swift */; };
+		F24000000000000000000002 /* CaskOperationCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000002 /* CaskOperationCapsule.swift */; };
 		41DFD48F30028F7D00608C7A /* Controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45330028F7D00608C7A /* Controls.swift */; };
 		41DFD49030028F7D00608C7A /* GlassPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45430028F7D00608C7A /* GlassPanel.swift */; };
 		41DFD49130028F7D00608C7A /* HeroCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45530028F7D00608C7A /* HeroCard.swift */; };
@@ -50,6 +51,7 @@
 		41DFD4A530028F7D00608C7A /* LocalHomebrewService+Brew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47330028F7D00608C7A /* LocalHomebrewService+Brew.swift */; };
 		C15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift */; };
 		A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000001 /* LocalHomebrewTypes.swift */; };
+		F24000000000000000000001 /* CaskOperationProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000001 /* CaskOperationProgress.swift */; };
 		A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000002 /* LocalHomebrewService+State.swift */; };
 		A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */; };
 		C13000000000000000000001 /* LocalHomebrewService+Mutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */; };
@@ -72,6 +74,8 @@
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
 		ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */; };
 		FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */; };
+		F24000000000000000000003 /* CaskOperationProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000003 /* CaskOperationProgressTests.swift */; };
+		F24000000000000000000004 /* BrewProcessRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000004 /* BrewProcessRunnerTests.swift */; };
 		A12000000000000000000004 /* ZombieDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000004 /* ZombieDetectionTests.swift */; };
 		C12000000000000000000001 /* BrewProcessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12000000000000000000001 /* BrewProcessRunner.swift */; };
 		C12000000000000000000002 /* added_dates.json in Resources */ = {isa = PBXBuildFile; fileRef = D12000000000000000000002 /* added_dates.json */; };
@@ -97,6 +101,7 @@
 		41DFD44F30028F7D00608C7A /* CaskHubApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubApp.swift; sourceTree = "<group>"; };
 		41DFD45130028F7D00608C7A /* BarrelMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarrelMark.swift; sourceTree = "<group>"; };
 		41DFD45230028F7D00608C7A /* CaskActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskActionsView.swift; sourceTree = "<group>"; };
+		E24000000000000000000002 /* CaskOperationCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskOperationCapsule.swift; sourceTree = "<group>"; };
 		41DFD45330028F7D00608C7A /* Controls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controls.swift; sourceTree = "<group>"; };
 		41DFD45430028F7D00608C7A /* GlassPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassPanel.swift; sourceTree = "<group>"; };
 		41DFD45530028F7D00608C7A /* HeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroCard.swift; sourceTree = "<group>"; };
@@ -129,6 +134,7 @@
 		41DFD47330028F7D00608C7A /* LocalHomebrewService+Brew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Brew.swift"; sourceTree = "<group>"; };
 		D15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+ExternalApps.swift"; sourceTree = "<group>"; };
 		B12000000000000000000001 /* LocalHomebrewTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewTypes.swift; sourceTree = "<group>"; };
+		E24000000000000000000001 /* CaskOperationProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskOperationProgress.swift; sourceTree = "<group>"; };
 		B12000000000000000000002 /* LocalHomebrewService+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+State.swift"; sourceTree = "<group>"; };
 		B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Adoption.swift"; sourceTree = "<group>"; };
 		D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Mutations.swift"; sourceTree = "<group>"; };
@@ -154,6 +160,8 @@
 		41EBDCEE2F37FD8C00BEABB8 /* CaskHubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaskHubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewTests.swift; sourceTree = "<group>"; };
 		8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdoptionTests.swift; sourceTree = "<group>"; };
+		E24000000000000000000003 /* CaskOperationProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskOperationProgressTests.swift; sourceTree = "<group>"; };
+		E24000000000000000000004 /* BrewProcessRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewProcessRunnerTests.swift; sourceTree = "<group>"; };
 		B12000000000000000000004 /* ZombieDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZombieDetectionTests.swift; sourceTree = "<group>"; };
 		D12000000000000000000001 /* BrewProcessRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewProcessRunner.swift; sourceTree = "<group>"; };
 		D12000000000000000000002 /* added_dates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = added_dates.json; sourceTree = "<group>"; };
@@ -195,6 +203,7 @@
 			children = (
 				41DFD45130028F7D00608C7A /* BarrelMark.swift */,
 				41DFD45230028F7D00608C7A /* CaskActionsView.swift */,
+				E24000000000000000000002 /* CaskOperationCapsule.swift */,
 				41DFD45330028F7D00608C7A /* Controls.swift */,
 				41DFD45430028F7D00608C7A /* GlassPanel.swift */,
 				41DFD45530028F7D00608C7A /* HeroCard.swift */,
@@ -275,6 +284,7 @@
 				41DFD47330028F7D00608C7A /* LocalHomebrewService+Brew.swift */,
 				D15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift */,
 				B12000000000000000000001 /* LocalHomebrewTypes.swift */,
+				E24000000000000000000001 /* CaskOperationProgress.swift */,
 				B12000000000000000000002 /* LocalHomebrewService+State.swift */,
 				B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */,
 				D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */,
@@ -358,6 +368,8 @@
 				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
 				ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */,
 				8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */,
+				E24000000000000000000003 /* CaskOperationProgressTests.swift */,
+				E24000000000000000000004 /* BrewProcessRunnerTests.swift */,
 				D13000000000000000000002 /* MutationRecoveryTests.swift */,
 				B12000000000000000000004 /* ZombieDetectionTests.swift */,
 				41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */,
@@ -527,6 +539,7 @@
 				41DFD48C30028F7D00608C7A /* CaskHubApp.swift in Sources */,
 				41DFD48D30028F7D00608C7A /* BarrelMark.swift in Sources */,
 				41DFD48E30028F7D00608C7A /* CaskActionsView.swift in Sources */,
+				F24000000000000000000002 /* CaskOperationCapsule.swift in Sources */,
 				41DFD48F30028F7D00608C7A /* Controls.swift in Sources */,
 				41DFD49030028F7D00608C7A /* GlassPanel.swift in Sources */,
 				41DFD49130028F7D00608C7A /* HeroCard.swift in Sources */,
@@ -557,6 +570,7 @@
 				41DFD4A530028F7D00608C7A /* LocalHomebrewService+Brew.swift in Sources */,
 				C15000000000000000000002 /* LocalHomebrewService+ExternalApps.swift in Sources */,
 				A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */,
+				F24000000000000000000001 /* CaskOperationProgress.swift in Sources */,
 				A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */,
 				A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */,
 				C13000000000000000000001 /* LocalHomebrewService+Mutations.swift in Sources */,
@@ -587,6 +601,8 @@
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,
 				FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */,
+				F24000000000000000000003 /* CaskOperationProgressTests.swift in Sources */,
+				F24000000000000000000004 /* BrewProcessRunnerTests.swift in Sources */,
 				C13000000000000000000002 /* MutationRecoveryTests.swift in Sources */,
 				A12000000000000000000004 /* ZombieDetectionTests.swift in Sources */,
 				41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */,

--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -129,37 +129,15 @@ struct CaskActionsView: View {
         let token = cask.token
         let isCanceling = localHomebrew.cancelRequested.contains(token)
         let canCancel = localHomebrew.cancellableDownloads.contains(token) && !isCanceling
-        let label = isCanceling
-            ? "Canceling…"
-            : (canCancel ? "Downloading…" : action.inProgressLabel)
 
-        return HStack(spacing: 6) {
-            ProgressView().controlSize(.small)
-            Text(label)
-                .font(CHType.bodySm)
-                .foregroundStyle(Color.chTextBody)
-            if canCancel {
-                Spacer(minLength: 0)
-                Button {
-                    localHomebrew.cancelInstall(token: token)
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 8, weight: .bold))
-                        .foregroundStyle(Color.chTextBody)
-                        .padding(4)
-                        .background(Circle().fill(Color.chSurfaceField))
-                        .overlay(Circle().strokeBorder(Color.chHairline, lineWidth: 1))
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .help("Cancel download")
-            }
-        }
-        .frame(maxWidth: fullWidth ? .infinity : nil)
-        .padding(.vertical, 5)
-        .padding(.horizontal, 16)
-        .background(Capsule().fill(Color.chSurfaceField))
-        .overlay(Capsule().strokeBorder(Color.chHairline, lineWidth: 1))
+        return CaskOperationCapsule(
+            action: action,
+            progress: localHomebrew.operationProgress[token],
+            isCanceling: isCanceling,
+            canCancel: canCancel,
+            fullWidth: fullWidth,
+            onCancel: { localHomebrew.cancelInstall(token: token) }
+        )
     }
 }
 

--- a/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
+++ b/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
@@ -27,8 +27,8 @@ struct CaskOperationCapsule: View {
             }
 
             if let byteProgress = downloadingByteProgress {
-                Text("Downloading ·")
-                    .font(CHType.downloadProgress)
+                Text("Downloading")
+                    .font(CHType.downloadLabel)
                     .foregroundStyle(Color.chTextBody)
                     .lineLimit(1)
                     .fixedSize()

--- a/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
+++ b/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
@@ -1,0 +1,157 @@
+//
+//  CaskOperationCapsule.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 24/07/2026.
+//
+
+import SwiftUI
+
+struct CaskOperationCapsule: View {
+    let action: CaskAction
+    let progress: CaskOperationProgress?
+    let isCanceling: Bool
+    let canCancel: Bool
+    let fullWidth: Bool
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if fractionCompleted == nil {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Image(systemName: "arrow.down")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(accentColor)
+            }
+
+            if let byteProgress = downloadingByteProgress {
+                Text("Downloading ·")
+                    .font(CHType.downloadProgress)
+                    .foregroundStyle(Color.chTextBody)
+                    .lineLimit(1)
+                    .fixedSize()
+
+                Spacer(minLength: 6)
+
+                Text(byteProgress.text)
+                    .font(CHType.downloadProgress)
+                    .monospacedDigit()
+                    .foregroundStyle(Color.chTextBody)
+                    .lineLimit(1)
+            } else {
+                operationLabel
+                    .foregroundStyle(Color.chTextBody)
+                    .lineLimit(1)
+            }
+
+            if canCancel {
+                if downloadingByteProgress == nil {
+                    Spacer(minLength: 0)
+                }
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(Color.chTextBody)
+                        .padding(4)
+                        .background(Circle().fill(Color.chSurfaceField))
+                        .overlay(Circle().strokeBorder(Color.chHairline, lineWidth: 1))
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .help("Cancel download")
+            }
+        }
+        .frame(
+            minWidth: fullWidth ? nil : 200,
+            maxWidth: fullWidth ? .infinity : nil
+        )
+        .frame(height: CHSize.actionCapsuleHeight)
+        .padding(.horizontal, 12)
+        .background {
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.chSurfaceField)
+                if let fractionCompleted {
+                    SmoothProgressFill(
+                        fraction: fractionCompleted,
+                        color: accentColor.opacity(0.18)
+                    )
+                }
+            }
+        }
+        .overlay(Capsule().strokeBorder(Color.chHairline, lineWidth: 1))
+        .accessibilityLabel(label.replacingOccurrences(of: " · ", with: ", "))
+    }
+
+    @ViewBuilder
+    private var operationLabel: some View {
+        if isCanceling {
+            Text("Canceling…")
+                .font(CHType.bodySm)
+        } else {
+            Text(progress?.inlineLabel ?? action.inProgressLabel)
+                .font(CHType.bodySm)
+        }
+    }
+
+    private var downloadingByteProgress: CaskByteProgress? {
+        guard !isCanceling, progress?.phase == .downloading else { return nil }
+        return progress?.byteProgress
+    }
+
+    private var label: String {
+        if isCanceling {
+            return "Canceling…"
+        }
+        return progress?.inlineLabel ?? action.inProgressLabel
+    }
+
+    private var fractionCompleted: Double? {
+        guard !isCanceling, progress?.phase == .downloading else { return nil }
+        return progress?.fractionCompleted
+    }
+
+    private var accentColor: Color {
+        switch action {
+        case .updating:
+            return .chActionUpdateFg
+        case .installing, .adopting, .repairing:
+            return .chActionInstallFg
+        default:
+            return .chTextBrand
+        }
+    }
+}
+
+private struct SmoothProgressFill: View {
+    let fraction: Double
+    let color: Color
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var displayedFraction: Double
+
+    init(fraction: Double, color: Color) {
+        self.fraction = fraction
+        self.color = color
+        _displayedFraction = State(initialValue: fraction)
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            Rectangle()
+                .fill(color)
+                .frame(width: proxy.size.width * displayedFraction)
+        }
+        .clipShape(Capsule())
+        .onChange(of: fraction) { _, newValue in
+            if reduceMotion {
+                displayedFraction = newValue
+            } else {
+                withAnimation(.linear(duration: 0.20)) {
+                    displayedFraction = newValue
+                }
+            }
+        }
+    }
+}

--- a/CaskHub/DesignSystem/Components/Controls.swift
+++ b/CaskHub/DesignSystem/Components/Controls.swift
@@ -79,7 +79,7 @@ struct ActionCapsuleLabel: View {
         .foregroundStyle(action.foreground)
         .lineLimit(1)
         .frame(maxWidth: fullWidth ? .infinity : nil)
-        .padding(.vertical, 6)
+        .frame(height: CHSize.actionCapsuleHeight)
         .padding(.horizontal, fullWidth ? 4 : 22)
         .background(Capsule().fill(action.background))
         .overlay(Capsule().strokeBorder(action.border, lineWidth: 1))

--- a/CaskHub/DesignSystem/Components/StatusBarView.swift
+++ b/CaskHub/DesignSystem/Components/StatusBarView.swift
@@ -11,6 +11,7 @@ struct StatusBarView: View {
     var caskCount: Int
     var brewVersion: String?
     var caskFlowRelease: String?
+    var operation: CaskOperationStatus?
 
     var body: some View {
         HStack(spacing: 16) {
@@ -20,6 +21,11 @@ struct StatusBarView: View {
             Text(statusLine)
                 .font(CHType.statusMono)
                 .foregroundStyle(Color.chTextBody)
+
+            if let operation {
+                operationView(operation)
+                    .transition(.move(edge: .leading).combined(with: .opacity))
+            }
 
             Spacer()
 
@@ -40,6 +46,27 @@ struct StatusBarView: View {
         .overlay(alignment: .top) {
             Rectangle().fill(Color.chHairline).frame(height: 1)
         }
+        .animation(.snappy(duration: 0.28), value: operation != nil)
+    }
+
+    private func operationView(_ operation: CaskOperationStatus) -> some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(Color.chHairlineStrong)
+                .frame(width: 1, height: 13)
+
+            ProgressView()
+                .controlSize(.mini)
+                .tint(Color.chTextBrand)
+
+            Text(operation.message)
+                .font(CHType.statusMono)
+                .monospacedDigit()
+                .foregroundStyle(Color.chTextBody)
+                .lineLimit(1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(operation.message)
     }
 
     private var statusLine: String {
@@ -55,7 +82,17 @@ struct StatusBarView: View {
 #Preview {
     ZStack(alignment: .bottom) {
         WindowBackdrop()
-        StatusBarView(caskCount: 3781, caskFlowRelease: "caskflow-v2026.07.10")
+        StatusBarView(
+            caskCount: 3781,
+            caskFlowRelease: "caskflow-v2026.07.10",
+            operation: CaskOperationStatus(
+                label: "Downloading Docker Desktop",
+                byteProgress: CaskByteProgress(
+                    completedBytes: 84_000_000,
+                    totalBytes: 245_000_000
+                )
+            )
+        )
     }
     .frame(width: 700, height: 200)
 }

--- a/CaskHub/DesignSystem/Tokens/SurfaceTokens.swift
+++ b/CaskHub/DesignSystem/Tokens/SurfaceTokens.swift
@@ -21,6 +21,7 @@ enum CHSize {
     static let cardWidth: CGFloat = 261
     static let cardHeight: CGFloat = 176
     static let heroHeight: CGFloat = 180
+    static let actionCapsuleHeight: CGFloat = 28
 }
 
 enum CHSpace {

--- a/CaskHub/DesignSystem/Tokens/TypographyTokens.swift
+++ b/CaskHub/DesignSystem/Tokens/TypographyTokens.swift
@@ -29,6 +29,7 @@ enum CHType {
     static let bodySm = Font.custom(uiFamily, size: 11).weight(.semibold)
     static let body = Font.custom(uiFamily, size: 13).weight(.semibold)
     static let button = Font.custom(uiFamily, size: 12).weight(.heavy)
+    static let downloadProgress = Font.custom(uiFamily, size: 9).weight(.semibold)
     static let label = Font.custom(uiFamily, size: 10).weight(.heavy) // + .kerning(trackingLabel), uppercase
 
     // Mono — versions, counts, keycaps, status bar

--- a/CaskHub/DesignSystem/Tokens/TypographyTokens.swift
+++ b/CaskHub/DesignSystem/Tokens/TypographyTokens.swift
@@ -29,6 +29,7 @@ enum CHType {
     static let bodySm = Font.custom(uiFamily, size: 11).weight(.semibold)
     static let body = Font.custom(uiFamily, size: 13).weight(.semibold)
     static let button = Font.custom(uiFamily, size: 12).weight(.heavy)
+    static let downloadLabel = Font.custom(uiFamily, size: 10).weight(.semibold)
     static let downloadProgress = Font.custom(uiFamily, size: 9).weight(.semibold)
     static let label = Font.custom(uiFamily, size: 10).weight(.heavy) // + .kerning(trackingLabel), uppercase
 

--- a/CaskHub/Services/BrewOutputCollector.swift
+++ b/CaskHub/Services/BrewOutputCollector.swift
@@ -21,8 +21,19 @@ nonisolated final class BrewOutputCollector: @unchecked Sendable {
 
     /// Must be called before `process.run()` so a fast-exiting process can't
     /// slip past the termination handler.
-    func attach(to process: Process, pipe: Pipe, onChunk: @escaping @Sendable (String) -> Void) {
-        let handle = pipe.fileHandleForReading
+    func attach(
+        to process: Process,
+        pipe: Pipe,
+        onChunk: @escaping @Sendable (String) -> Void
+    ) {
+        attach(to: process, readHandle: pipe.fileHandleForReading, onChunk: onChunk)
+    }
+
+    func attach(
+        to process: Process,
+        readHandle handle: FileHandle,
+        onChunk: @escaping @Sendable (String) -> Void
+    ) {
         handle.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
             if data.isEmpty { handle.readabilityHandler = nil }
@@ -32,8 +43,11 @@ nonisolated final class BrewOutputCollector: @unchecked Sendable {
                     self.sawEOF = true
                     if self.exited { self.finish() }
                 } else if let text = String(data: data, encoding: .utf8) {
-                    self.tail = String((self.tail + text).suffix(2000))
-                    onChunk(text)
+                    let plainText = Self.plainText(text)
+                    self.tail = String((self.tail + plainText).suffix(2000))
+                    if !plainText.isEmpty {
+                        onChunk(plainText)
+                    }
                 }
             }
         }
@@ -69,5 +83,15 @@ nonisolated final class BrewOutputCollector: @unchecked Sendable {
         finished = true
         continuation?.resume(returning: tail)
         continuation = nil
+    }
+
+    private static func plainText(_ text: String) -> String {
+        text
+            .replacingOccurrences(
+                of: "\u{001B}\\[[0-?]*[ -/]*[@-~]",
+                with: "",
+                options: .regularExpression
+            )
+            .replacingOccurrences(of: "\r", with: "\n")
     }
 }

--- a/CaskHub/Services/BrewProcessRunner.swift
+++ b/CaskHub/Services/BrewProcessRunner.swift
@@ -5,6 +5,7 @@
 //  Created by Ali Elsokary on 20/07/2026.
 //
 
+import Darwin
 import Foundation
 
 struct BrewProcessResult: Sendable {
@@ -21,7 +22,7 @@ protocol BrewProcessRunning {
         arguments: [String],
         environment: [String: String],
         onStart: @escaping (Process) -> Void,
-        onChunk: @escaping @Sendable (String) -> Void
+        onChunk: @escaping @MainActor @Sendable (String) -> Void
     ) async throws -> BrewProcessResult
 }
 
@@ -32,28 +33,83 @@ final class SystemBrewProcessRunner: BrewProcessRunning {
         arguments: [String],
         environment: [String: String],
         onStart: @escaping (Process) -> Void,
-        onChunk: @escaping @Sendable (String) -> Void
+        onChunk: @escaping @MainActor @Sendable (String) -> Void
     ) async throws -> BrewProcessResult {
         let process = Process()
         process.executableURL = executableURL
         process.arguments = arguments
-        process.environment = environment
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
         process.standardInput = FileHandle.nullDevice
 
-        let collector = BrewOutputCollector()
-        collector.attach(to: process, pipe: pipe, onChunk: onChunk)
+        let terminal = BrewPseudoTerminal()
+        let readHandle: FileHandle
+        if let terminal {
+            var terminalEnvironment = environment
+            terminalEnvironment["TERM"] = "xterm-256color"
+            process.environment = terminalEnvironment
+            process.standardOutput = terminal.childHandle
+            process.standardError = terminal.childHandle
+            readHandle = terminal.outputHandle
+        } else {
+            process.environment = environment
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
+            readHandle = pipe.fileHandleForReading
+        }
 
-        try process.run()
+        let (chunkStream, chunkContinuation) = AsyncStream<String>.makeStream()
+        let deliveryTask = Task { @MainActor in
+            for await chunk in chunkStream {
+                onChunk(chunk)
+            }
+        }
+
+        let collector = BrewOutputCollector()
+        collector.attach(to: process, readHandle: readHandle) { chunk in
+            chunkContinuation.yield(chunk)
+        }
+
+        do {
+            try process.run()
+        } catch {
+            chunkContinuation.finish()
+            await deliveryTask.value
+            throw error
+        }
+        terminal?.childHandle.closeFile()
         onStart(process)
 
         let output = await collector.output()
+        chunkContinuation.finish()
+        await deliveryTask.value
         return BrewProcessResult(
             exitCode: process.terminationStatus,
             output: output
         )
+    }
+}
+
+private struct BrewPseudoTerminal {
+    let outputHandle: FileHandle
+    let childHandle: FileHandle
+
+    init?() {
+        var outputDescriptor: Int32 = -1
+        var childDescriptor: Int32 = -1
+        var size = winsize()
+        size.ws_row = 24
+        size.ws_col = 180
+
+        guard openpty(
+            &outputDescriptor,
+            &childDescriptor,
+            nil,
+            nil,
+            &size
+        ) == 0 else {
+            return nil
+        }
+        outputHandle = FileHandle(fileDescriptor: outputDescriptor, closeOnDealloc: true)
+        childHandle = FileHandle(fileDescriptor: childDescriptor, closeOnDealloc: true)
     }
 }

--- a/CaskHub/Services/CaskOperationProgress.swift
+++ b/CaskHub/Services/CaskOperationProgress.swift
@@ -1,0 +1,247 @@
+//
+//  CaskOperationProgress.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 24/07/2026.
+//
+
+import Foundation
+
+enum CaskOperationPhase: Equatable {
+    case queued
+    case preparing
+    case downloading
+    case verifying
+    case performing
+    case canceling
+
+    func label(for action: CaskAction) -> String {
+        switch self {
+        case .queued:
+            return "Queued"
+        case .preparing:
+            return "Preparing"
+        case .downloading:
+            return "Downloading"
+        case .verifying:
+            return "Verifying"
+        case .performing:
+            return action.inProgressLabel.replacingOccurrences(of: "…", with: "")
+        case .canceling:
+            return "Canceling"
+        }
+    }
+}
+
+struct CaskOperationProgress: Equatable {
+    let token: String
+    let displayName: String
+    let action: CaskAction
+    var phase: CaskOperationPhase
+    var completedBytes: Int64?
+    var totalBytes: Int64?
+
+    var fractionCompleted: Double? {
+        byteProgress?.fractionCompleted
+    }
+
+    var byteProgress: CaskByteProgress? {
+        guard let completedBytes, let totalBytes, totalBytes > 0 else { return nil }
+        return CaskByteProgress(completedBytes: completedBytes, totalBytes: totalBytes)
+    }
+
+    var byteProgressText: String? {
+        byteProgress?.text
+    }
+
+    var inlineLabel: String {
+        let phaseLabel = phase.label(for: action)
+        guard phase == .downloading, let byteProgressText else {
+            return "\(phaseLabel)…"
+        }
+        return "\(phaseLabel) · \(byteProgressText)"
+    }
+}
+
+struct CaskByteProgress: Equatable {
+    let completedBytes: Int64
+    let totalBytes: Int64
+
+    var fractionCompleted: Double {
+        guard totalBytes > 0 else { return 0 }
+        return min(max(Double(completedBytes) / Double(totalBytes), 0), 1)
+    }
+
+    var text: String {
+        let unit = ByteUnit.forTotalBytes(totalBytes)
+        let clampedCompleted = min(max(completedBytes, 0), max(totalBytes, 0))
+        return [
+            Self.format(clampedCompleted, in: unit),
+            "/",
+            Self.format(totalBytes, in: unit),
+            unit.symbol
+        ].joined(separator: " ")
+    }
+
+    private static func format(_ bytes: Int64, in unit: ByteUnit) -> String {
+        let formatted = String(
+            format: "%.1f",
+            locale: Locale(identifier: "en_US_POSIX"),
+            Double(bytes) / unit.divisor
+        )
+        return formatted.hasSuffix(".0") ? String(formatted.dropLast(2)) : formatted
+    }
+
+    private enum ByteUnit {
+        case bytes
+        case kilobytes
+        case megabytes
+        case gigabytes
+
+        static func forTotalBytes(_ bytes: Int64) -> ByteUnit {
+            switch bytes {
+            case 1_000_000_000...:
+                return .gigabytes
+            case 1_000_000...:
+                return .megabytes
+            case 1_000...:
+                return .kilobytes
+            default:
+                return .bytes
+            }
+        }
+
+        var divisor: Double {
+            switch self {
+            case .bytes: return 1
+            case .kilobytes: return 1_000
+            case .megabytes: return 1_000_000
+            case .gigabytes: return 1_000_000_000
+            }
+        }
+
+        var symbol: String {
+            switch self {
+            case .bytes: return "B"
+            case .kilobytes: return "KB"
+            case .megabytes: return "MB"
+            case .gigabytes: return "GB"
+            }
+        }
+    }
+}
+
+struct CaskUpdateAllProgress: Equatable {
+    let currentIndex: Int
+    let totalCount: Int
+    let currentToken: String
+    let currentDisplayName: String
+}
+
+struct CaskOperationStatus: Equatable {
+    let label: String
+    let byteProgress: CaskByteProgress?
+
+    init(label: String, byteProgress: CaskByteProgress? = nil) {
+        self.label = label
+        self.byteProgress = byteProgress
+    }
+
+    var message: String {
+        guard let byteProgress else { return label }
+        return "\(label) · \(byteProgress.text)"
+    }
+
+    static func make(
+        operations: [CaskOperationProgress],
+        updateAll: CaskUpdateAllProgress?
+    ) -> CaskOperationStatus? {
+        if let updateAll {
+            let label = [
+                "Updating \(updateAll.currentIndex) of \(updateAll.totalCount)",
+                updateAll.currentDisplayName
+            ].joined(separator: " · ")
+            let current = operations.first(where: { $0.token == updateAll.currentToken })
+            let byteProgress = current?.phase == .downloading ? current?.byteProgress : nil
+            return CaskOperationStatus(label: label, byteProgress: byteProgress)
+        }
+
+        let sortedOperations = operations.sorted {
+            if $0.displayName == $1.displayName { return $0.token < $1.token }
+            return $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending
+        }
+        guard !sortedOperations.isEmpty else { return nil }
+
+        if sortedOperations.count == 1, let operation = sortedOperations.first {
+            let byteProgress = operation.phase == .downloading ? operation.byteProgress : nil
+            var label = "\(operation.phase.label(for: operation.action)) \(operation.displayName)"
+            if byteProgress == nil { label += "…" }
+            return CaskOperationStatus(label: label, byteProgress: byteProgress)
+        }
+
+        var counts: [String: Int] = [:]
+        for operation in sortedOperations {
+            let label = operation.phase.label(for: operation.action).lowercased()
+            counts[label, default: 0] += 1
+        }
+        let phaseOrder = [
+            "downloading", "verifying", "installing", "updating", "adopting",
+            "uninstalling", "repairing", "preparing", "canceling", "queued"
+        ]
+        let details = phaseOrder.compactMap { label -> String? in
+            guard let count = counts[label], count > 0 else { return nil }
+            return "\(count) \(label)"
+        }
+        let summary = "\(sortedOperations.count) operations in progress"
+        return CaskOperationStatus(label: ([summary] + details).joined(separator: " · "))
+    }
+}
+
+nonisolated enum BrewProgressParser {
+    private static let progressPattern =
+        #"Downloading\s+([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)\s*/\s*([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)"#
+
+    static func byteProgress(in output: String) -> (completed: Int64, total: Int64)? {
+        guard let expression = try? NSRegularExpression(pattern: progressPattern) else { return nil }
+        let range = NSRange(output.startIndex..<output.endIndex, in: output)
+        guard let match = expression.matches(in: output, range: range).last,
+              let completed = value(in: output, match: match, valueGroup: 1, unitGroup: 2),
+              let total = value(in: output, match: match, valueGroup: 3, unitGroup: 4)
+        else { return nil }
+        return (completed, total)
+    }
+
+    static func latestPhase(in output: String) -> CaskOperationPhase? {
+        let markers: [(String, CaskOperationPhase)] = [
+            ("Downloading", .downloading),
+            (" Verifying ", .verifying),
+            ("Verifying checksum", .verifying),
+            ("==> Installing Cask", .performing),
+            ("==> Upgrading ", .performing)
+        ]
+        return markers.compactMap { marker, phase in
+            output.range(of: marker, options: .backwards).map { ($0.lowerBound, phase) }
+        }
+        .max { $0.0 < $1.0 }?
+        .1
+    }
+
+    private static func value(
+        in output: String,
+        match: NSTextCheckingResult,
+        valueGroup: Int,
+        unitGroup: Int
+    ) -> Int64? {
+        guard let valueRange = Range(match.range(at: valueGroup), in: output),
+              let unitRange = Range(match.range(at: unitGroup), in: output),
+              let value = Double(output[valueRange])
+        else { return nil }
+        let multiplier: Double = switch output[unitRange] {
+        case "KB": 1_000
+        case "MB": 1_000_000
+        case "GB": 1_000_000_000
+        default: 1
+        }
+        return Int64((value * multiplier).rounded())
+    }
+}

--- a/CaskHub/Services/LocalHomebrewService+Brew.swift
+++ b/CaskHub/Services/LocalHomebrewService+Brew.swift
@@ -316,6 +316,17 @@ extension LocalHomebrewService {
         brewPrefixCandidates("Caskroom").first { fileManager.fileExists(atPath: $0.path) }
     }
 
+    func configuredCaskroomURL() -> URL? {
+        if let customBrewPrefix, !customBrewPrefix.isEmpty {
+            let configured = URL(fileURLWithPath: customBrewPrefix)
+                .appendingPathComponent("Caskroom")
+            if fileManager.fileExists(atPath: configured.path) {
+                return configured
+            }
+        }
+        return Self.locateCaskroom(fileManager: fileManager)
+    }
+
     /// Resolves a user's picker selection to a brew prefix. Accepts the brew
     /// binary itself, a prefix folder, or the bin folder inside it.
     nonisolated static func brewPrefix(fromSelection url: URL) -> String? {

--- a/CaskHub/Services/LocalHomebrewService+ExternalApps.swift
+++ b/CaskHub/Services/LocalHomebrewService+ExternalApps.swift
@@ -6,6 +6,57 @@
 import Foundation
 
 extension LocalHomebrewService {
+    /// The catalog provides app identity and package receipt metadata needed to
+    /// associate software already on the Mac with exactly one Homebrew cask.
+    func updatePackageCatalog(_ casks: [Cask]) async {
+        caskDisplayNames = casks.reduce(into: [:]) { names, cask in
+            names[cask.token] = cask.displayName
+        }
+        applicationCaskSignatures = casks.compactMap { cask in
+            guard !cask.appArtifactNames.isEmpty else { return nil }
+            return ApplicationCaskSignature(
+                token: cask.token,
+                appBundleNames: Set(cask.appArtifactNames),
+                bundleIdentifiers: Set(cask.applicationBundleIdentifiers)
+            )
+        }
+        packageCaskSignatures = casks.compactMap { cask in
+            guard cask.hasPackageArtifact, !cask.packageIdentifiers.isEmpty else { return nil }
+            return PackageCaskSignature(
+                token: cask.token,
+                displayName: cask.displayName,
+                receiptPatterns: cask.packageIdentifiers,
+                appNameCandidates: cask.packageAppNameCandidates
+            )
+        }
+        packageCatalogGeneration &+= 1
+        let packageGeneration = packageCatalogGeneration
+
+        let packageSignatures = packageCaskSignatures
+        let fm = fileManager
+        let appDirs = applicationDirectories
+        let (applications, packages) = await Task.detached(priority: .userInitiated) {
+            let applications = Self.scanApplications(fileManager: fm, directories: appDirs)
+            let packages = packageSignatures.isEmpty ? [:] : Self.scanExternalPackageInstallations(
+                signatures: packageSignatures,
+                availableAppNames: applications.nonStoreNames
+            )
+            return (applications, packages)
+        }.value
+        guard packageGeneration == packageCatalogGeneration else { return }
+
+        externalAppNames = applications.adoptableNames
+        macAppStoreAppNames = applications.macAppStoreNames
+        macAppStoreBundleIdentifiers = applications.macAppStoreBundleIdentifiers
+        detectedApplications = applications.applications
+        externalApplicationOwners = Self.resolveExternalApplicationOwners(
+            signatures: applicationCaskSignatures,
+            applications: applications.applications,
+            installedCasks: installedCasks
+        )
+        externalPackageInstallations = packages
+    }
+
     nonisolated static func scanApplications(
         fileManager: FileManager,
         directories: [URL]? = nil
@@ -46,6 +97,64 @@ extension LocalHomebrewService {
             }
         }
         return ExternalApplicationScan(applications: applications)
+    }
+
+    /// Assigns each directly installed application to at most one cask.
+    /// Bundle names identify ordinary apps; shared names require one exact
+    /// bundle-identifier match. Installed Homebrew casks claim their bundles
+    /// before external applications are considered.
+    nonisolated static func resolveExternalApplicationOwners(
+        signatures: [ApplicationCaskSignature],
+        applications: [DetectedApplication],
+        installedCasks: [String: LocalCaskInstallation]
+    ) -> [String: DetectedApplication] {
+        guard !signatures.isEmpty else { return [:] }
+
+        let signaturesByToken = Dictionary(
+            signatures.map { ($0.token, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let installedBundleNames = Set(installedCasks.values.flatMap { installation in
+            let catalogNames = signaturesByToken[installation.token]?.appBundleNames ?? []
+            return installation.appBundleNames + Array(catalogNames)
+        }.map { normalizedApplicationName($0) })
+
+        var owners: [String: DetectedApplication] = [:]
+        for application in applications where
+            !application.isMacAppStore && application.isDirectlyInApplicationDirectory {
+            let normalizedName = normalizedApplicationName(application.bundleName)
+            guard !installedBundleNames.contains(normalizedName) else { continue }
+
+            let candidates = signatures.filter { signature in
+                signature.appBundleNames.contains {
+                    normalizedApplicationName($0) == normalizedName
+                } && !installedCasks.keys.contains(signature.token)
+            }
+            guard let owner = externalApplicationOwner(
+                for: application, candidates: candidates
+            ) else { continue }
+            owners[owner.token] = application
+        }
+        return owners
+    }
+
+    private nonisolated static func externalApplicationOwner(
+        for application: DetectedApplication,
+        candidates: [ApplicationCaskSignature]
+    ) -> ApplicationCaskSignature? {
+        if candidates.count == 1 { return candidates[0] }
+        guard candidates.count > 1,
+              let identifier = application.bundleIdentifier?.lowercased()
+        else { return nil }
+
+        let exactMatches = candidates.filter { signature in
+            signature.bundleIdentifiers.contains { $0.lowercased() == identifier }
+        }
+        return exactMatches.count == 1 ? exactMatches[0] : nil
+    }
+
+    private nonisolated static func normalizedApplicationName(_ name: String) -> String {
+        name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
     }
 
     /// A directory ending in `.app` is not necessarily launchable. Partial

--- a/CaskHub/Services/LocalHomebrewService+Mutations.swift
+++ b/CaskHub/Services/LocalHomebrewService+Mutations.swift
@@ -80,7 +80,7 @@ extension LocalHomebrewService {
     }
 
     private func hasStrandedCopy(token: String) -> Bool {
-        guard let caskroom = Self.locateCaskroom(fileManager: fileManager) else { return false }
+        guard let caskroom = configuredCaskroomURL() else { return false }
         return Self.strandedCopyExists(in: caskroom, token: token, fileManager: fileManager)
     }
 

--- a/CaskHub/Services/LocalHomebrewService+Mutations.swift
+++ b/CaskHub/Services/LocalHomebrewService+Mutations.swift
@@ -31,14 +31,10 @@ extension LocalHomebrewService {
         recoverIf: (() -> Bool)? = nil
     ) async throws {
         guard inFlightActions[token] == nil || inFlightActions[token] == .queued else { return }
-        inFlightActions[token] = action
+        beginOperation(action, token: token)
         actionErrors[token] = nil
         Analytics.caskActionStarted(action, token: token, origin: origin)
-        defer {
-            inFlightActions[token] = nil
-            cancellableDownloads.remove(token)
-            runningProcesses[token] = nil
-        }
+        defer { clearOperation(token: token) }
 
         let span = CrashReporter.span(name: args.first ?? "brew", operation: "brew")
         do {
@@ -109,18 +105,17 @@ extension LocalHomebrewService {
             environment["SUDO_ASKPASS"] = askpass.path
         }
 
+        let service = self
         let result = try await processRunner.run(
             executableURL: brewURL,
             arguments: args,
             environment: environment,
-            onStart: { [weak self] process in
-                self?.runningProcesses[token] = process
-                if cancellable { self?.cancellableDownloads.insert(token) }
+            onStart: { process in
+                service.runningProcesses[token] = process
+                if cancellable { service.cancellableDownloads.insert(token) }
             },
-            onChunk: { [weak self] text in
-                guard text.contains("==> Installing Cask") else { return }
-                guard let self else { return }
-                Task { @MainActor in self.cancellableDownloads.remove(token) }
+            onChunk: { text in
+                service.consumeBrewOutput(text, token: token)
             }
         )
 
@@ -131,6 +126,57 @@ extension LocalHomebrewService {
                 stderr: Self.diagnosticOutput(from: result.output)
             )
         }
+    }
+
+    func beginOperation(_ action: CaskAction, token: String) {
+        inFlightActions[token] = action
+        brewOutputBuffers[token] = nil
+        lastProgressUpdates[token] = nil
+        operationProgress[token] = CaskOperationProgress(
+            token: token,
+            displayName: displayName(for: token),
+            action: action,
+            phase: action == .uninstalling ? .performing : .preparing
+        )
+    }
+
+    func clearOperation(token: String) {
+        inFlightActions[token] = nil
+        operationProgress[token] = nil
+        cancellableDownloads.remove(token)
+        brewOutputBuffers[token] = nil
+        lastProgressUpdates[token] = nil
+        runningProcesses[token] = nil
+    }
+
+    func consumeBrewOutput(_ output: String, token: String) {
+        guard var progress = operationProgress[token],
+              progress.phase != .canceling
+        else { return }
+
+        let buffered = String(((brewOutputBuffers[token] ?? "") + output).suffix(6_000))
+        brewOutputBuffers[token] = buffered
+
+        if let bytes = BrewProgressParser.byteProgress(in: buffered) {
+            let now = Date()
+            let shouldPublish = lastProgressUpdates[token].map {
+                now.timeIntervalSince($0) >= 0.10
+            } ?? true
+            if shouldPublish || bytes.completed >= bytes.total {
+                progress.phase = .downloading
+                progress.completedBytes = bytes.completed
+                progress.totalBytes = bytes.total
+                lastProgressUpdates[token] = now
+            }
+        }
+        if let phase = BrewProgressParser.latestPhase(in: buffered) {
+            progress.phase = phase
+            if phase == .performing {
+                cancellableDownloads.remove(token)
+            }
+        }
+
+        operationProgress[token] = progress
     }
 
     func repairRemovalSatisfied(

--- a/CaskHub/Services/LocalHomebrewService+State.swift
+++ b/CaskHub/Services/LocalHomebrewService+State.swift
@@ -34,8 +34,13 @@ extension LocalHomebrewService {
     }
 
     func isAdoptableApplication(_ cask: Cask) -> Bool {
-        installedCasks[cask.token] == nil
-            && cask.appArtifactNames.contains(where: externalAppNames.contains)
+        guard installedCasks[cask.token] == nil else { return false }
+        if !applicationCaskSignatures.isEmpty {
+            return externalApplicationOwners[cask.token] != nil
+        }
+
+        // Catalog-less fallback for previews and isolated state injection.
+        return cask.appArtifactNames.contains(where: externalAppNames.contains)
     }
 
     func isExternalPackageInstalled(_ cask: Cask) -> Bool {
@@ -137,6 +142,10 @@ extension LocalHomebrewService {
             appLauncher(application.url)
             return
         }
+        if let application = externalApplicationOwners[cask.token] {
+            appLauncher(application.url)
+            return
+        }
         openBundle(named: externalBundleNameCandidates(for: cask), token: cask.token)
     }
 
@@ -145,6 +154,7 @@ extension LocalHomebrewService {
         guard installedCasks[cask.token] == nil,
               installationSource(for: cask) != nil,
               let appURL = macAppStoreApplication(for: cask)?.url
+                ?? externalApplicationOwners[cask.token]?.url
                 ?? existingBundleURL(named: externalBundleNameCandidates(for: cask)),
               let info = Bundle(url: appURL)?.infoDictionary
         else { return nil }

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -19,6 +19,10 @@ final class LocalHomebrewService {
     /// Non-Mac-App-Store bundle names found in /Applications and ~/Applications.
     var externalAppNames: Set<String> = []
 
+    /// Directly installed applications resolved to one catalog cask. A token is
+    /// absent when a shared bundle name cannot be disambiguated safely.
+    var externalApplicationOwners: [String: DetectedApplication] = [:]
+
     /// Mac App Store bundles that must be shown as installed but never adopted.
     var macAppStoreAppNames: Set<String> = []
 
@@ -35,11 +39,13 @@ final class LocalHomebrewService {
     /// Package-installed apps matched to cask receipt metadata.
     var externalPackageInstallations: [String: ExternalPackageInstallation] = [:]
 
+    @ObservationIgnored var applicationCaskSignatures: [ApplicationCaskSignature] = []
+
     /// Package adoptions awaiting the user's reinstall confirmation.
     var packageAdoptionRequests: Set<String> = []
 
     @ObservationIgnored var packageCaskSignatures: [PackageCaskSignature] = []
-    @ObservationIgnored private var packageCatalogGeneration = 0
+    @ObservationIgnored var packageCatalogGeneration = 0
 
     var adoptReplaceOffers: Set<String> = []
 
@@ -170,12 +176,17 @@ final class LocalHomebrewService {
             brewVersion = await brewVersionProvider()
         }
         let appDirs = applicationDirectories
+        let caskroom = configuredCaskroomURL()
         let packageSignatures = packageCaskSignatures
         let packageGeneration = packageCatalogGeneration
         let (casks, applications, binaryPaths, packages) = await Task.detached(priority: .userInitiated) {
             let applications = Self.scanApplications(fileManager: fm, directories: appDirs)
             return (
-                Self.scanCaskroom(fileManager: fm, applicationDirectories: appDirs),
+                caskroom.map {
+                    Self.scanCaskroom(
+                        at: $0, fileManager: fm, applicationDirectories: appDirs
+                    )
+                } ?? [:],
                 applications,
                 Self.scanBinaryDirectories(fileManager: fm),
                 Self.scanExternalPackageInstallations(
@@ -184,64 +195,27 @@ final class LocalHomebrewService {
                 )
             )
         }.value
+        installedCasks = casks
         externalAppNames = applications.adoptableNames
         macAppStoreAppNames = applications.macAppStoreNames
         macAppStoreBundleIdentifiers = applications.macAppStoreBundleIdentifiers
         detectedApplications = applications.applications
+        externalApplicationOwners = Self.resolveExternalApplicationOwners(
+            signatures: applicationCaskSignatures,
+            applications: applications.applications,
+            installedCasks: casks
+        )
         externalBinaryPaths = binaryPaths
         if packageGeneration == packageCatalogGeneration {
             externalPackageInstallations = packages
         }
 
         CrashReporter.tag("brew.path", value: Self.locateBrewBinary()?.path ?? "not found")
-        CrashReporter.tag("brew.caskroom", value: Self.locateCaskroom(fileManager: fm)?.path ?? "not found")
+        CrashReporter.tag("brew.caskroom", value: caskroom?.path ?? "not found")
 
-        installedCasks = casks
         lastRefresh = .now
     }
 
-    /// The catalog provides the package receipt identifiers needed to associate
-    /// system package records with Homebrew casks.
-    func updatePackageCatalog(_ casks: [Cask]) async {
-        caskDisplayNames = casks.reduce(into: [:]) { names, cask in
-            names[cask.token] = cask.displayName
-        }
-        packageCaskSignatures = casks.compactMap { cask in
-            guard cask.hasPackageArtifact, !cask.packageIdentifiers.isEmpty else { return nil }
-            return PackageCaskSignature(
-                token: cask.token,
-                displayName: cask.displayName,
-                receiptPatterns: cask.packageIdentifiers,
-                appNameCandidates: cask.packageAppNameCandidates
-            )
-        }
-        packageCatalogGeneration &+= 1
-        let packageGeneration = packageCatalogGeneration
-        guard !packageCaskSignatures.isEmpty else {
-            externalPackageInstallations = [:]
-            return
-        }
-
-        let signatures = packageCaskSignatures
-        let fm = fileManager
-        let appDirs = applicationDirectories
-        let applications = await Task.detached(priority: .userInitiated) {
-            Self.scanApplications(fileManager: fm, directories: appDirs)
-        }.value
-        externalAppNames = applications.adoptableNames
-        macAppStoreAppNames = applications.macAppStoreNames
-        macAppStoreBundleIdentifiers = applications.macAppStoreBundleIdentifiers
-        detectedApplications = applications.applications
-        let packages = await Task.detached(priority: .userInitiated) {
-            Self.scanExternalPackageInstallations(
-                signatures: signatures,
-                availableAppNames: applications.nonStoreNames
-            )
-        }.value
-        if packageGeneration == packageCatalogGeneration {
-            externalPackageInstallations = packages
-        }
-    }
 }
 
 // MARK: - Actions
@@ -279,7 +253,7 @@ extension LocalHomebrewService {
     func repairReinstalling(token: String) async throws {
         guard inFlightActions[token] == nil else { return }
         repairOffers.remove(token)
-        let caskroomEntry = Self.locateCaskroom(fileManager: fileManager)?
+        let caskroomEntry = configuredCaskroomURL()?
             .appendingPathComponent(token)
         let appBundleNames = installedCasks[token]?.appBundleNames ?? []
         Analytics.caskActionStarted(.repairing, token: token, origin: .repair)

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -70,9 +70,17 @@ final class LocalHomebrewService {
 
     var inFlightActions: [String: CaskAction] = [:]
 
+    var operationProgress: [String: CaskOperationProgress] = [:]
+
+    var updateAllProgress: CaskUpdateAllProgress?
+
     var cancellableDownloads: Set<String> = []
 
     var cancelRequested: Set<String> = []
+
+    @ObservationIgnored var caskDisplayNames: [String: String] = [:]
+    @ObservationIgnored var brewOutputBuffers: [String: String] = [:]
+    @ObservationIgnored var lastProgressUpdates: [String: Date] = [:]
 
     @ObservationIgnored var runningProcesses: [String: Process] = [:]
 
@@ -195,6 +203,9 @@ final class LocalHomebrewService {
     /// The catalog provides the package receipt identifiers needed to associate
     /// system package records with Homebrew casks.
     func updatePackageCatalog(_ casks: [Cask]) async {
+        caskDisplayNames = casks.reduce(into: [:]) { names, cask in
+            names[cask.token] = cask.displayName
+        }
         packageCaskSignatures = casks.compactMap { cask in
             guard cask.hasPackageArtifact, !cask.packageIdentifiers.isEmpty else { return nil }
             return PackageCaskSignature(
@@ -231,9 +242,11 @@ final class LocalHomebrewService {
             externalPackageInstallations = packages
         }
     }
+}
 
-    // MARK: - Actions
+// MARK: - Actions
 
+extension LocalHomebrewService {
     func install(token: String, origin: CaskActionOrigin = .individual) async throws {
         try await runMutation(
             .installing, token: token, args: ["install", "--cask", token], origin: origin
@@ -270,14 +283,12 @@ final class LocalHomebrewService {
             .appendingPathComponent(token)
         let appBundleNames = installedCasks[token]?.appBundleNames ?? []
         Analytics.caskActionStarted(.repairing, token: token, origin: .repair)
-        inFlightActions[token] = .repairing
+        beginOperation(.repairing, token: token)
         do {
             try await runBrewStreaming(token: token, args: ["fetch", "--cask", token], cancellable: false)
-            inFlightActions[token] = nil
-            runningProcesses[token] = nil
+            clearOperation(token: token)
         } catch {
-            inFlightActions[token] = nil
-            runningProcesses[token] = nil
+            clearOperation(token: token)
             CrashReporter.capture(error)
             Analytics.caskActionFailed(.repairing, token: token, origin: .repair)
             actionErrors[token] = (error as? LocalHomebrewError)?.errorDescription
@@ -319,11 +330,20 @@ final class LocalHomebrewService {
     func updateAll(tokens: [String]) async {
         guard !isUpdatingAll else { return }
         isUpdatingAll = true
-        defer { isUpdatingAll = false }
+        defer {
+            updateAllProgress = nil
+            isUpdatingAll = false
+        }
         for token in tokens where inFlightActions[token] == nil {
             inFlightActions[token] = .queued
         }
-        for token in tokens {
+        for (index, token) in tokens.enumerated() {
+            updateAllProgress = CaskUpdateAllProgress(
+                currentIndex: index + 1,
+                totalCount: tokens.count,
+                currentToken: token,
+                currentDisplayName: displayName(for: token)
+            )
             try? await upgrade(token: token, origin: .updateAll)
         }
     }
@@ -333,6 +353,10 @@ final class LocalHomebrewService {
               let process = runningProcesses[token] else { return }
         cancelRequested.insert(token)
         cancellableDownloads.remove(token)
+        if var progress = operationProgress[token] {
+            progress.phase = .canceling
+            operationProgress[token] = progress
+        }
 
         let pid = process.processIdentifier
         Task.detached(priority: .userInitiated) {
@@ -340,5 +364,16 @@ final class LocalHomebrewService {
             try? await Task.sleep(for: .seconds(5))
             if process.isRunning { process.terminate() }
         }
+    }
+
+    var statusBarOperation: CaskOperationStatus? {
+        CaskOperationStatus.make(
+            operations: Array(operationProgress.values),
+            updateAll: updateAllProgress
+        )
+    }
+
+    func displayName(for token: String) -> String {
+        caskDisplayNames[token] ?? token
     }
 }

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -44,6 +44,12 @@ nonisolated struct ExternalApplicationScan {
     }
 }
 
+nonisolated struct ApplicationCaskSignature {
+    let token: String
+    let appBundleNames: Set<String>
+    let bundleIdentifiers: Set<String>
+}
+
 nonisolated struct PackageCaskSignature {
     let token: String
     let displayName: String

--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -22,6 +22,7 @@ enum SortOption: String, CaseIterable, Identifiable {
     case mostPopular = "Most Popular"
     case nameAZ = "Name (A→Z)"
     case nameZA = "Name (Z→A)"
+    case recentlyInstalled = "Recently Installed"
     case newest = "Newest"
     case oldest = "Oldest"
 
@@ -30,6 +31,7 @@ enum SortOption: String, CaseIterable, Identifiable {
     }
 
     static let standard: [SortOption] = [.mostPopular, .nameAZ, .nameZA]
+    static let installed: [SortOption] = [.recentlyInstalled] + standard
 }
 
 @MainActor
@@ -55,7 +57,23 @@ final class CaskCatalogViewModel {
     }
 
     var sortOption: SortOption = .mostPopular
-    var selectedSidebar: SidebarSelection = .discover(.browse)
+    var selectedSidebar: SidebarSelection = .discover(.browse) {
+        didSet {
+            guard oldValue != selectedSidebar else { return }
+            switch selectedSidebar {
+            case .library(.installed):
+                sortOption = .recentlyInstalled
+            case .library(.updates), .library(.adopt):
+                sortOption = .nameAZ
+            case .discover(.recentlyAdded):
+                sortOption = .newest
+            default:
+                if !SortOption.standard.contains(sortOption) {
+                    sortOption = .mostPopular
+                }
+            }
+        }
+    }
 
     private(set) var recentlyAddedWindow: RecentlyAddedWindow = .days30
 
@@ -208,6 +226,19 @@ final class CaskCatalogViewModel {
         source.sorted { (recentlyAdded.addedDate(for: $0.token) ?? "") > (recentlyAdded.addedDate(for: $1.token) ?? "") }
     }
 
+    private func sortedByRecentlyInstalled(_ source: [Cask]) -> [Cask] {
+        source.sorted { lhs, rhs in
+            let lhsDate = localHomebrew.installedCasks[lhs.token]?.installedAt
+            let rhsDate = localHomebrew.installedCasks[rhs.token]?.installedAt
+            if lhsDate != rhsDate {
+                if let lhsDate, let rhsDate { return lhsDate > rhsDate }
+                return lhsDate != nil
+            }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+                == .orderedAscending
+        }
+    }
+
     private func applySort(to casks: [Cask]) -> [Cask] {
         switch sortOption {
         case .mostPopular:
@@ -216,6 +247,8 @@ final class CaskCatalogViewModel {
             return casks.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
         case .nameZA:
             return casks.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedDescending }
+        case .recentlyInstalled:
+            return sortedByRecentlyInstalled(casks)
         case .newest:
             return sortedByNewest(casks)
         case .oldest:

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -44,9 +44,7 @@ struct ContentView: View {
                     title: sectionName,
                     caskCount: viewModel.filteredCasks.count,
                     sortOption: $viewModel.sortOption,
-                    sortOptions: selectedSidebar == .discover(.recentlyAdded)
-                        ? SortOption.standard + [.oldest, .newest]
-                        : SortOption.standard,
+                    sortOptions: sortOptions,
                     viewMode: $viewMode,
                     searchText: $viewModel.searchText,
                     searchFocus: $searchFocused,
@@ -130,11 +128,6 @@ struct ContentView: View {
             if newValue == .discover(.topCharts) {
                 Task { await viewModel.selectAnalyticsPeriod(viewModel.analyticsPeriod) }
             }
-            if newValue == .discover(.recentlyAdded) {
-                viewModel.sortOption = .newest
-            } else if !SortOption.standard.contains(viewModel.sortOption) {
-                viewModel.sortOption = .mostPopular
-            }
         }
         .onChange(of: viewMode) { _, newValue in
             Analytics.viewModeChanged(newValue)
@@ -203,6 +196,17 @@ struct ContentView: View {
         selectedSidebar == .discover(.browse)
             && viewModel.searchText.isEmpty
             && viewMode == .grid
+    }
+
+    private var sortOptions: [SortOption] {
+        switch selectedSidebar {
+        case .library(.installed):
+            return SortOption.installed
+        case .discover(.recentlyAdded):
+            return SortOption.standard + [.oldest, .newest]
+        default:
+            return SortOption.standard
+        }
     }
 
     private func categoryInfo(for cask: Cask) -> (id: String, name: String)? {

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -109,7 +109,8 @@ struct ContentView: View {
             StatusBarView(
                 caskCount: viewModel.casks.count,
                 brewVersion: localHomebrew.brewVersion,
-                caskFlowRelease: categoryService.releaseTag
+                caskFlowRelease: categoryService.releaseTag,
+                operation: localHomebrew.statusBarOperation
             )
         }
         .containerBackground(for: .window) {

--- a/CaskHubTests/AdoptionTests.swift
+++ b/CaskHubTests/AdoptionTests.swift
@@ -29,6 +29,7 @@ final class StubBrewProcessRunner: BrewProcessRunning {
     }
 
     var queuedResults: [BrewProcessResult] = []
+    var queuedChunks: [[String]] = []
     var thrownError: Error?
     var onRequest: ((Request) throws -> Void)?
     private(set) var requests: [Request] = []
@@ -38,7 +39,7 @@ final class StubBrewProcessRunner: BrewProcessRunning {
         arguments: [String],
         environment: [String: String],
         onStart _: @escaping (Process) -> Void,
-        onChunk _: @escaping @Sendable (String) -> Void
+        onChunk: @escaping @MainActor @Sendable (String) -> Void
     ) async throws -> BrewProcessResult {
         let askpassContents = environment["SUDO_ASKPASS"].flatMap {
             try? String(contentsOfFile: $0, encoding: .utf8)
@@ -52,6 +53,9 @@ final class StubBrewProcessRunner: BrewProcessRunning {
         requests.append(request)
         try onRequest?(request)
         if let thrownError { throw thrownError }
+        if !queuedChunks.isEmpty {
+            queuedChunks.removeFirst().forEach(onChunk)
+        }
         return queuedResults.isEmpty
             ? BrewProcessResult(exitCode: 0, output: "")
             : queuedResults.removeFirst()

--- a/CaskHubTests/BrewProcessRunnerTests.swift
+++ b/CaskHubTests/BrewProcessRunnerTests.swift
@@ -1,0 +1,58 @@
+//
+//  BrewProcessRunnerTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 24/07/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+final class BrewProcessRunnerTests: XCTestCase {
+    @MainActor
+    func test_system_runner_collects_pseudo_terminal_output() async throws {
+        let result = try await SystemBrewProcessRunner().run(
+            executableURL: URL(fileURLWithPath: "/bin/echo"),
+            arguments: ["terminal progress"],
+            environment: ProcessInfo.processInfo.environment,
+            onStart: { _ in },
+            onChunk: { _ in }
+        )
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertTrue(result.output.contains("terminal progress"))
+    }
+
+    @MainActor
+    func test_system_runner_promotes_dumb_terminal_for_progress_output() async throws {
+        var environment = ProcessInfo.processInfo.environment
+        environment["TERM"] = "dumb"
+
+        let result = try await SystemBrewProcessRunner().run(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "printf '%s' \"$TERM\""],
+            environment: environment,
+            onStart: { _ in },
+            onChunk: { _ in }
+        )
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.output, "xterm-256color")
+    }
+
+    @MainActor
+    func test_system_runner_delivers_chunks_in_output_order() async throws {
+        var deliveredOutput = ""
+        let result = try await SystemBrewProcessRunner().run(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "printf first; sleep 0.05; printf second; sleep 0.05; printf third"],
+            environment: ProcessInfo.processInfo.environment,
+            onStart: { _ in },
+            onChunk: { deliveredOutput += $0 }
+        )
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(deliveredOutput, "firstsecondthird")
+        XCTAssertEqual(result.output, deliveredOutput)
+    }
+}

--- a/CaskHubTests/CaskCatalogSortTests.swift
+++ b/CaskHubTests/CaskCatalogSortTests.swift
@@ -1,0 +1,100 @@
+//
+//  CaskCatalogSortTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 24/07/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+final class CaskCatalogSortTests: XCTestCase {
+    private func detectedApplication(named name: String) -> DetectedApplication {
+        DetectedApplication(
+            url: URL(fileURLWithPath: "/Applications/\(name)"),
+            bundleName: name,
+            bundleIdentifier: "com.example.\(name)",
+            isMacAppStore: false,
+            isDirectlyInApplicationDirectory: true
+        )
+    }
+
+    @MainActor
+    func test_sort_options_order_by_downloads_name_and_added_date() async {
+        let recent = RecentlyAddedService()
+        recent.addedDates = [
+            "bravo": dateString(daysAgo: 1),
+            "alpha": dateString(daysAgo: 50)
+        ]
+        let (vm, _) = await makeSUT(
+            casks: [makeCask("alpha"), makeCask("charlie"), makeCask("bravo")],
+            analytics: [("bravo", "300"), ("alpha", "200"), ("charlie", "100")],
+            recentlyAdded: recent
+        )
+
+        vm.sortOption = .mostPopular
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["bravo", "alpha", "charlie"])
+
+        vm.sortOption = .nameAZ
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["alpha", "bravo", "charlie"])
+
+        vm.sortOption = .nameZA
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["charlie", "bravo", "alpha"])
+
+        vm.sortOption = .newest
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["bravo", "alpha", "charlie"])
+
+        vm.sortOption = .oldest
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["alpha", "bravo", "charlie"])
+    }
+
+    @MainActor
+    func test_library_pages_apply_their_default_sorts() async {
+        XCTAssertEqual(
+            SortOption.installed,
+            [.recentlyInstalled, .mostPopular, .nameAZ, .nameZA]
+        )
+
+        let now = Date()
+        let local = LocalHomebrewService(defaults: makeScratchDefaults("library-sort-defaults"))
+        local.installedCasks = [
+            "alpha": LocalCaskInstallation(
+                token: "alpha",
+                installedVersion: "1.0",
+                installedAt: now.addingTimeInterval(-86_400),
+                appBundleNames: []
+            ),
+            "zulu": LocalCaskInstallation(
+                token: "zulu",
+                installedVersion: "1.0",
+                installedAt: now,
+                appBundleNames: []
+            )
+        ]
+        let (vm, _) = await makeSUT(
+            casks: [
+                makeCask("alpha", version: "2.0"),
+                makeCask("zulu", version: "2.0"),
+                makeCask("able", appNames: ["Able.app"]),
+                makeCask("bravo", appNames: ["Bravo.app"])
+            ],
+            localHomebrew: local
+        )
+        local.externalApplicationOwners = [
+            "able": detectedApplication(named: "Able.app"),
+            "bravo": detectedApplication(named: "Bravo.app")
+        ]
+
+        vm.selectedSidebar = .library(.installed)
+        XCTAssertEqual(vm.sortOption, .recentlyInstalled)
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["zulu", "alpha", "able", "bravo"])
+
+        vm.selectedSidebar = .library(.updates)
+        XCTAssertEqual(vm.sortOption, .nameAZ)
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["alpha", "zulu"])
+
+        vm.selectedSidebar = .library(.adopt)
+        XCTAssertEqual(vm.sortOption, .nameAZ)
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["able", "bravo"])
+    }
+}

--- a/CaskHubTests/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/CaskCatalogViewModelTests.swift
@@ -151,37 +151,6 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(Set(vm.filteredCasks.map(\.token)), ["new-app"])
     }
 
-    // MARK: Sorting
-
-    @MainActor
-    func test_sort_options_order_by_downloads_name_and_added_date() async {
-        let recent = RecentlyAddedService()
-        recent.addedDates = [
-            "bravo": dateString(daysAgo: 1),
-            "alpha": dateString(daysAgo: 50)
-        ]
-        let (vm, _) = await makeSUT(
-            casks: [makeCask("alpha"), makeCask("charlie"), makeCask("bravo")],
-            analytics: [("bravo", "300"), ("alpha", "200"), ("charlie", "100")],
-            recentlyAdded: recent
-        )
-
-        vm.sortOption = .mostPopular
-        XCTAssertEqual(vm.filteredCasks.map(\.token), ["bravo", "alpha", "charlie"])
-
-        vm.sortOption = .nameAZ
-        XCTAssertEqual(vm.filteredCasks.map(\.token), ["alpha", "bravo", "charlie"])
-
-        vm.sortOption = .nameZA
-        XCTAssertEqual(vm.filteredCasks.map(\.token), ["charlie", "bravo", "alpha"])
-
-        vm.sortOption = .newest
-        XCTAssertEqual(vm.filteredCasks.map(\.token), ["bravo", "alpha", "charlie"])
-
-        vm.sortOption = .oldest
-        XCTAssertEqual(vm.filteredCasks.map(\.token), ["alpha", "bravo", "charlie"])
-    }
-
     // MARK: Browse sections
 
     @MainActor

--- a/CaskHubTests/CaskOperationProgressTests.swift
+++ b/CaskHubTests/CaskOperationProgressTests.swift
@@ -1,0 +1,149 @@
+//
+//  CaskOperationProgressTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 24/07/2026.
+//
+
+@testable import CaskHub
+import SwiftUI
+import XCTest
+
+final class CaskOperationProgressTests: XCTestCase {
+    func test_brew_progress_parser_reads_homebrew_byte_totals() throws {
+        let output = "Cask docker-desktop    #######    Downloading    84.2MB/245.0MB"
+        let progress = try XCTUnwrap(BrewProgressParser.byteProgress(in: output))
+
+        XCTAssertEqual(progress.completed, 84_200_000)
+        XCTAssertEqual(progress.total, 245_000_000)
+    }
+
+    func test_byte_progress_uses_one_shared_unit() {
+        let progress = CaskByteProgress(
+            completedBytes: 46_300_000,
+            totalBytes: 220_600_000
+        )
+
+        XCTAssertEqual(progress.text, "46.3 / 220.6 MB")
+    }
+
+    @MainActor
+    func test_brew_output_updates_download_phase_then_install_phase() throws {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("operation-progress"))
+        service.caskDisplayNames["firefox"] = "Firefox"
+        service.beginOperation(.installing, token: "firefox")
+        service.cancellableDownloads.insert("firefox")
+
+        service.consumeBrewOutput(
+            "Cask firefox    ########    Downloading    42.0MB/100.0MB",
+            token: "firefox"
+        )
+        let downloading = try XCTUnwrap(service.operationProgress["firefox"])
+        XCTAssertEqual(downloading.phase, .downloading)
+        XCTAssertEqual(downloading.completedBytes, 42_000_000)
+        XCTAssertEqual(downloading.totalBytes, 100_000_000)
+        XCTAssertEqual(try XCTUnwrap(downloading.fractionCompleted), 0.42, accuracy: 0.001)
+        XCTAssertTrue(service.statusBarOperation?.message.contains("Downloading Firefox") == true)
+
+        service.consumeBrewOutput("==> Installing Cask firefox", token: "firefox")
+        XCTAssertEqual(service.operationProgress["firefox"]?.phase, .performing)
+        XCTAssertFalse(service.cancellableDownloads.contains("firefox"))
+    }
+
+    @MainActor
+    func test_brew_output_updates_download_phase_then_upgrade_phase() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("update-progress"))
+        service.beginOperation(.updating, token: "firefox")
+        service.cancellableDownloads.insert("firefox")
+
+        service.consumeBrewOutput(
+            """
+            ==> Upgrading firefox
+            Cask firefox    ########    Downloading    100.0MB/100.0MB
+            """,
+            token: "firefox"
+        )
+        XCTAssertEqual(service.operationProgress["firefox"]?.phase, .downloading)
+
+        service.consumeBrewOutput("==> Upgrading firefox", token: "firefox")
+        XCTAssertEqual(service.operationProgress["firefox"]?.phase, .performing)
+        XCTAssertFalse(service.cancellableDownloads.contains("firefox"))
+    }
+
+    func test_operation_status_summarizes_multiple_operations() {
+        let operations = [
+            CaskOperationProgress(
+                token: "docker",
+                displayName: "Docker Desktop",
+                action: .installing,
+                phase: .downloading,
+                completedBytes: 84_000_000,
+                totalBytes: 245_000_000
+            ),
+            CaskOperationProgress(
+                token: "firefox",
+                displayName: "Firefox",
+                action: .updating,
+                phase: .performing
+            )
+        ]
+
+        XCTAssertEqual(
+            CaskOperationStatus.make(operations: operations, updateAll: nil)?.message,
+            "2 operations in progress · 1 downloading · 1 updating"
+        )
+    }
+
+    func test_operation_status_appends_current_update_all_download() {
+        let operation = CaskOperationProgress(
+            token: "docker",
+            displayName: "Docker Desktop",
+            action: .updating,
+            phase: .downloading,
+            completedBytes: 84_000_000,
+            totalBytes: 245_000_000
+        )
+        let updateAll = CaskUpdateAllProgress(
+            currentIndex: 3,
+            totalCount: 8,
+            currentToken: "docker",
+            currentDisplayName: "Docker Desktop"
+        )
+        let message = CaskOperationStatus.make(
+            operations: [operation],
+            updateAll: updateAll
+        )?.message
+
+        XCTAssertEqual(
+            message,
+            "Updating 3 of 8 · Docker Desktop · 84 / 245 MB"
+        )
+    }
+
+    @MainActor
+    func test_progress_capsule_and_status_bar_render() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("progress-render"))
+        service.beginOperation(.installing, token: "plain")
+        service.consumeBrewOutput(
+            "Cask plain    ########    Downloading    84.0MB/245.0MB",
+            token: "plain"
+        )
+
+        render(CaskActionsView(cask: makeCask("plain")).environment(service))
+        render(CaskActionsView(cask: makeCask("plain"), fullWidth: false).environment(service))
+        render(
+            StatusBarView(
+                caskCount: 3_781,
+                caskFlowRelease: "caskflow-v2026.07.18",
+                operation: service.statusBarOperation
+            )
+        )
+    }
+
+    @MainActor
+    private func render(_ view: some View, width: CGFloat = 420, height: CGFloat = 400) {
+        let hosting = NSHostingView(rootView: AnyView(view))
+        hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        hosting.layoutSubtreeIfNeeded()
+    }
+}

--- a/CaskHubTests/ExternalApplicationOwnershipTests.swift
+++ b/CaskHubTests/ExternalApplicationOwnershipTests.swift
@@ -1,0 +1,144 @@
+//
+//  ExternalApplicationOwnershipTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 24/07/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+final class ExternalApplicationOwnershipTests: XCTestCase {
+    private let glaze = DetectedApplication(
+        url: URL(fileURLWithPath: "/Applications/Glaze.app"),
+        bundleName: "Glaze.app",
+        bundleIdentifier: "app.glaze.macos.main",
+        isMacAppStore: false,
+        isDirectlyInApplicationDirectory: true
+    )
+
+    private let glazeSignatures = [
+        ApplicationCaskSignature(
+            token: "glaze-app",
+            appBundleNames: ["Glaze.app"],
+            bundleIdentifiers: []
+        ),
+        ApplicationCaskSignature(
+            token: "raycast-glaze",
+            appBundleNames: ["Glaze.app"],
+            bundleIdentifiers: ["app.glaze.macos.main"]
+        )
+    ]
+
+    func test_shared_app_name_resolves_to_exact_bundle_identifier_match() {
+        let owners = LocalHomebrewService.resolveExternalApplicationOwners(
+            signatures: glazeSignatures,
+            applications: [glaze],
+            installedCasks: [:]
+        )
+
+        XCTAssertNil(owners["glaze-app"])
+        XCTAssertEqual(owners["raycast-glaze"], glaze)
+    }
+
+    func test_installed_cask_claims_shared_app_before_external_resolution() {
+        let installed = LocalCaskInstallation(
+            token: "raycast-glaze",
+            installedVersion: "0.11.1",
+            installedAt: nil,
+            appBundleNames: ["Glaze.app"]
+        )
+
+        let owners = LocalHomebrewService.resolveExternalApplicationOwners(
+            signatures: glazeSignatures,
+            applications: [glaze],
+            installedCasks: ["raycast-glaze": installed]
+        )
+
+        XCTAssertTrue(owners.isEmpty)
+    }
+
+    func test_shared_app_name_without_one_exact_identifier_match_is_not_adoptable() {
+        let application = DetectedApplication(
+            url: URL(fileURLWithPath: "/Applications/Shared.app"),
+            bundleName: "Shared.app",
+            bundleIdentifier: "com.example.shared",
+            isMacAppStore: false,
+            isDirectlyInApplicationDirectory: true
+        )
+        let signatures = [
+            ApplicationCaskSignature(
+                token: "shared-one",
+                appBundleNames: ["Shared.app"],
+                bundleIdentifiers: []
+            ),
+            ApplicationCaskSignature(
+                token: "shared-two",
+                appBundleNames: ["Shared.app"],
+                bundleIdentifiers: []
+            )
+        ]
+
+        let owners = LocalHomebrewService.resolveExternalApplicationOwners(
+            signatures: signatures,
+            applications: [application],
+            installedCasks: [:]
+        )
+
+        XCTAssertTrue(owners.isEmpty)
+    }
+
+    func test_unique_app_name_remains_adoptable_without_bundle_identifier_metadata() {
+        let application = DetectedApplication(
+            url: URL(fileURLWithPath: "/Applications/Unique.app"),
+            bundleName: "Unique.app",
+            bundleIdentifier: "com.example.unique",
+            isMacAppStore: false,
+            isDirectlyInApplicationDirectory: true
+        )
+        let signature = ApplicationCaskSignature(
+            token: "unique",
+            appBundleNames: ["Unique.app"],
+            bundleIdentifiers: []
+        )
+
+        let owners = LocalHomebrewService.resolveExternalApplicationOwners(
+            signatures: [signature],
+            applications: [application],
+            installedCasks: [:]
+        )
+
+        XCTAssertEqual(owners["unique"], application)
+    }
+
+    @MainActor
+    func test_catalog_resolution_exposes_only_raycast_glaze_for_adoption() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("glaze-ownership-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try makeApplicationBundle(
+            in: root,
+            named: "Glaze.app",
+            bundleIdentifier: "app.glaze.macos.main"
+        )
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("glaze-ownership"),
+            applicationDirectories: [root]
+        )
+        let glazeApp = makeCask("glaze-app", appNames: ["Glaze.app"])
+        let raycastGlaze = makeCask(
+            "raycast-glaze",
+            appNames: ["Glaze.app"],
+            applicationBundleIdentifiers: ["app.glaze.macos.main"]
+        )
+
+        await service.updatePackageCatalog([glazeApp, raycastGlaze])
+
+        XCTAssertFalse(service.isAdoptable(glazeApp))
+        XCTAssertTrue(service.isAdoptable(raycastGlaze))
+        XCTAssertEqual(
+            service.installationSource(for: raycastGlaze),
+            .externalApplication
+        )
+    }
+}

--- a/CaskHubTests/MutationRecoveryTests.swift
+++ b/CaskHubTests/MutationRecoveryTests.swift
@@ -12,6 +12,7 @@ import XCTest
 final class MutationRecoveryTests: XCTestCase {
     private let fileManager = FileManager.default
     private var root: URL!
+    private var defaults: UserDefaults!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -21,11 +22,11 @@ final class MutationRecoveryTests: XCTestCase {
             at: root.appendingPathComponent("Caskroom/zed/1.10.3"),
             withIntermediateDirectories: true
         )
-        UserDefaults.standard.set(root.path, forKey: LocalHomebrewService.customBrewPrefixKey)
+        defaults = makeScratchDefaults("repair-recovery-\(UUID().uuidString)")
+        defaults.set(root.path, forKey: LocalHomebrewService.customBrewPrefixKey)
     }
 
     override func tearDownWithError() throws {
-        UserDefaults.standard.removeObject(forKey: LocalHomebrewService.customBrewPrefixKey)
         try? fileManager.removeItem(at: root)
         try super.tearDownWithError()
     }
@@ -33,7 +34,7 @@ final class MutationRecoveryTests: XCTestCase {
     private func makeService(runner: StubBrewProcessRunner) -> LocalHomebrewService {
         LocalHomebrewService(
             fileManager: fileManager,
-            defaults: makeScratchDefaults("repair-recovery"),
+            defaults: defaults,
             applicationDirectories: [root.appendingPathComponent("Applications")],
             processRunner: runner,
             brewBinaryProvider: { URL(fileURLWithPath: "/test/bin/brew") },

--- a/CaskHubTests/ZombieDetectionTests.swift
+++ b/CaskHubTests/ZombieDetectionTests.swift
@@ -158,10 +158,10 @@ final class ZombieDetectionTests: XCTestCase {
         try fm.createDirectory(
             at: versionDir.appendingPathComponent("Tabby.app"), withIntermediateDirectories: true
         )
-        UserDefaults.standard.set(root.path, forKey: LocalHomebrewService.customBrewPrefixKey)
-        defer { UserDefaults.standard.removeObject(forKey: LocalHomebrewService.customBrewPrefixKey) }
+        let defaults = makeScratchDefaults("stranded-fs")
+        defaults.set(root.path, forKey: LocalHomebrewService.customBrewPrefixKey)
 
-        let service = LocalHomebrewService(defaults: makeScratchDefaults("stranded-fs"))
+        let service = LocalHomebrewService(defaults: defaults)
         let rewordedUpgrade = LocalHomebrewError.brewCommandFailed(
             args: ["upgrade", "--cask", "tabby"], exitCode: 1,
             stderr: "some future brew wording our strings don't match"


### PR DESCRIPTION
## Summary

- show cask download progress and remaining size in the install, adopt, and update capsule
- add passive single-operation, multi-operation, and update-all status to the bottom status bar
- preserve Homebrew output order and recognize both install and upgrade phase transitions
- split progress state, UI, and tests into focused files while keeping the compact 9 pt progress text

## Testing

- xcodebuild test -quiet -project CaskHub.xcodeproj -scheme CaskHub -configuration Debug -derivedDataPath /tmp/CaskHubDerivedData -destination platform=macOS,arch=arm64 CODE_SIGNING_ALLOWED=NO
- plutil -lint CaskHub.xcodeproj/project.pbxproj
- git diff --check