### PR TITLE
fix: Refine list action controls

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
 		ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */; };
 		FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */; };
+		F26000000000000000000001 /* CaskListActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26000000000000000000001 /* CaskListActionTests.swift */; };
 		F24000000000000000000003 /* CaskOperationProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000003 /* CaskOperationProgressTests.swift */; };
 		F24000000000000000000004 /* BrewProcessRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000004 /* BrewProcessRunnerTests.swift */; };
 		A12000000000000000000004 /* ZombieDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000004 /* ZombieDetectionTests.swift */; };
@@ -164,6 +165,7 @@
 		41EBDCEE2F37FD8C00BEABB8 /* CaskHubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaskHubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewTests.swift; sourceTree = "<group>"; };
 		8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdoptionTests.swift; sourceTree = "<group>"; };
+		E26000000000000000000001 /* CaskListActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskListActionTests.swift; sourceTree = "<group>"; };
 		E24000000000000000000003 /* CaskOperationProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskOperationProgressTests.swift; sourceTree = "<group>"; };
 		E24000000000000000000004 /* BrewProcessRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewProcessRunnerTests.swift; sourceTree = "<group>"; };
 		B12000000000000000000004 /* ZombieDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZombieDetectionTests.swift; sourceTree = "<group>"; };
@@ -374,6 +376,7 @@
 				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
 				ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */,
 				8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */,
+				E26000000000000000000001 /* CaskListActionTests.swift */,
 				E24000000000000000000003 /* CaskOperationProgressTests.swift */,
 				E24000000000000000000004 /* BrewProcessRunnerTests.swift */,
 				D13000000000000000000002 /* MutationRecoveryTests.swift */,
@@ -609,6 +612,7 @@
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,
 				FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */,
+				F26000000000000000000001 /* CaskListActionTests.swift in Sources */,
 				F24000000000000000000003 /* CaskOperationProgressTests.swift in Sources */,
 				F24000000000000000000004 /* BrewProcessRunnerTests.swift in Sources */,
 				C13000000000000000000002 /* MutationRecoveryTests.swift in Sources */,

--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -23,6 +23,8 @@ struct CaskActionsView: View {
     let cask: Cask
     var fullWidth = true
     var onUninstall: (() -> Void)?
+    var showsUninstallControl = true
+    var usesIconOnlyOpenAndUpdate = false
 
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @Environment(\.isAdoptPage) private var isAdoptPage
@@ -43,28 +45,30 @@ struct CaskActionsView: View {
                         }
                     }
                 } else {
-                    ActionCapsuleButton(action: .open, fullWidth: fullWidth) {
+                    openButton(fullWidth: fullWidth) {
                         localHomebrew.openExternalApp(cask: cask)
                     }
                 }
-                DisabledUninstallControl(
-                    message: "Adopt this app first so CaskHub can manage/uninstall it."
-                )
+                if showsUninstallControl,
+                   let reason = localHomebrew.uninstallAvailability(for: cask).unavailableReason {
+                    DisabledUninstallControl(message: reason)
+                }
             }
         } else if localHomebrew.isMacAppStoreInstalled(cask) {
             HStack(spacing: 8) {
-                ActionCapsuleButton(action: .open, fullWidth: fullWidth) {
+                openButton(fullWidth: fullWidth) {
                     localHomebrew.openExternalApp(cask: cask)
                 }
-                DisabledUninstallControl(
-                    message: "Installed from the Mac App Store. Uninstall it from Finder or Launchpad."
-                )
+                if showsUninstallControl,
+                   let reason = localHomebrew.uninstallAvailability(for: cask).unavailableReason {
+                    DisabledUninstallControl(message: reason)
+                }
             }
         } else if let externalPath = localHomebrew.externalCLIPath(cask) {
             ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
                 .help(
-                    "Installed outside Homebrew at \(externalPath.path). "
-                        + "Remove or move that file manually before installing the Homebrew version."
+                    localHomebrew.uninstallAvailability(for: cask).unavailableReason
+                        ?? "Installed outside Homebrew at \(externalPath.path)."
                 )
         } else {
             ActionCapsuleButton(action: .install, fullWidth: fullWidth) {
@@ -97,12 +101,15 @@ struct CaskActionsView: View {
 
         HStack(spacing: 8) {
             if canOpen {
-                ActionCapsuleButton(action: .open, fullWidth: fullWidth && !showUpdate) {
+                openButton(
+                    fullWidth: fullWidth && !showUpdate,
+                    isPairedWithUpdate: showUpdate
+                ) {
                     localHomebrew.open(cask)
                 }
             }
             if showUpdate {
-                ActionCapsuleButton(action: .update, fullWidth: fullWidth) {
+                updateButton(fullWidth: fullWidth) {
                     Task { try? await localHomebrew.upgrade(token: cask.token) }
                 }
             }
@@ -122,6 +129,28 @@ struct CaskActionsView: View {
                 }
                 .buttonStyle(.plain)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func openButton(
+        fullWidth: Bool,
+        isPairedWithUpdate: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        if usesIconOnlyOpenAndUpdate && isPairedWithUpdate {
+            ActionCapsuleIconButton(action: .open, onTap: action)
+        } else {
+            ActionCapsuleButton(action: .open, fullWidth: fullWidth, onTap: action)
+        }
+    }
+
+    @ViewBuilder
+    private func updateButton(fullWidth: Bool, action: @escaping () -> Void) -> some View {
+        if usesIconOnlyOpenAndUpdate {
+            ActionCapsuleIconButton(action: .update, onTap: action)
+        } else {
+            ActionCapsuleButton(action: .update, fullWidth: fullWidth, onTap: action)
         }
     }
 

--- a/CaskHub/DesignSystem/Components/Controls.swift
+++ b/CaskHub/DesignSystem/Components/Controls.swift
@@ -100,6 +100,27 @@ struct ActionCapsuleButton: View {
     }
 }
 
+struct ActionCapsuleIconButton: View {
+    let action: CaskActionStyle
+    var onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Image(systemName: action.icon)
+                .font(.system(size: action.iconSize, weight: .bold))
+                .foregroundStyle(action.foreground)
+                .frame(minWidth: 44, maxWidth: .infinity)
+                .frame(height: CHSize.actionCapsuleHeight)
+                .background(Capsule().fill(action.background))
+                .overlay(Capsule().strokeBorder(action.border, lineWidth: 1))
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help(action.title)
+        .accessibilityLabel(action.title)
+    }
+}
+
 struct CountBadge: View {
     let count: Int
 

--- a/CaskHub/DesignSystem/Tokens/SurfaceTokens.swift
+++ b/CaskHub/DesignSystem/Tokens/SurfaceTokens.swift
@@ -22,6 +22,7 @@ enum CHSize {
     static let cardHeight: CGFloat = 176
     static let heroHeight: CGFloat = 180
     static let actionCapsuleHeight: CGFloat = 28
+    static let listActionWidth: CGFloat = 110
 }
 
 enum CHSpace {

--- a/CaskHub/Services/LocalHomebrewService+State.swift
+++ b/CaskHub/Services/LocalHomebrewService+State.swift
@@ -82,6 +82,29 @@ extension LocalHomebrewService {
         return nil
     }
 
+    func uninstallAvailability(for cask: Cask) -> CaskUninstallAvailability {
+        if isInstalled(token: cask.token) {
+            return .available
+        }
+        if isAdoptable(cask) {
+            return .unavailable(
+                reason: "Adopt this app first so CaskHub can manage/uninstall it."
+            )
+        }
+        if isMacAppStoreInstalled(cask) {
+            return .unavailable(
+                reason: "Installed from the Mac App Store. Uninstall it from Finder or Launchpad."
+            )
+        }
+        if let externalPath = externalCLIPath(cask) {
+            return .unavailable(
+                reason: "Installed outside Homebrew at \(externalPath.path). "
+                    + "Remove or move that file manually before installing the Homebrew version."
+            )
+        }
+        return .notApplicable
+    }
+
     func isOutdated(token: String, remoteVersion: String) -> Bool {
         guard let installation = installedCasks[token], !installation.isZombie else { return false }
         return Self.comparableVersion(installation.installedVersion)

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -77,6 +77,17 @@ enum CaskInstallationSource: String, Equatable {
     case externalExecutable = "External executable"
 }
 
+enum CaskUninstallAvailability: Equatable {
+    case available
+    case unavailable(reason: String)
+    case notApplicable
+
+    var unavailableReason: String? {
+        guard case let .unavailable(reason) = self else { return nil }
+        return reason
+    }
+}
+
 struct LocalCaskInstallation: Hashable, Identifiable {
     let token: String
     let installedVersion: String

--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -112,7 +112,7 @@ struct CaskRowView: View {
     }
 }
 
-private struct CaskRowActionsMenuButton: NSViewRepresentable {
+struct CaskRowActionsMenuButton: NSViewRepresentable {
     let showsUpdate: Bool
     let isBusy: Bool
     let uninstallAvailability: CaskUninstallAvailability
@@ -163,19 +163,19 @@ private struct CaskRowActionsMenuButton: NSViewRepresentable {
             )
         }
 
-        @objc private func showInfo() {
+        @objc func showInfo() {
             configuration.onInfo()
         }
 
-        @objc private func update() {
+        @objc func update() {
             configuration.onUpdate()
         }
 
-        @objc private func uninstall() {
+        @objc func uninstall() {
             configuration.onUninstall()
         }
 
-        private func makeMenu() -> NSMenu {
+        func makeMenu() -> NSMenu {
             let menu = NSMenu()
             menu.autoenablesItems = false
             menu.addItem(

--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -5,6 +5,7 @@
 //  Created by Ali Elsokary on 21/02/2026.
 //
 
+import AppKit
 import SwiftUI
 
 struct CaskRowView: View {
@@ -13,6 +14,7 @@ struct CaskRowView: View {
 
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @State private var showDeleteConfirmation = false
+    @State private var showingInfo = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -21,7 +23,7 @@ struct CaskRowView: View {
             Spacer()
             metadata
             actionsControl
-                .frame(minWidth: 130, alignment: .trailing)
+                .frame(width: CHSize.listActionWidth, alignment: .trailing)
             menuSlot
                 .frame(width: 24)
         }
@@ -58,36 +60,190 @@ struct CaskRowView: View {
     // MARK: - Actions
 
     private var actionsControl: some View {
-        CaskActionsView(cask: cask, fullWidth: false)
+        CaskActionsView(
+            cask: cask,
+            fullWidth: true,
+            showsUninstallControl: false,
+            usesIconOnlyOpenAndUpdate: true
+        )
     }
 
-    @ViewBuilder
     private var menuSlot: some View {
-        if localHomebrew.isInstalled(token: cask.token),
-           localHomebrew.inFlightActions[cask.token] == nil {
-            installedActionsMenu
-        } else {
-            Color.clear
+        actionsMenu
+    }
+
+    private var actionsMenu: some View {
+        CaskRowActionsMenuButton(
+            showsUpdate: hasAvailableUpdate,
+            isBusy: isBusy,
+            uninstallAvailability: uninstallAvailability,
+            onInfo: {
+                DispatchQueue.main.async {
+                    showingInfo = true
+                }
+            },
+            onUpdate: {
+                Task { try? await localHomebrew.upgrade(token: cask.token) }
+            },
+            onUninstall: {
+                showDeleteConfirmation = true
+            }
+        )
+        .frame(width: 24, height: 24)
+        .popover(isPresented: $showingInfo) {
+            CaskInfoPopover(cask: cask)
         }
     }
 
-    private var installedActionsMenu: some View {
-        Menu {
-            Button(role: .destructive) {
-                showDeleteConfirmation = true
-            } label: {
-                Label("Uninstall", systemImage: "trash")
-            }
-        } label: {
-            Image(systemName: "ellipsis.circle")
-                .font(.body)
-                .foregroundStyle(Color.chTextMuted)
-                .padding(.horizontal, 6)
-                .contentShape(Rectangle())
+    private var hasAvailableUpdate: Bool {
+        localHomebrew.hasAvailableUpdate(
+            token: cask.token,
+            remoteVersion: cask.version,
+            autoUpdates: cask.autoUpdates
+        )
+    }
+
+    private var uninstallAvailability: CaskUninstallAvailability {
+        localHomebrew.uninstallAvailability(for: cask)
+    }
+
+    private var isBusy: Bool {
+        localHomebrew.inFlightActions[cask.token] != nil
+    }
+}
+
+private struct CaskRowActionsMenuButton: NSViewRepresentable {
+    let showsUpdate: Bool
+    let isBusy: Bool
+    let uninstallAvailability: CaskUninstallAvailability
+    let onInfo: () -> Void
+    let onUpdate: () -> Void
+    let onUninstall: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(configuration: self)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = NSButton()
+        button.isBordered = false
+        button.imagePosition = .imageOnly
+        button.imageScaling = .scaleProportionallyDown
+        button.image = NSImage(
+            systemSymbolName: "ellipsis.circle",
+            accessibilityDescription: "More actions"
+        )?.withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
+        button.contentTintColor = NSColor(Color.chTextMuted)
+        button.focusRingType = .none
+        button.toolTip = "More actions"
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.showMenu(_:))
+        button.setAccessibilityLabel("More actions")
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.configuration = self
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var configuration: CaskRowActionsMenuButton
+
+        init(configuration: CaskRowActionsMenuButton) {
+            self.configuration = configuration
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
+
+        @objc func showMenu(_ sender: NSButton) {
+            let menu = makeMenu()
+            menu.popUp(
+                positioning: nil,
+                at: NSPoint(x: sender.bounds.minX, y: sender.bounds.minY - 4),
+                in: sender
+            )
+        }
+
+        @objc private func showInfo() {
+            configuration.onInfo()
+        }
+
+        @objc private func update() {
+            configuration.onUpdate()
+        }
+
+        @objc private func uninstall() {
+            configuration.onUninstall()
+        }
+
+        private func makeMenu() -> NSMenu {
+            let menu = NSMenu()
+            menu.autoenablesItems = false
+            menu.addItem(
+                menuItem(
+                    title: "Info",
+                    systemImage: "info.circle",
+                    action: #selector(showInfo)
+                )
+            )
+
+            if configuration.showsUpdate {
+                menu.addItem(
+                    menuItem(
+                        title: "Update",
+                        systemImage: "arrow.clockwise",
+                        action: #selector(update),
+                        isEnabled: !configuration.isBusy,
+                        toolTip: configuration.isBusy
+                            ? "Wait for the current action to finish."
+                            : nil
+                    )
+                )
+            }
+
+            if configuration.uninstallAvailability != .notApplicable {
+                menu.addItem(.separator())
+                menu.addItem(uninstallMenuItem())
+            }
+            return menu
+        }
+
+        private func uninstallMenuItem() -> NSMenuItem {
+            let reason: String?
+            switch configuration.uninstallAvailability {
+            case .available:
+                reason = configuration.isBusy
+                    ? "Wait for the current action to finish."
+                    : nil
+            case let .unavailable(unavailableReason):
+                reason = unavailableReason
+            case .notApplicable:
+                reason = nil
+            }
+
+            return menuItem(
+                title: "Uninstall",
+                systemImage: "trash",
+                action: #selector(uninstall),
+                isEnabled: reason == nil,
+                toolTip: reason
+            )
+        }
+
+        private func menuItem(
+            title: String,
+            systemImage: String,
+            action: Selector,
+            isEnabled: Bool = true,
+            toolTip: String? = nil
+        ) -> NSMenuItem {
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+            item.target = self
+            item.image = NSImage(systemSymbolName: systemImage, accessibilityDescription: title)
+            item.isEnabled = isEnabled
+            item.toolTip = toolTip
+            item.setAccessibilityHelp(toolTip)
+            return item
+        }
     }
 }
 

--- a/CaskHubTests/AdoptionTests.swift
+++ b/CaskHubTests/AdoptionTests.swift
@@ -351,7 +351,10 @@ final class AdoptionViewRenderTests: XCTestCase {
 
         let adoptable = makeCask("chrome", appNames: ["Chrome.app"])
         render(CaskActionsView(cask: adoptable).environment(service).environment(\.isAdoptPage, true))
-        render(CaskActionsView(cask: adoptable).environment(service))
+        render(
+            CaskActionsView(cask: adoptable, usesIconOnlyOpenAndUpdate: true)
+                .environment(service)
+        )
         render(CaskActionsView(cask: makeCask("store", appNames: ["Store.app"])).environment(service))
         render(CaskActionsView(cask: makeCask("claude-code", binaryNames: ["claude"])).environment(service))
         render(CaskActionsView(cask: makeCask("plain")).environment(service))

--- a/CaskHubTests/CaskHubTests.swift
+++ b/CaskHubTests/CaskHubTests.swift
@@ -113,6 +113,31 @@ final class CaskHubTests: XCTestCase {
         XCTAssertNil(service.externalCLIPath(other))
     }
 
+    @MainActor
+    func test_uninstall_availability_explains_each_installed_source() {
+        let service = LocalHomebrewService()
+        let managed = makeCask("managed")
+        service.installedCasks[managed.token] = installation(managed.token, version: "1.0")
+        XCTAssertEqual(service.uninstallAvailability(for: managed), .available)
+
+        let adoptable = makeCask("adoptable", appNames: ["Adoptable.app"])
+        service.externalAppNames = ["Adoptable.app"]
+        let adoptHint = "Adopt this app first so CaskHub can manage/uninstall it."
+        XCTAssertEqual(service.uninstallAvailability(for: adoptable).unavailableReason, adoptHint)
+
+        let store = makeCask("store", appNames: ["Store.app"])
+        service.macAppStoreAppNames = ["Store.app"]
+        let storeHint = "Installed from the Mac App Store. Uninstall it from Finder or Launchpad."
+        XCTAssertEqual(service.uninstallAvailability(for: store).unavailableReason, storeHint)
+
+        let external = makeCask("external", binaryNames: ["external"])
+        service.externalBinaryPaths = ["external": URL(fileURLWithPath: "/usr/local/bin/external")]
+        let externalHint = "Installed outside Homebrew at /usr/local/bin/external. "
+            + "Remove or move that file manually before installing the Homebrew version."
+        XCTAssertEqual(service.uninstallAvailability(for: external).unavailableReason, externalHint)
+        XCTAssertEqual(service.uninstallAvailability(for: makeCask("missing")), .notApplicable)
+    }
+
     func test_binary_scan_detects_executables_in_homebrew_prefix() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("binary-scan-\(UUID().uuidString)")

--- a/CaskHubTests/CaskListActionTests.swift
+++ b/CaskHubTests/CaskListActionTests.swift
@@ -1,0 +1,199 @@
+//
+//  CaskListActionTests.swift
+//  CaskHubTests
+//
+
+@testable import CaskHub
+import SwiftUI
+import XCTest
+
+@MainActor
+final class CaskListActionTests: XCTestCase {
+    private final class ActionRecorder {
+        var calls: [String] = []
+    }
+
+    private func makeImageCache() -> ImageCacheService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RequestRecordingProtocol.self]
+        let cache = ImageCacheService(session: URLSession(configuration: configuration))
+        cache.knownIconTokens = { [] }
+        return cache
+    }
+
+    @discardableResult
+    private func render(
+        _ view: some View,
+        width: CGFloat = 760,
+        height: CGFloat = 64
+    ) -> NSHostingView<AnyView> {
+        let hosting = NSHostingView(rootView: AnyView(view))
+        hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        hosting.layoutSubtreeIfNeeded()
+        return hosting
+    }
+
+    private func row(
+        _ cask: Cask,
+        service: LocalHomebrewService,
+        downloads: String? = "1.2M"
+    ) -> some View {
+        CaskRowView(cask: cask, downloads: downloads)
+            .environment(service)
+            .environment(makeImageCache())
+    }
+
+    private func menuButton(
+        showsUpdate: Bool,
+        isBusy: Bool = false,
+        uninstallAvailability: CaskUninstallAvailability,
+        recorder: ActionRecorder = ActionRecorder()
+    ) -> CaskRowActionsMenuButton {
+        CaskRowActionsMenuButton(
+            showsUpdate: showsUpdate,
+            isBusy: isBusy,
+            uninstallAvailability: uninstallAvailability,
+            onInfo: { recorder.calls.append("info") },
+            onUpdate: { recorder.calls.append("update") },
+            onUninstall: { recorder.calls.append("uninstall") }
+        )
+    }
+
+    func test_row_action_menu_only_shows_info_when_uninstall_does_not_apply() {
+        let coordinator = menuButton(
+            showsUpdate: false,
+            uninstallAvailability: .notApplicable
+        ).makeCoordinator()
+
+        let menu = coordinator.makeMenu()
+
+        XCTAssertFalse(menu.autoenablesItems)
+        XCTAssertEqual(menu.items.map(\.title), ["Info"])
+        XCTAssertTrue(menu.items[0].isEnabled)
+        XCTAssertNotNil(menu.items[0].image)
+    }
+
+    func test_row_action_menu_enables_available_actions_and_invokes_callbacks() {
+        let recorder = ActionRecorder()
+        let coordinator = menuButton(
+            showsUpdate: true,
+            uninstallAvailability: .available,
+            recorder: recorder
+        ).makeCoordinator()
+
+        let menu = coordinator.makeMenu()
+
+        XCTAssertEqual(menu.items.map(\.title), ["Info", "Update", "", "Uninstall"])
+        XCTAssertTrue(menu.items[1].isEnabled)
+        XCTAssertNil(menu.items[1].toolTip)
+        XCTAssertTrue(menu.items[3].isEnabled)
+        XCTAssertNil(menu.items[3].toolTip)
+        XCTAssertNotNil(menu.items[1].image)
+        XCTAssertNotNil(menu.items[3].image)
+
+        coordinator.showInfo()
+        coordinator.update()
+        coordinator.uninstall()
+        XCTAssertEqual(recorder.calls, ["info", "update", "uninstall"])
+    }
+
+    func test_row_action_menu_disables_update_and_uninstall_while_busy() {
+        let coordinator = menuButton(
+            showsUpdate: true,
+            isBusy: true,
+            uninstallAvailability: .available
+        ).makeCoordinator()
+
+        let menu = coordinator.makeMenu()
+        let expectedHint = "Wait for the current action to finish."
+
+        XCTAssertFalse(menu.items[1].isEnabled)
+        XCTAssertEqual(menu.items[1].toolTip, expectedHint)
+        XCTAssertFalse(menu.items[3].isEnabled)
+        XCTAssertEqual(menu.items[3].toolTip, expectedHint)
+    }
+
+    func test_row_action_menu_preserves_unavailable_uninstall_hint() {
+        let hint = "Adopt this app first so CaskHub can manage/uninstall it."
+        let coordinator = menuButton(
+            showsUpdate: false,
+            uninstallAvailability: .unavailable(reason: hint)
+        ).makeCoordinator()
+
+        let menu = coordinator.makeMenu()
+
+        XCTAssertEqual(menu.items.map(\.title), ["Info", "", "Uninstall"])
+        XCTAssertFalse(menu.items[2].isEnabled)
+        XCTAssertEqual(menu.items[2].toolTip, hint)
+    }
+
+    func test_list_rows_render_install_and_external_installation_states() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("list-external"))
+        service.externalAppNames = ["Adoptable.app"]
+        service.macAppStoreAppNames = ["Store.app"]
+        service.externalBinaryPaths = ["native-cli": URL(fileURLWithPath: "/usr/local/bin/native-cli")]
+
+        render(row(makeCask("plain", desc: "A new app"), service: service))
+        render(row(makeCask("adoptable", appNames: ["Adoptable.app"]), service: service))
+        render(row(makeCask("store", appNames: ["Store.app"]), service: service))
+        render(row(makeCask("native", binaryNames: ["native-cli"]), service: service, downloads: nil))
+    }
+
+    func test_list_rows_render_every_managed_action_layout() throws {
+        let applications = FileManager.default.temporaryDirectory
+            .appendingPathComponent("list-action-apps-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: applications, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: applications) }
+        try makeApplicationBundle(
+            in: applications,
+            named: "Managed.app",
+            bundleIdentifier: "test.managed"
+        )
+
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("list-managed"),
+            applicationDirectories: [applications]
+        )
+        let managed = makeCask("managed", desc: "Managed app", appNames: ["Managed.app"])
+        service.installedCasks[managed.token] = LocalCaskInstallation(
+            token: managed.token,
+            installedVersion: "1.0",
+            installedAt: nil,
+            appBundleNames: ["Managed.app"]
+        )
+
+        render(row(managed, service: service))
+        render(row(makeCask("managed", version: "2.0", appNames: ["Managed.app"]), service: service))
+
+        service.inFlightActions[managed.token] = .updating
+        render(row(managed, service: service))
+        service.inFlightActions[managed.token] = nil
+
+        let installedOnly = makeCask("installed-only")
+        service.installedCasks[installedOnly.token] = installation(installedOnly.token, version: "1.0")
+        render(row(installedOnly, service: service))
+
+        let updateOnly = makeCask("update-only", version: "2.0")
+        service.installedCasks[updateOnly.token] = installation(updateOnly.token, version: "1.0")
+        render(row(updateOnly, service: service))
+
+        let zombie = makeCask("zombie", appNames: ["Missing.app"])
+        service.installedCasks[zombie.token] = LocalCaskInstallation(
+            token: zombie.token,
+            installedVersion: "1.0",
+            installedAt: nil,
+            appBundleNames: ["Missing.app"],
+            isZombie: true
+        )
+        render(row(zombie, service: service))
+    }
+
+    func test_icon_only_open_and_update_controls_render() {
+        render(
+            HStack {
+                ActionCapsuleIconButton(action: .open) {}
+                ActionCapsuleIconButton(action: .update) {}
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Standardize the list action column and compact Open/Update sizing
- Show a labeled full-width Open action when it is the only row action
- Move Info, conditional Update, and Uninstall into the three-dot menu
- Preserve disabled uninstall explanations with native macOS menu tooltips
- Centralize uninstall availability across managed and externally installed apps

## Testing
- xcodebuild test -project CaskHub.xcodeproj -scheme CaskHub -destination platform=macOS -derivedDataPath /tmp/CaskHubDesignDerived -only-testing:CaskHubTests/AdoptionViewRenderTests CODE_SIGNING_ALLOWED=NO
- focused uninstall availability test passed during implementation
- git diff --check