### PR TITLE
fix: Cached cask download progress states

### DIFF
--- a/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
+++ b/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
@@ -17,17 +17,17 @@ struct CaskOperationCapsule: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            if fractionCompleted == nil {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
+            if showsDownloadIcon {
                 Image(systemName: "arrow.down")
                     .font(.system(size: 9, weight: .bold))
                     .foregroundStyle(accentColor)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
             }
 
-            if let byteProgress = downloadingByteProgress {
-                Text("Downloading")
+            if let byteProgress = downloadByteProgress {
+                Text(progress?.phase.label(for: action) ?? "Downloading")
                     .font(CHType.downloadLabel)
                     .foregroundStyle(Color.chTextBody)
                     .lineLimit(1)
@@ -47,7 +47,7 @@ struct CaskOperationCapsule: View {
             }
 
             if canCancel {
-                if downloadingByteProgress == nil {
+                if downloadByteProgress == nil {
                     Spacer(minLength: 0)
                 }
                 Button(action: onCancel) {
@@ -60,7 +60,7 @@ struct CaskOperationCapsule: View {
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
-                .help("Cancel download")
+                .help("Cancel operation")
             }
         }
         .frame(
@@ -77,6 +77,8 @@ struct CaskOperationCapsule: View {
                         fraction: fractionCompleted,
                         color: accentColor.opacity(0.18)
                     )
+                } else if showsIndeterminateDownloadFill {
+                    IndeterminateProgressFill(color: accentColor.opacity(0.18))
                 }
             }
         }
@@ -95,8 +97,8 @@ struct CaskOperationCapsule: View {
         }
     }
 
-    private var downloadingByteProgress: CaskByteProgress? {
-        guard !isCanceling, progress?.phase == .downloading else { return nil }
+    private var downloadByteProgress: CaskByteProgress? {
+        guard !isCanceling, progress?.phase.showsByteProgress == true else { return nil }
         return progress?.byteProgress
     }
 
@@ -108,8 +110,16 @@ struct CaskOperationCapsule: View {
     }
 
     private var fractionCompleted: Double? {
-        guard !isCanceling, progress?.phase == .downloading else { return nil }
+        guard !isCanceling, progress?.phase.showsByteProgress == true else { return nil }
         return progress?.fractionCompleted
+    }
+
+    private var showsDownloadIcon: Bool {
+        !isCanceling && progress?.phase.isDownloadActivity == true
+    }
+
+    private var showsIndeterminateDownloadFill: Bool {
+        showsDownloadIcon && fractionCompleted == nil
     }
 
     private var accentColor: Color {
@@ -121,6 +131,35 @@ struct CaskOperationCapsule: View {
         default:
             return .chTextBrand
         }
+    }
+}
+
+private struct IndeterminateProgressFill: View {
+    let color: Color
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isAnimating = false
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = max(proxy.size.width * 0.34, 24)
+
+            Capsule()
+                .fill(color)
+                .frame(width: width)
+                .offset(
+                    x: reduceMotion
+                        ? 0
+                        : (isAnimating ? proxy.size.width : -width)
+                )
+                .onAppear {
+                    guard !reduceMotion else { return }
+                    withAnimation(.linear(duration: 1.15).repeatForever(autoreverses: false)) {
+                        isAnimating = true
+                    }
+                }
+        }
+        .clipShape(Capsule())
     }
 }
 

--- a/CaskHub/Services/CaskOperationProgress.swift
+++ b/CaskHub/Services/CaskOperationProgress.swift
@@ -10,7 +10,9 @@ import Foundation
 enum CaskOperationPhase: Equatable {
     case queued
     case preparing
+    case checkingDownload
     case downloading
+    case usingCachedDownload
     case verifying
     case performing
     case canceling
@@ -21,8 +23,12 @@ enum CaskOperationPhase: Equatable {
             return "Queued"
         case .preparing:
             return "Preparing"
+        case .checkingDownload:
+            return "Checking download"
         case .downloading:
             return "Downloading"
+        case .usingCachedDownload:
+            return "Using cache"
         case .verifying:
             return "Verifying"
         case .performing:
@@ -30,6 +36,19 @@ enum CaskOperationPhase: Equatable {
         case .canceling:
             return "Canceling"
         }
+    }
+
+    var isDownloadActivity: Bool {
+        switch self {
+        case .checkingDownload, .downloading, .usingCachedDownload:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var showsByteProgress: Bool {
+        self == .downloading || self == .usingCachedDownload
     }
 }
 
@@ -56,7 +75,7 @@ struct CaskOperationProgress: Equatable {
 
     var inlineLabel: String {
         let phaseLabel = phase.label(for: action)
-        guard phase == .downloading, let byteProgressText else {
+        guard phase.showsByteProgress, let byteProgressText else {
             return "\(phaseLabel)…"
         }
         return "\(phaseLabel) · \(byteProgressText)"
@@ -162,7 +181,9 @@ struct CaskOperationStatus: Equatable {
                 updateAll.currentDisplayName
             ].joined(separator: " · ")
             let current = operations.first(where: { $0.token == updateAll.currentToken })
-            let byteProgress = current?.phase == .downloading ? current?.byteProgress : nil
+            let byteProgress = current?.phase.showsByteProgress == true
+                ? current?.byteProgress
+                : nil
             return CaskOperationStatus(label: label, byteProgress: byteProgress)
         }
 
@@ -173,7 +194,7 @@ struct CaskOperationStatus: Equatable {
         guard !sortedOperations.isEmpty else { return nil }
 
         if sortedOperations.count == 1, let operation = sortedOperations.first {
-            let byteProgress = operation.phase == .downloading ? operation.byteProgress : nil
+            let byteProgress = operation.phase.showsByteProgress ? operation.byteProgress : nil
             var label = "\(operation.phase.label(for: operation.action)) \(operation.displayName)"
             if byteProgress == nil { label += "…" }
             return CaskOperationStatus(label: label, byteProgress: byteProgress)
@@ -185,8 +206,9 @@ struct CaskOperationStatus: Equatable {
             counts[label, default: 0] += 1
         }
         let phaseOrder = [
-            "downloading", "verifying", "installing", "updating", "adopting",
-            "uninstalling", "repairing", "preparing", "canceling", "queued"
+            "downloading", "checking download", "using cache", "verifying", "installing",
+            "updating", "adopting", "uninstalling", "repairing", "preparing",
+            "canceling", "queued"
         ]
         let details = phaseOrder.compactMap { label -> String? in
             guard let count = counts[label], count > 0 else { return nil }
@@ -198,32 +220,88 @@ struct CaskOperationStatus: Equatable {
 }
 
 nonisolated enum BrewProgressParser {
+    struct Update {
+        let phase: CaskOperationPhase?
+        let byteProgress: (completed: Int64, total: Int64)?
+        let cachedDownloadPath: String?
+    }
+
     private static let progressPattern =
         #"Downloading\s+([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)\s*/\s*([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)"#
 
-    static func byteProgress(in output: String) -> (completed: Int64, total: Int64)? {
-        guard let expression = try? NSRegularExpression(pattern: progressPattern) else { return nil }
-        let range = NSRange(output.startIndex..<output.endIndex, in: output)
-        guard let match = expression.matches(in: output, range: range).last,
-              let completed = value(in: output, match: match, valueGroup: 1, unitGroup: 2),
-              let total = value(in: output, match: match, valueGroup: 3, unitGroup: 4)
-        else { return nil }
-        return (completed, total)
-    }
+    static func parse(_ output: String) -> Update {
+        let progressMatch = progressMatches(in: output).last
+        let byteProgress = progressMatch.flatMap { match -> (Int64, Int64)? in
+            guard
+                let completed = value(
+                    in: output,
+                    match: match,
+                    valueGroup: 1,
+                    unitGroup: 2
+                ),
+                let total = value(
+                    in: output,
+                    match: match,
+                    valueGroup: 3,
+                    unitGroup: 4
+                )
+            else { return nil }
+            return (completed, total)
+        }
 
-    static func latestPhase(in output: String) -> CaskOperationPhase? {
+        var events: [(String.Index, CaskOperationPhase)] = []
+        if let match = progressMatch,
+           let range = Range(match.range, in: output) {
+            events.append((range.lowerBound, .downloading))
+        }
+
         let markers: [(String, CaskOperationPhase)] = [
-            ("Downloading", .downloading),
+            ("==> Downloading ", .checkingDownload),
+            ("Already downloaded:", .usingCachedDownload),
             (" Verifying ", .verifying),
             ("Verifying checksum", .verifying),
             ("==> Installing Cask", .performing),
             ("==> Upgrading ", .performing)
         ]
-        return markers.compactMap { marker, phase in
-            output.range(of: marker, options: .backwards).map { ($0.lowerBound, phase) }
+        events += markers.compactMap { marker, phase in
+            output.range(of: marker, options: .backwards).map {
+                ($0.lowerBound, phase)
+            }
         }
-        .max { $0.0 < $1.0 }?
-        .1
+
+        let phase = events.max { $0.0 < $1.0 }?.1
+        let cachedPath: String?
+        switch phase {
+        case .usingCachedDownload:
+            cachedPath = cachedDownloadPath(in: output)
+        default:
+            cachedPath = nil
+        }
+
+        return Update(
+            phase: phase,
+            byteProgress: byteProgress,
+            cachedDownloadPath: cachedPath
+        )
+    }
+
+    private static func progressMatches(in output: String) -> [NSTextCheckingResult] {
+        guard let expression = try? NSRegularExpression(pattern: progressPattern) else {
+            return []
+        }
+        let range = NSRange(output.startIndex..<output.endIndex, in: output)
+        return expression.matches(in: output, range: range)
+    }
+
+    private static func cachedDownloadPath(in output: String) -> String? {
+        let prefix = "Already downloaded:"
+        guard let line = output.components(separatedBy: .newlines).reversed().first(where: {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix(prefix)
+        }) else { return nil }
+
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let path = trimmed.dropFirst(prefix.count).trimmingCharacters(in: .whitespaces)
+        return path.hasPrefix("/") ? path : nil
     }
 
     private static func value(

--- a/CaskHub/Services/CaskOperationProgress.swift
+++ b/CaskHub/Services/CaskOperationProgress.swift
@@ -231,22 +231,8 @@ nonisolated enum BrewProgressParser {
 
     static func parse(_ output: String) -> Update {
         let progressMatch = progressMatches(in: output).last
-        let byteProgress = progressMatch.flatMap { match -> (Int64, Int64)? in
-            guard
-                let completed = value(
-                    in: output,
-                    match: match,
-                    valueGroup: 1,
-                    unitGroup: 2
-                ),
-                let total = value(
-                    in: output,
-                    match: match,
-                    valueGroup: 3,
-                    unitGroup: 4
-                )
-            else { return nil }
-            return (completed, total)
+        let byteProgress = progressMatch.flatMap {
+            parsedByteProgress(in: output, match: $0)
         }
 
         var events: [(String.Index, CaskOperationPhase)] = []
@@ -283,6 +269,17 @@ nonisolated enum BrewProgressParser {
             byteProgress: byteProgress,
             cachedDownloadPath: cachedPath
         )
+    }
+
+    private static func parsedByteProgress(
+        in output: String,
+        match: NSTextCheckingResult
+    ) -> (completed: Int64, total: Int64)? {
+        guard
+            let completed = value(in: output, match: match, valueGroup: 1, unitGroup: 2),
+            let total = value(in: output, match: match, valueGroup: 3, unitGroup: 4)
+        else { return nil }
+        return (completed, total)
     }
 
     private static func progressMatches(in output: String) -> [NSTextCheckingResult] {

--- a/CaskHub/Services/LocalHomebrewService+Mutations.swift
+++ b/CaskHub/Services/LocalHomebrewService+Mutations.swift
@@ -157,7 +157,12 @@ extension LocalHomebrewService {
         let buffered = String(((brewOutputBuffers[token] ?? "") + output).suffix(6_000))
         brewOutputBuffers[token] = buffered
 
-        if let bytes = BrewProgressParser.byteProgress(in: buffered) {
+        let update = BrewProgressParser.parse(buffered)
+        if update.phase == .checkingDownload {
+            progress.completedBytes = nil
+            progress.totalBytes = nil
+        }
+        if let bytes = update.byteProgress {
             let now = Date()
             let shouldPublish = lastProgressUpdates[token].map {
                 now.timeIntervalSince($0) >= 0.10
@@ -169,7 +174,18 @@ extension LocalHomebrewService {
                 lastProgressUpdates[token] = now
             }
         }
-        if let phase = BrewProgressParser.latestPhase(in: buffered) {
+        if update.phase == .usingCachedDownload {
+            progress.completedBytes = nil
+            progress.totalBytes = nil
+            if let path = update.cachedDownloadPath,
+               let attributes = try? fileManager.attributesOfItem(atPath: path),
+               let size = attributes[.size] as? NSNumber,
+               size.int64Value > 0 {
+                progress.completedBytes = size.int64Value
+                progress.totalBytes = size.int64Value
+            }
+        }
+        if let phase = update.phase {
             progress.phase = phase
             if phase == .performing {
                 cancellableDownloads.remove(token)

--- a/CaskHubTests/CaskOperationProgressTests.swift
+++ b/CaskHubTests/CaskOperationProgressTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class CaskOperationProgressTests: XCTestCase {
     func test_brew_progress_parser_reads_homebrew_byte_totals() throws {
         let output = "Cask docker-desktop    #######    Downloading    84.2MB/245.0MB"
-        let progress = try XCTUnwrap(BrewProgressParser.byteProgress(in: output))
+        let progress = try XCTUnwrap(BrewProgressParser.parse(output).byteProgress)
 
         XCTAssertEqual(progress.completed, 84_200_000)
         XCTAssertEqual(progress.total, 245_000_000)
@@ -35,6 +35,16 @@ final class CaskOperationProgressTests: XCTestCase {
         service.cancellableDownloads.insert("firefox")
 
         service.consumeBrewOutput(
+            "==> Downloading https://example.com/firefox.dmg",
+            token: "firefox"
+        )
+        XCTAssertEqual(service.operationProgress["firefox"]?.phase, .checkingDownload)
+        XCTAssertEqual(
+            service.operationProgress["firefox"]?.inlineLabel,
+            "Checking download…"
+        )
+
+        service.consumeBrewOutput(
             "Cask firefox    ########    Downloading    42.0MB/100.0MB",
             token: "firefox"
         )
@@ -48,6 +58,40 @@ final class CaskOperationProgressTests: XCTestCase {
         service.consumeBrewOutput("==> Installing Cask firefox", token: "firefox")
         XCTAssertEqual(service.operationProgress["firefox"]?.phase, .performing)
         XCTAssertFalse(service.cancellableDownloads.contains("firefox"))
+    }
+
+    @MainActor
+    func test_brew_output_reports_cached_download_at_full_size() throws {
+        let cachedDownload = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cached download-\(UUID().uuidString).dmg")
+        try Data(repeating: 0, count: 2_048).write(to: cachedDownload)
+        defer { try? FileManager.default.removeItem(at: cachedDownload) }
+
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("cached-progress"))
+        service.beginOperation(.installing, token: "chatgpt-classic")
+        service.consumeBrewOutput(
+            """
+            ==> Downloading https://example.com/ChatGPT_Classic.dmg
+            Already downloaded: \(cachedDownload.path)
+            """,
+            token: "chatgpt-classic"
+        )
+
+        let progress = try XCTUnwrap(service.operationProgress["chatgpt-classic"])
+        XCTAssertEqual(progress.phase, .usingCachedDownload)
+        XCTAssertEqual(progress.completedBytes, 2_048)
+        XCTAssertEqual(progress.totalBytes, 2_048)
+        XCTAssertEqual(progress.fractionCompleted, 1)
+        XCTAssertEqual(progress.inlineLabel, "Using cache · 2 / 2 KB")
+    }
+
+    func test_phase_parser_does_not_treat_download_preflight_as_byte_transfer() {
+        let update = BrewProgressParser.parse(
+            "==> Downloading https://example.com/ChatGPT_Classic.dmg"
+        )
+
+        XCTAssertEqual(update.phase, .checkingDownload)
+        XCTAssertNil(update.byteProgress)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- Distinguish Homebrew download preflight from real byte transfer
- Show cache hits with the cached file size and a completed determinate bar
- Keep the modern progress capsule active during indeterminate download checks
- Add parser, service, status, and rendering coverage

## Testing

- `xcodebuild test -quiet -project CaskHub.xcodeproj -scheme CaskHub -configuration Debug -destination "platform=macOS" -derivedDataPath .build/test-derived-data`