### PR TITLE
refactor: Improve catalog, sidebar, and layout performance

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000001 /* LocalHomebrewTypes.swift */; };
 		F24000000000000000000001 /* CaskOperationProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000001 /* CaskOperationProgress.swift */; };
 		A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000002 /* LocalHomebrewService+State.swift */; };
+		F28000000000000000000002 /* LocalHomebrewService+InstallationIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28000000000000000000001 /* LocalHomebrewService+InstallationIndex.swift */; };
 		A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */; };
 		C13000000000000000000001 /* LocalHomebrewService+Mutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */; };
 		C13000000000000000000002 /* MutationRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13000000000000000000002 /* MutationRecoveryTests.swift */; };
@@ -141,6 +142,7 @@
 		B12000000000000000000001 /* LocalHomebrewTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewTypes.swift; sourceTree = "<group>"; };
 		E24000000000000000000001 /* CaskOperationProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskOperationProgress.swift; sourceTree = "<group>"; };
 		B12000000000000000000002 /* LocalHomebrewService+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+State.swift"; sourceTree = "<group>"; };
+		F28000000000000000000001 /* LocalHomebrewService+InstallationIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+InstallationIndex.swift"; sourceTree = "<group>"; };
 		B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Adoption.swift"; sourceTree = "<group>"; };
 		D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Mutations.swift"; sourceTree = "<group>"; };
 		D13000000000000000000002 /* MutationRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRecoveryTests.swift; sourceTree = "<group>"; };
@@ -296,6 +298,7 @@
 				B12000000000000000000001 /* LocalHomebrewTypes.swift */,
 				E24000000000000000000001 /* CaskOperationProgress.swift */,
 				B12000000000000000000002 /* LocalHomebrewService+State.swift */,
+				F28000000000000000000001 /* LocalHomebrewService+InstallationIndex.swift */,
 				B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */,
 				D13000000000000000000001 /* LocalHomebrewService+Mutations.swift */,
 				41DFD47430028F7D00608C7A /* RecentlyAddedService.swift */,
@@ -587,6 +590,7 @@
 				A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */,
 				F24000000000000000000001 /* CaskOperationProgress.swift in Sources */,
 				A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */,
+				F28000000000000000000002 /* LocalHomebrewService+InstallationIndex.swift in Sources */,
 				A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */,
 				C13000000000000000000001 /* LocalHomebrewService+Mutations.swift in Sources */,
 				41DFD4A630028F7D00608C7A /* RecentlyAddedService.swift in Sources */,

--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		C13000000000000000000002 /* MutationRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13000000000000000000002 /* MutationRecoveryTests.swift */; };
 		41DFD4A630028F7D00608C7A /* RecentlyAddedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47430028F7D00608C7A /* RecentlyAddedService.swift */; };
 		41DFD4A730028F7D00608C7A /* CaskCatalogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47630028F7D00608C7A /* CaskCatalogViewModel.swift */; };
+		F27000000000000000000002 /* CatalogProjectionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27000000000000000000001 /* CatalogProjectionCache.swift */; };
+		F27000000000000000000004 /* CaskCatalogViewModel+Projection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27000000000000000000003 /* CaskCatalogViewModel+Projection.swift */; };
 		41DFD4A830028F7D00608C7A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47830028F7D00608C7A /* SettingsView.swift */; };
 		41DFD4E230028F7D00608C7A /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4E130028F7D00608C7A /* AppearanceSettingsView.swift */; };
 		41DFD4A930028F7D00608C7A /* CaskActionAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47A30028F7D00608C7A /* CaskActionAlerts.swift */; };
@@ -144,6 +146,8 @@
 		D13000000000000000000002 /* MutationRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationRecoveryTests.swift; sourceTree = "<group>"; };
 		41DFD47430028F7D00608C7A /* RecentlyAddedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyAddedService.swift; sourceTree = "<group>"; };
 		41DFD47630028F7D00608C7A /* CaskCatalogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogViewModel.swift; sourceTree = "<group>"; };
+		F27000000000000000000001 /* CatalogProjectionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogProjectionCache.swift; sourceTree = "<group>"; };
+		F27000000000000000000003 /* CaskCatalogViewModel+Projection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaskCatalogViewModel+Projection.swift"; sourceTree = "<group>"; };
 		41DFD47830028F7D00608C7A /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		41DFD4E130028F7D00608C7A /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		41DFD47A30028F7D00608C7A /* CaskActionAlerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskActionAlerts.swift; sourceTree = "<group>"; };
@@ -304,6 +308,8 @@
 			isa = PBXGroup;
 			children = (
 				41DFD47630028F7D00608C7A /* CaskCatalogViewModel.swift */,
+				F27000000000000000000001 /* CatalogProjectionCache.swift */,
+				F27000000000000000000003 /* CaskCatalogViewModel+Projection.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -586,6 +592,8 @@
 				41DFD4A630028F7D00608C7A /* RecentlyAddedService.swift in Sources */,
 				41AD10312F68D00200BEABB8 /* UpdaterService.swift in Sources */,
 				41DFD4A730028F7D00608C7A /* CaskCatalogViewModel.swift in Sources */,
+				F27000000000000000000002 /* CatalogProjectionCache.swift in Sources */,
+				F27000000000000000000004 /* CaskCatalogViewModel+Projection.swift in Sources */,
 				41DFD4A830028F7D00608C7A /* SettingsView.swift in Sources */,
 				41DFD4E230028F7D00608C7A /* AppearanceSettingsView.swift in Sources */,
 				41DFD4A930028F7D00608C7A /* CaskActionAlerts.swift in Sources */,

--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -21,6 +21,7 @@ extension EnvironmentValues {
 
 struct CaskActionsView: View {
     let cask: Cask
+    var localState: CaskLocalState?
     var fullWidth = true
     var onUninstall: (() -> Void)?
     var showsUninstallControl = true
@@ -30,15 +31,16 @@ struct CaskActionsView: View {
     @Environment(\.isAdoptPage) private var isAdoptPage
 
     var body: some View {
+        let state = localState ?? localHomebrew.localState(for: cask)
         if let inFlight = localHomebrew.inFlightActions[cask.token] {
             inFlightCapsule(for: inFlight)
-        } else if localHomebrew.installedCasks[cask.token] != nil {
-            installedActions
-        } else if localHomebrew.isAdoptable(cask) {
+        } else if state.isHomebrewInstalled {
+            installedActions(state)
+        } else if state.isAdoptable {
             HStack(spacing: 8) {
                 if isAdoptPage {
                     ActionCapsuleButton(action: .adopt, fullWidth: fullWidth) {
-                        if localHomebrew.isExternalPackageInstalled(cask) {
+                        if state.isExternalPackage {
                             localHomebrew.requestPackageAdoption(token: cask.token)
                         } else {
                             Task { try? await localHomebrew.adopt(cask) }
@@ -50,24 +52,24 @@ struct CaskActionsView: View {
                     }
                 }
                 if showsUninstallControl,
-                   let reason = localHomebrew.uninstallAvailability(for: cask).unavailableReason {
+                   let reason = state.uninstallAvailability.unavailableReason {
                     DisabledUninstallControl(message: reason)
                 }
             }
-        } else if localHomebrew.isMacAppStoreInstalled(cask) {
+        } else if state.installationSource == .macAppStore {
             HStack(spacing: 8) {
                 openButton(fullWidth: fullWidth) {
                     localHomebrew.openExternalApp(cask: cask)
                 }
                 if showsUninstallControl,
-                   let reason = localHomebrew.uninstallAvailability(for: cask).unavailableReason {
+                   let reason = state.uninstallAvailability.unavailableReason {
                     DisabledUninstallControl(message: reason)
                 }
             }
-        } else if let externalPath = localHomebrew.externalCLIPath(cask) {
+        } else if let externalPath = state.externalCLIPath {
             ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
                 .help(
-                    localHomebrew.uninstallAvailability(for: cask).unavailableReason
+                    state.uninstallAvailability.unavailableReason
                         ?? "Installed outside Homebrew at \(externalPath.path)."
                 )
         } else {
@@ -78,8 +80,8 @@ struct CaskActionsView: View {
     }
 
     @ViewBuilder
-    private var installedActions: some View {
-        if localHomebrew.isZombie(cask) {
+    private func installedActions(_ state: CaskLocalState) -> some View {
+        if state.isZombie {
             ActionCapsuleButton(action: .cleanup, fullWidth: fullWidth) {
                 Task { try? await localHomebrew.repair(token: cask.token) }
             }
@@ -88,32 +90,27 @@ struct CaskActionsView: View {
             has records for it. Clean Up removes the leftover data.
             """)
         } else {
-            managedActions
+            managedActions(state)
         }
     }
 
     @ViewBuilder
-    private var managedActions: some View {
-        let showUpdate = localHomebrew.hasAvailableUpdate(
-            token: cask.token, remoteVersion: cask.version, autoUpdates: cask.autoUpdates
-        )
-        let canOpen = localHomebrew.canOpen(cask)
-
+    private func managedActions(_ state: CaskLocalState) -> some View {
         HStack(spacing: 8) {
-            if canOpen {
+            if state.canOpen {
                 openButton(
-                    fullWidth: fullWidth && !showUpdate,
-                    isPairedWithUpdate: showUpdate
+                    fullWidth: fullWidth && !state.hasAvailableUpdate,
+                    isPairedWithUpdate: state.hasAvailableUpdate
                 ) {
                     localHomebrew.open(cask)
                 }
             }
-            if showUpdate {
+            if state.hasAvailableUpdate {
                 updateButton(fullWidth: fullWidth) {
                     Task { try? await localHomebrew.upgrade(token: cask.token) }
                 }
             }
-            if !canOpen && !showUpdate {
+            if !state.canOpen && !state.hasAvailableUpdate {
                 ActionCapsuleLabel(action: .installed, fullWidth: fullWidth)
             }
             if let onUninstall {

--- a/CaskHub/DesignSystem/Components/HeroCard.swift
+++ b/CaskHub/DesignSystem/Components/HeroCard.swift
@@ -11,6 +11,7 @@ struct HeroCard: View {
     let cask: Cask
     var downloads: String?
     var categoryName: String?
+    var localState: CaskLocalState?
 
     var body: some View {
         HStack(spacing: 28) {
@@ -35,7 +36,7 @@ struct HeroCard: View {
                 }
 
                 HStack(spacing: 14) {
-                    CaskActionsView(cask: cask, fullWidth: false)
+                    CaskActionsView(cask: cask, localState: localState, fullWidth: false)
                     Text(metaLine)
                         .font(CHType.statusMono)
                         .foregroundStyle(Color.chTextMuted)

--- a/CaskHub/DesignSystem/Components/StatusBarView.swift
+++ b/CaskHub/DesignSystem/Components/StatusBarView.swift
@@ -7,6 +7,25 @@
 
 import SwiftUI
 
+/// Owns high-frequency operation observation so byte-progress changes invalidate
+/// only the status bar, never the catalog root or its scroll containers.
+struct ObservedStatusBarView: View {
+    var caskCount: Int
+    var brewVersion: String?
+    var caskFlowRelease: String?
+
+    @Environment(LocalHomebrewService.self) private var localHomebrew
+
+    var body: some View {
+        StatusBarView(
+            caskCount: caskCount,
+            brewVersion: brewVersion,
+            caskFlowRelease: caskFlowRelease,
+            operation: localHomebrew.statusBarOperation
+        )
+    }
+}
+
 struct StatusBarView: View {
     var caskCount: Int
     var brewVersion: String?

--- a/CaskHub/Services/CategoryService.swift
+++ b/CaskHub/Services/CategoryService.swift
@@ -42,6 +42,7 @@ final class CategoryService {
     private(set) var generatedDate: String = ""
     private(set) var releaseTag: String?
     private(set) var iconTokens: Set<String>?
+    private(set) var catalogStateRevision = 0
 
     var orderedCategories: [(id: CategoryID, definition: CategoryDefinition)] {
         categoryDefinitions
@@ -88,6 +89,7 @@ final class CategoryService {
         generatedDate = catalog.generatedDate
         releaseTag = catalog.releaseTag
         iconTokens = catalog.iconTokens.map(Set.init)
+        catalogStateRevision &+= 1
     }
 
     func category(for token: String) -> CategoryID? {

--- a/CaskHub/Services/LocalHomebrewService+ExternalApps.swift
+++ b/CaskHub/Services/LocalHomebrewService+ExternalApps.swift
@@ -13,41 +13,37 @@ extension LocalHomebrewService {
         packageCatalogGeneration &+= 1
         let packageGeneration = packageCatalogGeneration
 
-        let appSignatures = applicationCaskSignatures
-        let catalog = installationCatalog
         let packageSignatures = packageCaskSignatures
-        let installed = installedCasks
-        let binaryPaths = externalBinaryPaths
         let fm = fileManager
         let appDirs = applicationDirectories
-        let result = await Task.detached(priority: .userInitiated) {
+        let (applications, packages) = await Task.detached(priority: .userInitiated) {
             let applications = Self.scanApplications(fileManager: fm, directories: appDirs)
             let packages = packageSignatures.isEmpty ? [:] : Self.scanExternalPackageInstallations(
                 signatures: packageSignatures,
                 availableAppNames: applications.nonStoreNames
             )
-            let owners = Self.resolveExternalApplicationOwners(
-                signatures: appSignatures,
-                applications: applications.applications,
-                installedCasks: installed
-            )
-            let index = Self.buildInstallationIndex(
-                catalog: catalog,
-                applications: applications.applications,
-                binaryPaths: binaryPaths,
-                installedCasks: installed
-            )
-            return (applications, packages, owners, index)
+            return (applications, packages)
         }.value
         guard packageGeneration == packageCatalogGeneration else { return }
 
-        externalAppNames = result.0.adoptableNames
-        macAppStoreAppNames = result.0.macAppStoreNames
-        macAppStoreBundleIdentifiers = result.0.macAppStoreBundleIdentifiers
-        detectedApplications = result.0.applications
-        externalApplicationOwners = result.2
-        externalPackageInstallations = result.1
-        installationIndex = result.3
+        let owners = Self.resolveExternalApplicationOwners(
+            signatures: applicationCaskSignatures,
+            applications: applications.applications,
+            installedCasks: installedCasks
+        )
+        let index = Self.buildInstallationIndex(
+            catalog: installationCatalog,
+            applications: applications.applications,
+            binaryPaths: externalBinaryPaths,
+            installedCasks: installedCasks
+        )
+        externalAppNames = applications.adoptableNames
+        macAppStoreAppNames = applications.macAppStoreNames
+        macAppStoreBundleIdentifiers = applications.macAppStoreBundleIdentifiers
+        detectedApplications = applications.applications
+        externalApplicationOwners = owners
+        externalPackageInstallations = packages
+        installationIndex = index
     }
 
     private func updateCatalogSignatures(_ casks: [Cask]) {
@@ -80,10 +76,12 @@ extension LocalHomebrewService {
                 binaryNames: cask.binaryArtifactNames
             )
         }
+        let applicationSignatures = Self.makeCatalogApplicationSignatures(casks)
         installationCatalog = CaskInstallationCatalog(
             tokens: Set(casks.map(\.token)),
             macAppStoreSignatures: storeSignatures,
-            binarySignatures: binarySignatures
+            binarySignatures: binarySignatures,
+            applicationSignatures: applicationSignatures
         )
         packageCaskSignatures = casks.compactMap { cask in
             guard cask.hasPackageArtifact, !cask.packageIdentifiers.isEmpty else { return nil }

--- a/CaskHub/Services/LocalHomebrewService+ExternalApps.swift
+++ b/CaskHub/Services/LocalHomebrewService+ExternalApps.swift
@@ -9,6 +9,48 @@ extension LocalHomebrewService {
     /// The catalog provides app identity and package receipt metadata needed to
     /// associate software already on the Mac with exactly one Homebrew cask.
     func updatePackageCatalog(_ casks: [Cask]) async {
+        updateCatalogSignatures(casks)
+        packageCatalogGeneration &+= 1
+        let packageGeneration = packageCatalogGeneration
+
+        let appSignatures = applicationCaskSignatures
+        let catalog = installationCatalog
+        let packageSignatures = packageCaskSignatures
+        let installed = installedCasks
+        let binaryPaths = externalBinaryPaths
+        let fm = fileManager
+        let appDirs = applicationDirectories
+        let result = await Task.detached(priority: .userInitiated) {
+            let applications = Self.scanApplications(fileManager: fm, directories: appDirs)
+            let packages = packageSignatures.isEmpty ? [:] : Self.scanExternalPackageInstallations(
+                signatures: packageSignatures,
+                availableAppNames: applications.nonStoreNames
+            )
+            let owners = Self.resolveExternalApplicationOwners(
+                signatures: appSignatures,
+                applications: applications.applications,
+                installedCasks: installed
+            )
+            let index = Self.buildInstallationIndex(
+                catalog: catalog,
+                applications: applications.applications,
+                binaryPaths: binaryPaths,
+                installedCasks: installed
+            )
+            return (applications, packages, owners, index)
+        }.value
+        guard packageGeneration == packageCatalogGeneration else { return }
+
+        externalAppNames = result.0.adoptableNames
+        macAppStoreAppNames = result.0.macAppStoreNames
+        macAppStoreBundleIdentifiers = result.0.macAppStoreBundleIdentifiers
+        detectedApplications = result.0.applications
+        externalApplicationOwners = result.2
+        externalPackageInstallations = result.1
+        installationIndex = result.3
+    }
+
+    private func updateCatalogSignatures(_ casks: [Cask]) {
         caskDisplayNames = casks.reduce(into: [:]) { names, cask in
             names[cask.token] = cask.displayName
         }
@@ -20,6 +62,29 @@ extension LocalHomebrewService {
                 bundleIdentifiers: Set(cask.applicationBundleIdentifiers)
             )
         }
+        let storeSignatures: [MacAppStoreCaskSignature] = casks.compactMap { cask in
+            let bundleNames = Set(cask.appArtifactNames + cask.packageAppNameCandidates)
+            guard !bundleNames.isEmpty else { return nil }
+            return MacAppStoreCaskSignature(
+                token: cask.token,
+                bundleNames: bundleNames,
+                hasPackageArtifact: cask.hasPackageArtifact,
+                applicationBundleIdentifiers: cask.applicationBundleIdentifiers,
+                packageIdentifiers: cask.packageIdentifiers
+            )
+        }
+        let binarySignatures: [BinaryCaskSignature] = casks.compactMap { cask in
+            guard !cask.binaryArtifactNames.isEmpty else { return nil }
+            return BinaryCaskSignature(
+                token: cask.token,
+                binaryNames: cask.binaryArtifactNames
+            )
+        }
+        installationCatalog = CaskInstallationCatalog(
+            tokens: Set(casks.map(\.token)),
+            macAppStoreSignatures: storeSignatures,
+            binarySignatures: binarySignatures
+        )
         packageCaskSignatures = casks.compactMap { cask in
             guard cask.hasPackageArtifact, !cask.packageIdentifiers.isEmpty else { return nil }
             return PackageCaskSignature(
@@ -29,32 +94,6 @@ extension LocalHomebrewService {
                 appNameCandidates: cask.packageAppNameCandidates
             )
         }
-        packageCatalogGeneration &+= 1
-        let packageGeneration = packageCatalogGeneration
-
-        let packageSignatures = packageCaskSignatures
-        let fm = fileManager
-        let appDirs = applicationDirectories
-        let (applications, packages) = await Task.detached(priority: .userInitiated) {
-            let applications = Self.scanApplications(fileManager: fm, directories: appDirs)
-            let packages = packageSignatures.isEmpty ? [:] : Self.scanExternalPackageInstallations(
-                signatures: packageSignatures,
-                availableAppNames: applications.nonStoreNames
-            )
-            return (applications, packages)
-        }.value
-        guard packageGeneration == packageCatalogGeneration else { return }
-
-        externalAppNames = applications.adoptableNames
-        macAppStoreAppNames = applications.macAppStoreNames
-        macAppStoreBundleIdentifiers = applications.macAppStoreBundleIdentifiers
-        detectedApplications = applications.applications
-        externalApplicationOwners = Self.resolveExternalApplicationOwners(
-            signatures: applicationCaskSignatures,
-            applications: applications.applications,
-            installedCasks: installedCasks
-        )
-        externalPackageInstallations = packages
     }
 
     nonisolated static func scanApplications(
@@ -118,6 +157,16 @@ extension LocalHomebrewService {
             let catalogNames = signaturesByToken[installation.token]?.appBundleNames ?? []
             return installation.appBundleNames + Array(catalogNames)
         }.map { normalizedApplicationName($0) })
+        let installedTokens = Set(installedCasks.keys)
+        var signaturesByBundleName: [String: [ApplicationCaskSignature]] = [:]
+        for signature in signatures where !installedTokens.contains(signature.token) {
+            for bundleName in signature.appBundleNames {
+                signaturesByBundleName[
+                    normalizedApplicationName(bundleName),
+                    default: []
+                ].append(signature)
+            }
+        }
 
         var owners: [String: DetectedApplication] = [:]
         for application in applications where
@@ -125,11 +174,7 @@ extension LocalHomebrewService {
             let normalizedName = normalizedApplicationName(application.bundleName)
             guard !installedBundleNames.contains(normalizedName) else { continue }
 
-            let candidates = signatures.filter { signature in
-                signature.appBundleNames.contains {
-                    normalizedApplicationName($0) == normalizedName
-                } && !installedCasks.keys.contains(signature.token)
-            }
+            let candidates = signaturesByBundleName[normalizedName] ?? []
             guard let owner = externalApplicationOwner(
                 for: application, candidates: candidates
             ) else { continue }

--- a/CaskHub/Services/LocalHomebrewService+InstallationIndex.swift
+++ b/CaskHub/Services/LocalHomebrewService+InstallationIndex.swift
@@ -1,0 +1,140 @@
+//
+//  LocalHomebrewService+InstallationIndex.swift
+//  CaskHub
+//
+
+import Foundation
+
+extension LocalHomebrewService {
+    static func makeCatalogApplicationSignatures(
+        _ casks: [Cask]
+    ) -> [CaskApplicationSignature] {
+        casks.compactMap { cask in
+            let currentBundleNames = Set(cask.appArtifactNames)
+            let launchableBundleNames = Set(
+                cask.appArtifactNames + cask.packageAppNameCandidates
+            )
+            guard !currentBundleNames.isEmpty || !launchableBundleNames.isEmpty else {
+                return nil
+            }
+            return CaskApplicationSignature(
+                token: cask.token,
+                currentBundleNames: currentBundleNames,
+                launchableBundleNames: launchableBundleNames
+            )
+        }
+    }
+
+    nonisolated static func buildInstallationIndex(
+        catalog: CaskInstallationCatalog,
+        applications: [DetectedApplication],
+        binaryPaths: [String: URL],
+        installedCasks: [String: LocalCaskInstallation]
+    ) -> CaskInstallationIndex {
+        let homebrewApplications = resolveHomebrewApplicationState(
+            signatures: catalog.applicationSignatures,
+            applications: applications,
+            installedCasks: installedCasks
+        )
+        return CaskInstallationIndex(
+            catalogTokens: catalog.tokens,
+            macAppStoreApplications: resolveMacAppStoreApplications(
+                signatures: catalog.macAppStoreSignatures,
+                applications: applications,
+                installedCasks: installedCasks
+            ),
+            externalCLIPaths: resolveExternalCLIPaths(
+                signatures: catalog.binarySignatures,
+                binaryPaths: binaryPaths,
+                installedCasks: installedCasks
+            ),
+            launchableHomebrewTokens: homebrewApplications.launchableTokens,
+            verifiedZombieTokens: homebrewApplications.zombieTokens
+        )
+    }
+
+    nonisolated static func resolveMacAppStoreApplications(
+        signatures: [MacAppStoreCaskSignature],
+        applications: [DetectedApplication],
+        installedCasks: [String: LocalCaskInstallation]
+    ) -> [String: DetectedApplication] {
+        let installedTokens = Set(installedCasks.keys)
+        var signaturesByBundleName: [String: [MacAppStoreCaskSignature]] = [:]
+        for signature in signatures where !installedTokens.contains(signature.token) {
+            for bundleName in signature.bundleNames {
+                signaturesByBundleName[bundleName, default: []].append(signature)
+            }
+        }
+
+        var result: [String: DetectedApplication] = [:]
+        for application in applications where application.isMacAppStore {
+            for signature in signaturesByBundleName[application.bundleName] ?? []
+                where result[signature.token] == nil
+                    && macAppStoreApplication(application, matches: signature) {
+                result[signature.token] = application
+            }
+        }
+        return result
+    }
+
+    nonisolated static func resolveExternalCLIPaths(
+        signatures: [BinaryCaskSignature],
+        binaryPaths: [String: URL],
+        installedCasks: [String: LocalCaskInstallation]
+    ) -> [String: URL] {
+        let installedTokens = Set(installedCasks.keys)
+        return signatures.reduce(into: [:]) { result, signature in
+            guard !installedTokens.contains(signature.token),
+                  let path = signature.binaryNames.lazy.compactMap({ binaryPaths[$0] }).first
+            else { return }
+            result[signature.token] = path
+        }
+    }
+
+    nonisolated static func resolveHomebrewApplicationState(
+        signatures: [CaskApplicationSignature],
+        applications: [DetectedApplication],
+        installedCasks: [String: LocalCaskInstallation]
+    ) -> (launchableTokens: Set<String>, zombieTokens: Set<String>) {
+        let signaturesByToken = Dictionary(
+            signatures.map { ($0.token, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let validBundleNames = Set(applications.map(\.bundleName))
+        var launchableTokens: Set<String> = []
+        var zombieTokens: Set<String> = []
+
+        for (token, installation) in installedCasks {
+            guard let signature = signaturesByToken[token] else { continue }
+            let launchableNames = Set(installation.appBundleNames)
+                .union(signature.launchableBundleNames)
+            if !launchableNames.isDisjoint(with: validBundleNames) {
+                launchableTokens.insert(token)
+            }
+            if installation.isZombie,
+               !signature.currentBundleNames.isEmpty,
+               signature.currentBundleNames.isDisjoint(with: validBundleNames) {
+                zombieTokens.insert(token)
+            }
+        }
+        return (launchableTokens, zombieTokens)
+    }
+
+    private nonisolated static func macAppStoreApplication(
+        _ application: DetectedApplication,
+        matches signature: MacAppStoreCaskSignature
+    ) -> Bool {
+        guard signature.hasPackageArtifact else { return true }
+        guard let bundleIdentifier = application.bundleIdentifier else { return false }
+        if !signature.applicationBundleIdentifiers.isEmpty {
+            return applicationBundleIdentifier(
+                bundleIdentifier,
+                matchesAny: signature.applicationBundleIdentifiers
+            )
+        }
+        return Self.bundleIdentifier(
+            bundleIdentifier,
+            matchesPackageIdentifiers: signature.packageIdentifiers
+        )
+    }
+}

--- a/CaskHub/Services/LocalHomebrewService+State.swift
+++ b/CaskHub/Services/LocalHomebrewService+State.swift
@@ -51,6 +51,9 @@ extension LocalHomebrewService {
     /// Mac App Store apps are present, but adopting them would break Store updates.
     func isMacAppStoreInstalled(_ cask: Cask) -> Bool {
         guard installedCasks[cask.token] == nil else { return false }
+        if installationIndex.catalogTokens.contains(cask.token) {
+            return installationIndex.macAppStoreApplications[cask.token] != nil
+        }
         if macAppStoreApplication(for: cask) != nil { return true }
 
         // Keep the name-indexed fallback for state injected by previews and tests.
@@ -70,7 +73,87 @@ extension LocalHomebrewService {
     /// (e.g. claude-code's native install script). Detected, not managed.
     func externalCLIPath(_ cask: Cask) -> URL? {
         guard installedCasks[cask.token] == nil else { return nil }
+        if installationIndex.catalogTokens.contains(cask.token) {
+            return installationIndex.externalCLIPaths[cask.token]
+        }
         return cask.binaryArtifactNames.lazy.compactMap { self.externalBinaryPaths[$0] }.first
+    }
+
+    nonisolated static func buildInstallationIndex(
+        catalog: CaskInstallationCatalog,
+        applications: [DetectedApplication],
+        binaryPaths: [String: URL],
+        installedCasks: [String: LocalCaskInstallation]
+    ) -> CaskInstallationIndex {
+        CaskInstallationIndex(
+            catalogTokens: catalog.tokens,
+            macAppStoreApplications: resolveMacAppStoreApplications(
+                signatures: catalog.macAppStoreSignatures,
+                applications: applications,
+                installedCasks: installedCasks
+            ),
+            externalCLIPaths: resolveExternalCLIPaths(
+                signatures: catalog.binarySignatures,
+                binaryPaths: binaryPaths,
+                installedCasks: installedCasks
+            )
+        )
+    }
+
+    nonisolated static func resolveMacAppStoreApplications(
+        signatures: [MacAppStoreCaskSignature],
+        applications: [DetectedApplication],
+        installedCasks: [String: LocalCaskInstallation]
+    ) -> [String: DetectedApplication] {
+        let installedTokens = Set(installedCasks.keys)
+        var signaturesByBundleName: [String: [MacAppStoreCaskSignature]] = [:]
+        for signature in signatures where !installedTokens.contains(signature.token) {
+            for bundleName in signature.bundleNames {
+                signaturesByBundleName[bundleName, default: []].append(signature)
+            }
+        }
+
+        var result: [String: DetectedApplication] = [:]
+        for application in applications where application.isMacAppStore {
+            for signature in signaturesByBundleName[application.bundleName] ?? []
+                where result[signature.token] == nil
+                    && macAppStoreApplication(application, matches: signature) {
+                result[signature.token] = application
+            }
+        }
+        return result
+    }
+
+    nonisolated static func resolveExternalCLIPaths(
+        signatures: [BinaryCaskSignature],
+        binaryPaths: [String: URL],
+        installedCasks: [String: LocalCaskInstallation]
+    ) -> [String: URL] {
+        let installedTokens = Set(installedCasks.keys)
+        return signatures.reduce(into: [:]) { result, signature in
+            guard !installedTokens.contains(signature.token),
+                  let path = signature.binaryNames.lazy.compactMap({ binaryPaths[$0] }).first
+            else { return }
+            result[signature.token] = path
+        }
+    }
+
+    private nonisolated static func macAppStoreApplication(
+        _ application: DetectedApplication,
+        matches signature: MacAppStoreCaskSignature
+    ) -> Bool {
+        guard signature.hasPackageArtifact else { return true }
+        guard let bundleIdentifier = application.bundleIdentifier else { return false }
+        if !signature.applicationBundleIdentifiers.isEmpty {
+            return applicationBundleIdentifier(
+                bundleIdentifier,
+                matchesAny: signature.applicationBundleIdentifiers
+            )
+        }
+        return Self.bundleIdentifier(
+            bundleIdentifier,
+            matchesPackageIdentifiers: signature.packageIdentifiers
+        )
     }
 
     func installationSource(for cask: Cask) -> CaskInstallationSource? {
@@ -204,6 +287,9 @@ extension LocalHomebrewService {
     }
 
     private func macAppStoreApplication(for cask: Cask) -> DetectedApplication? {
+        if installationIndex.catalogTokens.contains(cask.token) {
+            return installationIndex.macAppStoreApplications[cask.token]
+        }
         let matchingNames = Set(cask.appArtifactNames + cask.packageAppNameCandidates)
         return detectedApplications.first { application in
             guard application.isMacAppStore,

--- a/CaskHub/Services/LocalHomebrewService+State.swift
+++ b/CaskHub/Services/LocalHomebrewService+State.swift
@@ -79,83 +79,6 @@ extension LocalHomebrewService {
         return cask.binaryArtifactNames.lazy.compactMap { self.externalBinaryPaths[$0] }.first
     }
 
-    nonisolated static func buildInstallationIndex(
-        catalog: CaskInstallationCatalog,
-        applications: [DetectedApplication],
-        binaryPaths: [String: URL],
-        installedCasks: [String: LocalCaskInstallation]
-    ) -> CaskInstallationIndex {
-        CaskInstallationIndex(
-            catalogTokens: catalog.tokens,
-            macAppStoreApplications: resolveMacAppStoreApplications(
-                signatures: catalog.macAppStoreSignatures,
-                applications: applications,
-                installedCasks: installedCasks
-            ),
-            externalCLIPaths: resolveExternalCLIPaths(
-                signatures: catalog.binarySignatures,
-                binaryPaths: binaryPaths,
-                installedCasks: installedCasks
-            )
-        )
-    }
-
-    nonisolated static func resolveMacAppStoreApplications(
-        signatures: [MacAppStoreCaskSignature],
-        applications: [DetectedApplication],
-        installedCasks: [String: LocalCaskInstallation]
-    ) -> [String: DetectedApplication] {
-        let installedTokens = Set(installedCasks.keys)
-        var signaturesByBundleName: [String: [MacAppStoreCaskSignature]] = [:]
-        for signature in signatures where !installedTokens.contains(signature.token) {
-            for bundleName in signature.bundleNames {
-                signaturesByBundleName[bundleName, default: []].append(signature)
-            }
-        }
-
-        var result: [String: DetectedApplication] = [:]
-        for application in applications where application.isMacAppStore {
-            for signature in signaturesByBundleName[application.bundleName] ?? []
-                where result[signature.token] == nil
-                    && macAppStoreApplication(application, matches: signature) {
-                result[signature.token] = application
-            }
-        }
-        return result
-    }
-
-    nonisolated static func resolveExternalCLIPaths(
-        signatures: [BinaryCaskSignature],
-        binaryPaths: [String: URL],
-        installedCasks: [String: LocalCaskInstallation]
-    ) -> [String: URL] {
-        let installedTokens = Set(installedCasks.keys)
-        return signatures.reduce(into: [:]) { result, signature in
-            guard !installedTokens.contains(signature.token),
-                  let path = signature.binaryNames.lazy.compactMap({ binaryPaths[$0] }).first
-            else { return }
-            result[signature.token] = path
-        }
-    }
-
-    private nonisolated static func macAppStoreApplication(
-        _ application: DetectedApplication,
-        matches signature: MacAppStoreCaskSignature
-    ) -> Bool {
-        guard signature.hasPackageArtifact else { return true }
-        guard let bundleIdentifier = application.bundleIdentifier else { return false }
-        if !signature.applicationBundleIdentifiers.isEmpty {
-            return applicationBundleIdentifier(
-                bundleIdentifier,
-                matchesAny: signature.applicationBundleIdentifiers
-            )
-        }
-        return Self.bundleIdentifier(
-            bundleIdentifier,
-            matchesPackageIdentifiers: signature.packageIdentifiers
-        )
-    }
-
     func installationSource(for cask: Cask) -> CaskInstallationSource? {
         if installedCasks[cask.token] != nil { return .homebrew }
         if isMacAppStoreInstalled(cask) { return .macAppStore }
@@ -188,6 +111,22 @@ extension LocalHomebrewService {
         return .notApplicable
     }
 
+    func localState(for cask: Cask) -> CaskLocalState {
+        let source = installationSource(for: cask)
+        return CaskLocalState(
+            installationSource: source,
+            externalCLIPath: source == .externalExecutable ? externalCLIPath(cask) : nil,
+            uninstallAvailability: uninstallAvailability(for: cask),
+            hasAvailableUpdate: hasAvailableUpdate(
+                token: cask.token,
+                remoteVersion: cask.version,
+                autoUpdates: cask.autoUpdates
+            ),
+            isZombie: isZombie(cask),
+            canOpen: canOpen(cask)
+        )
+    }
+
     func isOutdated(token: String, remoteVersion: String) -> Bool {
         guard let installation = installedCasks[token], !installation.isZombie else { return false }
         return Self.comparableVersion(installation.installedVersion)
@@ -211,6 +150,9 @@ extension LocalHomebrewService {
         guard let installation = installedCasks[cask.token], installation.isZombie,
               !cask.appArtifactNames.isEmpty
         else { return false }
+        if installationIndex.catalogTokens.contains(cask.token) {
+            return installationIndex.verifiedZombieTokens.contains(cask.token)
+        }
         return existingBundleURL(named: cask.appArtifactNames) == nil
     }
 
@@ -222,6 +164,14 @@ extension LocalHomebrewService {
     }
 
     func canOpen(_ cask: Cask) -> Bool {
+        if installationIndex.catalogTokens.contains(cask.token) {
+            if installedCasks[cask.token] != nil {
+                return installationIndex.launchableHomebrewTokens.contains(cask.token)
+            }
+            return installationIndex.macAppStoreApplications[cask.token] != nil
+                || externalApplicationOwners[cask.token] != nil
+                || externalPackageInstallations[cask.token] != nil
+        }
         if installedCasks[cask.token] == nil,
            let application = macAppStoreApplication(for: cask) {
             return Self.applicationBundleMetadata(

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -40,6 +40,11 @@ final class LocalHomebrewService {
     var externalPackageInstallations: [String: ExternalPackageInstallation] = [:]
 
     @ObservationIgnored var applicationCaskSignatures: [ApplicationCaskSignature] = []
+    @ObservationIgnored var installationCatalog = CaskInstallationCatalog.empty
+
+    /// Catalog-wide installation lookups, rebuilt only when the catalog or a
+    /// local software scan changes. Rendering reads this snapshot in O(1).
+    var installationIndex = CaskInstallationIndex.empty
 
     /// Package adoptions awaiting the user's reinstall confirmation.
     var packageAdoptionRequests: Set<String> = []
@@ -177,37 +182,46 @@ final class LocalHomebrewService {
         }
         let appDirs = applicationDirectories
         let caskroom = configuredCaskroomURL()
+        let appSignatures = applicationCaskSignatures
+        let catalog = installationCatalog
         let packageSignatures = packageCaskSignatures
         let packageGeneration = packageCatalogGeneration
-        let (casks, applications, binaryPaths, packages) = await Task.detached(priority: .userInitiated) {
+        let result = await Task.detached(priority: .userInitiated) {
             let applications = Self.scanApplications(fileManager: fm, directories: appDirs)
-            return (
-                caskroom.map {
-                    Self.scanCaskroom(
-                        at: $0, fileManager: fm, applicationDirectories: appDirs
-                    )
-                } ?? [:],
-                applications,
-                Self.scanBinaryDirectories(fileManager: fm),
-                Self.scanExternalPackageInstallations(
-                    signatures: packageSignatures,
-                    availableAppNames: applications.nonStoreNames
+            let casks = caskroom.map {
+                Self.scanCaskroom(
+                    at: $0, fileManager: fm, applicationDirectories: appDirs
                 )
+            } ?? [:]
+            let binaryPaths = Self.scanBinaryDirectories(fileManager: fm)
+            let packages = Self.scanExternalPackageInstallations(
+                signatures: packageSignatures,
+                availableAppNames: applications.nonStoreNames
             )
+            let owners = Self.resolveExternalApplicationOwners(
+                signatures: appSignatures,
+                applications: applications.applications,
+                installedCasks: casks
+            )
+            let index = Self.buildInstallationIndex(
+                catalog: catalog,
+                applications: applications.applications,
+                binaryPaths: binaryPaths,
+                installedCasks: casks
+            )
+            return (casks, applications, binaryPaths, packages, owners, index)
         }.value
-        installedCasks = casks
-        externalAppNames = applications.adoptableNames
-        macAppStoreAppNames = applications.macAppStoreNames
-        macAppStoreBundleIdentifiers = applications.macAppStoreBundleIdentifiers
-        detectedApplications = applications.applications
-        externalApplicationOwners = Self.resolveExternalApplicationOwners(
-            signatures: applicationCaskSignatures,
-            applications: applications.applications,
-            installedCasks: casks
-        )
-        externalBinaryPaths = binaryPaths
+
+        installedCasks = result.0
+        externalAppNames = result.1.adoptableNames
+        macAppStoreAppNames = result.1.macAppStoreNames
+        macAppStoreBundleIdentifiers = result.1.macAppStoreBundleIdentifiers
+        detectedApplications = result.1.applications
+        externalApplicationOwners = result.4
+        externalBinaryPaths = result.2
+        installationIndex = result.5
         if packageGeneration == packageCatalogGeneration {
-            externalPackageInstallations = packages
+            externalPackageInstallations = result.3
         }
 
         CrashReporter.tag("brew.path", value: Self.locateBrewBinary()?.path ?? "not found")

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -14,14 +14,18 @@ import Observation
 @MainActor
 @Observable
 final class LocalHomebrewService {
-    var installedCasks: [String: LocalCaskInstallation] = [:]
+    var installedCasks: [String: LocalCaskInstallation] = [:] {
+        didSet { catalogStateRevision &+= 1 }
+    }
 
     /// Non-Mac-App-Store bundle names found in /Applications and ~/Applications.
     var externalAppNames: Set<String> = []
 
     /// Directly installed applications resolved to one catalog cask. A token is
     /// absent when a shared bundle name cannot be disambiguated safely.
-    var externalApplicationOwners: [String: DetectedApplication] = [:]
+    var externalApplicationOwners: [String: DetectedApplication] = [:] {
+        didSet { catalogStateRevision &+= 1 }
+    }
 
     /// Mac App Store bundles that must be shown as installed but never adopted.
     var macAppStoreAppNames: Set<String> = []
@@ -37,14 +41,22 @@ final class LocalHomebrewService {
     var externalBinaryPaths: [String: URL] = [:]
 
     /// Package-installed apps matched to cask receipt metadata.
-    var externalPackageInstallations: [String: ExternalPackageInstallation] = [:]
+    var externalPackageInstallations: [String: ExternalPackageInstallation] = [:] {
+        didSet { catalogStateRevision &+= 1 }
+    }
 
     @ObservationIgnored var applicationCaskSignatures: [ApplicationCaskSignature] = []
     @ObservationIgnored var installationCatalog = CaskInstallationCatalog.empty
 
     /// Catalog-wide installation lookups, rebuilt only when the catalog or a
     /// local software scan changes. Rendering reads this snapshot in O(1).
-    var installationIndex = CaskInstallationIndex.empty
+    var installationIndex = CaskInstallationIndex.empty {
+        didSet { catalogStateRevision &+= 1 }
+    }
+
+    /// Changes only when state that affects catalog membership or update
+    /// eligibility changes; operation progress deliberately does not touch it.
+    private(set) var catalogStateRevision = 0
 
     /// Package adoptions awaiting the user's reinstall confirmation.
     var packageAdoptionRequests: Set<String> = []
@@ -110,7 +122,9 @@ final class LocalHomebrewService {
     private(set) var customBrewPrefix: String?
 
     /// Include self-updating casks (`auto_updates: true`) in updates, via `brew upgrade --greedy`.
-    private(set) var greedyUpdates: Bool
+    private(set) var greedyUpdates: Bool {
+        didSet { catalogStateRevision &+= 1 }
+    }
 
     let fileManager: FileManager
     private let defaults: UserDefaults

--- a/CaskHub/Services/LocalHomebrewService.swift
+++ b/CaskHub/Services/LocalHomebrewService.swift
@@ -196,8 +196,6 @@ final class LocalHomebrewService {
         }
         let appDirs = applicationDirectories
         let caskroom = configuredCaskroomURL()
-        let appSignatures = applicationCaskSignatures
-        let catalog = installationCatalog
         let packageSignatures = packageCaskSignatures
         let packageGeneration = packageCatalogGeneration
         let result = await Task.detached(priority: .userInitiated) {
@@ -212,28 +210,28 @@ final class LocalHomebrewService {
                 signatures: packageSignatures,
                 availableAppNames: applications.nonStoreNames
             )
-            let owners = Self.resolveExternalApplicationOwners(
-                signatures: appSignatures,
-                applications: applications.applications,
-                installedCasks: casks
-            )
-            let index = Self.buildInstallationIndex(
-                catalog: catalog,
-                applications: applications.applications,
-                binaryPaths: binaryPaths,
-                installedCasks: casks
-            )
-            return (casks, applications, binaryPaths, packages, owners, index)
+            return (casks, applications, binaryPaths, packages)
         }.value
 
+        let owners = Self.resolveExternalApplicationOwners(
+            signatures: applicationCaskSignatures,
+            applications: result.1.applications,
+            installedCasks: result.0
+        )
+        let index = Self.buildInstallationIndex(
+            catalog: installationCatalog,
+            applications: result.1.applications,
+            binaryPaths: result.2,
+            installedCasks: result.0
+        )
         installedCasks = result.0
         externalAppNames = result.1.adoptableNames
         macAppStoreAppNames = result.1.macAppStoreNames
         macAppStoreBundleIdentifiers = result.1.macAppStoreBundleIdentifiers
         detectedApplications = result.1.applications
-        externalApplicationOwners = result.4
+        externalApplicationOwners = owners
         externalBinaryPaths = result.2
-        installationIndex = result.5
+        installationIndex = index
         if packageGeneration == packageCatalogGeneration {
             externalPackageInstallations = result.3
         }

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -50,6 +50,43 @@ nonisolated struct ApplicationCaskSignature {
     let bundleIdentifiers: Set<String>
 }
 
+nonisolated struct MacAppStoreCaskSignature: Sendable {
+    let token: String
+    let bundleNames: Set<String>
+    let hasPackageArtifact: Bool
+    let applicationBundleIdentifiers: [String]
+    let packageIdentifiers: [String]
+}
+
+nonisolated struct BinaryCaskSignature: Sendable {
+    let token: String
+    let binaryNames: [String]
+}
+
+nonisolated struct CaskInstallationCatalog: Sendable {
+    let tokens: Set<String>
+    let macAppStoreSignatures: [MacAppStoreCaskSignature]
+    let binarySignatures: [BinaryCaskSignature]
+
+    static let empty = CaskInstallationCatalog(
+        tokens: [],
+        macAppStoreSignatures: [],
+        binarySignatures: []
+    )
+}
+
+nonisolated struct CaskInstallationIndex: Sendable {
+    let catalogTokens: Set<String>
+    let macAppStoreApplications: [String: DetectedApplication]
+    let externalCLIPaths: [String: URL]
+
+    static let empty = CaskInstallationIndex(
+        catalogTokens: [],
+        macAppStoreApplications: [:],
+        externalCLIPaths: [:]
+    )
+}
+
 nonisolated struct PackageCaskSignature {
     let token: String
     let displayName: String

--- a/CaskHub/Services/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/LocalHomebrewTypes.swift
@@ -63,15 +63,32 @@ nonisolated struct BinaryCaskSignature: Sendable {
     let binaryNames: [String]
 }
 
+nonisolated struct CaskApplicationSignature: Sendable {
+    let token: String
+    let currentBundleNames: Set<String>
+    let launchableBundleNames: Set<String>
+}
+
 nonisolated struct CaskInstallationCatalog: Sendable {
     let tokens: Set<String>
     let macAppStoreSignatures: [MacAppStoreCaskSignature]
     let binarySignatures: [BinaryCaskSignature]
+    let applicationSignatures: [CaskApplicationSignature]
+
+    init(
+        tokens: Set<String>,
+        macAppStoreSignatures: [MacAppStoreCaskSignature],
+        binarySignatures: [BinaryCaskSignature],
+        applicationSignatures: [CaskApplicationSignature] = []
+    ) {
+        self.tokens = tokens
+        self.macAppStoreSignatures = macAppStoreSignatures
+        self.binarySignatures = binarySignatures
+        self.applicationSignatures = applicationSignatures
+    }
 
     static let empty = CaskInstallationCatalog(
-        tokens: [],
-        macAppStoreSignatures: [],
-        binarySignatures: []
+        tokens: [], macAppStoreSignatures: [], binarySignatures: []
     )
 }
 
@@ -79,11 +96,25 @@ nonisolated struct CaskInstallationIndex: Sendable {
     let catalogTokens: Set<String>
     let macAppStoreApplications: [String: DetectedApplication]
     let externalCLIPaths: [String: URL]
+    let launchableHomebrewTokens: Set<String>
+    let verifiedZombieTokens: Set<String>
+
+    init(
+        catalogTokens: Set<String>,
+        macAppStoreApplications: [String: DetectedApplication],
+        externalCLIPaths: [String: URL],
+        launchableHomebrewTokens: Set<String> = [],
+        verifiedZombieTokens: Set<String> = []
+    ) {
+        self.catalogTokens = catalogTokens
+        self.macAppStoreApplications = macAppStoreApplications
+        self.externalCLIPaths = externalCLIPaths
+        self.launchableHomebrewTokens = launchableHomebrewTokens
+        self.verifiedZombieTokens = verifiedZombieTokens
+    }
 
     static let empty = CaskInstallationIndex(
-        catalogTokens: [],
-        macAppStoreApplications: [:],
-        externalCLIPaths: [:]
+        catalogTokens: [], macAppStoreApplications: [:], externalCLIPaths: [:]
     )
 }
 
@@ -106,7 +137,7 @@ struct ExternalPackageInstallation: Hashable {
     let appBundleNames: [String]
 }
 
-enum CaskInstallationSource: String, Equatable {
+nonisolated enum CaskInstallationSource: String, Equatable, Sendable {
     case homebrew = "Homebrew"
     case macAppStore = "Mac App Store"
     case externalApplication = "External application"
@@ -114,7 +145,7 @@ enum CaskInstallationSource: String, Equatable {
     case externalExecutable = "External executable"
 }
 
-enum CaskUninstallAvailability: Equatable {
+nonisolated enum CaskUninstallAvailability: Equatable, Sendable {
     case available
     case unavailable(reason: String)
     case notApplicable
@@ -122,6 +153,32 @@ enum CaskUninstallAvailability: Equatable {
     var unavailableReason: String? {
         guard case let .unavailable(reason) = self else { return nil }
         return reason
+    }
+}
+
+nonisolated struct CaskLocalState: Equatable, Sendable {
+    let installationSource: CaskInstallationSource?
+    let externalCLIPath: URL?
+    let uninstallAvailability: CaskUninstallAvailability
+    let hasAvailableUpdate: Bool
+    let isZombie: Bool
+    let canOpen: Bool
+
+    var isPresent: Bool {
+        installationSource != nil
+    }
+
+    var isHomebrewInstalled: Bool {
+        installationSource == .homebrew
+    }
+
+    var isAdoptable: Bool {
+        installationSource == .externalApplication
+            || installationSource == .packageInstaller
+    }
+
+    var isExternalPackage: Bool {
+        installationSource == .packageInstaller
     }
 }
 

--- a/CaskHub/Services/RecentlyAddedService.swift
+++ b/CaskHub/Services/RecentlyAddedService.swift
@@ -33,8 +33,11 @@ final class RecentlyAddedService {
 
     private static let schemaVersion = 1
 
-    var addedDates: [String: String] = [:]
+    var addedDates: [String: String] = [:] {
+        didSet { catalogStateRevision &+= 1 }
+    }
     private(set) var generatedDate = ""
+    private(set) var catalogStateRevision = 0
 
     func loadBundledDates(bundle: Bundle = .main) {
         guard let url = bundle.url(forResource: "added_dates", withExtension: "json"),

--- a/CaskHub/ViewModels/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel+Projection.swift
@@ -32,6 +32,10 @@ extension CaskCatalogViewModel {
         librarySnapshot.categoryCounts
     }
 
+    func localState(for cask: Cask) -> CaskLocalState {
+        librarySnapshot.localStates[cask.token] ?? localHomebrew.localState(for: cask)
+    }
+
     private var libraryCacheKey: CatalogLibraryCacheKey {
         CatalogLibraryCacheKey(
             catalogRevision: catalogRevision,
@@ -45,18 +49,18 @@ extension CaskCatalogViewModel {
             var updatableCasks: [Cask] = []
             var installedCasks: [Cask] = []
             var adoptableCasks: [Cask] = []
+            var localStates: [String: CaskLocalState] = [:]
+            localStates.reserveCapacity(casks.count)
             for cask in casks {
-                if localHomebrew.hasAvailableUpdate(
-                    token: cask.token,
-                    remoteVersion: cask.version,
-                    autoUpdates: cask.autoUpdates
-                ) {
+                let localState = localHomebrew.localState(for: cask)
+                localStates[cask.token] = localState
+                if localState.hasAvailableUpdate {
                     updatableCasks.append(cask)
                 }
-                if localHomebrew.isPresent(cask) {
+                if localState.isPresent {
                     installedCasks.append(cask)
                 }
-                if localHomebrew.isAdoptable(cask) {
+                if localState.isAdoptable {
                     adoptableCasks.append(cask)
                 }
             }
@@ -68,7 +72,8 @@ extension CaskCatalogViewModel {
                 updatableCasks: updatableCasks,
                 installedCasks: installedCasks,
                 adoptableCasks: adoptableCasks,
-                categoryCounts: categoryCounts
+                categoryCounts: categoryCounts,
+                localStates: localStates
             )
         }
     }

--- a/CaskHub/ViewModels/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel+Projection.swift
@@ -1,0 +1,231 @@
+//
+//  CaskCatalogViewModel+Projection.swift
+//  CaskHub
+//
+
+import Foundation
+
+extension CaskCatalogViewModel {
+    // MARK: - Sidebar Counts
+
+    var updatableCasks: [Cask] {
+        librarySnapshot.updatableCasks
+    }
+
+    var updatesCount: Int {
+        updatableCasks.count
+    }
+
+    var installedCasks: [Cask] {
+        librarySnapshot.installedCasks
+    }
+
+    var installedCount: Int {
+        installedCasks.count
+    }
+
+    var adoptableCasks: [Cask] {
+        librarySnapshot.adoptableCasks
+    }
+
+    var categoryCounts: [String: Int] {
+        librarySnapshot.categoryCounts
+    }
+
+    private var libraryCacheKey: CatalogLibraryCacheKey {
+        CatalogLibraryCacheKey(
+            catalogRevision: catalogRevision,
+            installationRevision: localHomebrew.catalogStateRevision,
+            categoryRevision: categoryService.catalogStateRevision
+        )
+    }
+
+    private var librarySnapshot: CatalogLibrarySnapshot {
+        libraryCache.value(for: libraryCacheKey) { [casks, categoryService, localHomebrew] in
+            var updatableCasks: [Cask] = []
+            var installedCasks: [Cask] = []
+            var adoptableCasks: [Cask] = []
+            for cask in casks {
+                if localHomebrew.hasAvailableUpdate(
+                    token: cask.token,
+                    remoteVersion: cask.version,
+                    autoUpdates: cask.autoUpdates
+                ) {
+                    updatableCasks.append(cask)
+                }
+                if localHomebrew.isPresent(cask) {
+                    installedCasks.append(cask)
+                }
+                if localHomebrew.isAdoptable(cask) {
+                    adoptableCasks.append(cask)
+                }
+            }
+            let catalogTokens = Set(casks.map(\.token))
+            let categoryCounts = categoryService.categoryTokenSets.mapValues {
+                $0.intersection(catalogTokens).count
+            }
+            return CatalogLibrarySnapshot(
+                updatableCasks: updatableCasks,
+                installedCasks: installedCasks,
+                adoptableCasks: adoptableCasks,
+                categoryCounts: categoryCounts
+            )
+        }
+    }
+
+    // MARK: - Browse Sections
+
+    private static let browseSectionSize = 8
+
+    var browseSections: [BrowseSection] {
+        let key = BrowseCatalogCacheKey(
+            catalogRevision: catalogRevision,
+            categoryRevision: categoryService.catalogStateRevision,
+            recentlyAddedRevision: recentlyAdded.catalogStateRevision,
+            recentlyAddedWindow: recentlyAddedWindow
+        )
+        return browseCache.value(for: key) { makeBrowseSections() }
+    }
+
+    private func makeBrowseSections() -> [BrowseSection] {
+        let counts = analyticsByPeriod[.days365] ?? [:]
+        let popularityOrder = sortedByDownloads(casks, using: counts)
+        var casksByCategory: [String: [Cask]] = [:]
+        for cask in popularityOrder {
+            guard let mapping = categoryService.tokenMappings[cask.token] else { continue }
+            for categoryID in Set([mapping.primary] + mapping.secondary)
+                where casksByCategory[categoryID, default: []].count < Self.browseSectionSize {
+                casksByCategory[categoryID, default: []].append(cask)
+            }
+        }
+
+        let recentTokens = recentlyAdded.recentTokens(within: recentlyAddedWindow.rawValue)
+        var sections = [
+            BrowseSection(
+                title: "Most Popular",
+                destination: .discover(.topCharts),
+                casks: Array(popularityOrder.prefix(Self.browseSectionSize))
+            ),
+            BrowseSection(
+                title: "Recently Added",
+                destination: .discover(.recentlyAdded),
+                casks: Array(sortedByNewest(casks.filter {
+                    recentTokens.contains($0.token)
+                }).prefix(Self.browseSectionSize))
+            )
+        ]
+        for entry in categoryService.orderedCategories where entry.id != "other" {
+            sections.append(BrowseSection(
+                title: entry.definition.displayName,
+                destination: .category(entry.id),
+                casks: casksByCategory[entry.id] ?? []
+            ))
+        }
+        return sections.filter { !$0.casks.isEmpty }
+    }
+
+    // MARK: - Filtered Casks
+
+    var filteredCasks: [Cask] {
+        let key = FilteredCatalogCacheKey(
+            library: libraryCacheKey,
+            recentlyAddedRevision: recentlyAdded.catalogStateRevision,
+            analyticsPeriod: analyticsPeriod,
+            recentlyAddedWindow: recentlyAddedWindow,
+            selectedSidebar: selectedSidebar,
+            searchText: searchText,
+            sortOption: sortOption
+        )
+        return filteredCache.value(for: key) {
+            let sidebarFiltered = applySidebarFilter(to: casks)
+            let searched = applySearch(to: sidebarFiltered)
+            return applySort(to: searched)
+        }
+    }
+
+    private func applySidebarFilter(to casks: [Cask]) -> [Cask] {
+        switch selectedSidebar {
+        case .discover(.browse):
+            return casks
+        case .discover(.featured):
+            return Array(sortedByDownloads(casks, using: downloadCounts).prefix(100))
+        case .discover(.topCharts):
+            return casks
+        case .discover(.recentlyAdded):
+            let recentTokens = recentlyAdded.recentTokens(within: recentlyAddedWindow.rawValue)
+            return casks.filter { recentTokens.contains($0.token) }
+        case .library(.installed):
+            return installedCasks
+        case .library(.updates):
+            return updatableCasks
+        case .library(.adopt):
+            return adoptableCasks
+        case let .category(categoryID):
+            let tokens = categoryService.tokens(in: categoryID)
+            return casks.filter { tokens.contains($0.token) }
+        }
+    }
+
+    private func applySearch(to casks: [Cask]) -> [Cask] {
+        guard !searchText.isEmpty else { return casks }
+        let query = searchText.lowercased()
+        return casks.filter { cask in
+            cask.displayName.lowercased().contains(query)
+                || cask.token.lowercased().contains(query)
+                || (cask.desc?.lowercased().contains(query) ?? false)
+        }
+    }
+
+    private func sortedByDownloads(
+        _ source: [Cask],
+        using counts: [String: Int]
+    ) -> [Cask] {
+        source.sorted { (counts[$0.token] ?? 0) > (counts[$1.token] ?? 0) }
+    }
+
+    private func sortedByNewest(_ source: [Cask]) -> [Cask] {
+        source.sorted {
+            (recentlyAdded.addedDate(for: $0.token) ?? "")
+                > (recentlyAdded.addedDate(for: $1.token) ?? "")
+        }
+    }
+
+    private func sortedByRecentlyInstalled(_ source: [Cask]) -> [Cask] {
+        source.sorted { lhs, rhs in
+            let lhsDate = localHomebrew.installedCasks[lhs.token]?.installedAt
+            let rhsDate = localHomebrew.installedCasks[rhs.token]?.installedAt
+            if lhsDate != rhsDate {
+                if let lhsDate, let rhsDate { return lhsDate > rhsDate }
+                return lhsDate != nil
+            }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+                == .orderedAscending
+        }
+    }
+
+    private func applySort(to casks: [Cask]) -> [Cask] {
+        switch sortOption {
+        case .mostPopular:
+            return sortedByDownloads(casks, using: downloadCounts)
+        case .nameAZ:
+            return casks.sorted {
+                $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
+                    == .orderedAscending
+            }
+        case .nameZA:
+            return casks.sorted {
+                $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
+                    == .orderedDescending
+            }
+        case .recentlyInstalled:
+            return sortedByRecentlyInstalled(casks)
+        case .newest:
+            return sortedByNewest(casks)
+        case .oldest:
+            return casks.sorted {
+                (recentlyAdded.addedDate(for: $0.token) ?? "9999")
+                    < (recentlyAdded.addedDate(for: $1.token) ?? "9999")
+            }
+        }
+    }
+}

--- a/CaskHub/ViewModels/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel+Projection.swift
@@ -49,6 +49,7 @@ extension CaskCatalogViewModel {
             var updatableCasks: [Cask] = []
             var installedCasks: [Cask] = []
             var adoptableCasks: [Cask] = []
+            var casksByCategory: [String: [Cask]] = [:]
             var localStates: [String: CaskLocalState] = [:]
             localStates.reserveCapacity(casks.count)
             for cask in casks {
@@ -63,15 +64,18 @@ extension CaskCatalogViewModel {
                 if localState.isAdoptable {
                     adoptableCasks.append(cask)
                 }
+                if let mapping = categoryService.tokenMappings[cask.token] {
+                    for categoryID in Set([mapping.primary] + mapping.secondary) {
+                        casksByCategory[categoryID, default: []].append(cask)
+                    }
+                }
             }
-            let catalogTokens = Set(casks.map(\.token))
-            let categoryCounts = categoryService.categoryTokenSets.mapValues {
-                $0.intersection(catalogTokens).count
-            }
+            let categoryCounts = casksByCategory.mapValues(\.count)
             return CatalogLibrarySnapshot(
                 updatableCasks: updatableCasks,
                 installedCasks: installedCasks,
                 adoptableCasks: adoptableCasks,
+                casksByCategory: casksByCategory,
                 categoryCounts: categoryCounts,
                 localStates: localStates
             )
@@ -166,8 +170,7 @@ extension CaskCatalogViewModel {
         case .library(.adopt):
             return adoptableCasks
         case let .category(categoryID):
-            let tokens = categoryService.tokens(in: categoryID)
-            return casks.filter { tokens.contains($0.token) }
+            return librarySnapshot.casksByCategory[categoryID] ?? []
         }
     }
 

--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -37,13 +37,25 @@ enum SortOption: String, CaseIterable, Identifiable {
 @MainActor
 @Observable
 final class CaskCatalogViewModel {
-    private(set) var casks: [Cask] = []
+    private(set) var casks: [Cask] = [] {
+        didSet { catalogRevision &+= 1 }
+    }
     private(set) var isLoading = false
     private(set) var errorMessage: String?
-    private var analyticsByPeriod: [AnalyticsPeriod: [String: Int]] = [:]
+    var analyticsByPeriod: [AnalyticsPeriod: [String: Int]] = [:] {
+        didSet { catalogRevision &+= 1 }
+    }
     private(set) var analyticsPeriod: AnalyticsPeriod = .days365
     private var analyticsRequestID = UUID()
+    private(set) var catalogRevision = 0
     var searchText = ""
+
+    @ObservationIgnored let libraryCache =
+        MemoizedValue<CatalogLibraryCacheKey, CatalogLibrarySnapshot>()
+    @ObservationIgnored let filteredCache =
+        MemoizedValue<FilteredCatalogCacheKey, [Cask]>()
+    @ObservationIgnored let browseCache =
+        MemoizedValue<BrowseCatalogCacheKey, [BrowseSection]>()
 
     private static let periodKey = "analyticsPeriod"
     private static let windowKey = "recentlyAddedWindow"
@@ -78,9 +90,9 @@ final class CaskCatalogViewModel {
     private(set) var recentlyAddedWindow: RecentlyAddedWindow = .days30
 
     private let apiClient: BrewAPIClientProtocol
-    private let categoryService: CategoryService
-    private let recentlyAdded: RecentlyAddedService
-    private let localHomebrew: LocalHomebrewService
+    let categoryService: CategoryService
+    let recentlyAdded: RecentlyAddedService
+    let localHomebrew: LocalHomebrewService
     private let defaults: UserDefaults
 
     init(
@@ -102,157 +114,6 @@ final class CaskCatalogViewModel {
         }
         if let window = RecentlyAddedWindow(rawValue: defaults.integer(forKey: Self.windowKey)) {
             recentlyAddedWindow = window
-        }
-    }
-
-    // MARK: - Sidebar Counts
-
-    var updatableCasks: [Cask] {
-        casks.filter { [localHomebrew] in
-            localHomebrew.hasAvailableUpdate(token: $0.token, remoteVersion: $0.version, autoUpdates: $0.autoUpdates)
-        }
-    }
-
-    var updatesCount: Int {
-        updatableCasks.count
-    }
-
-    var installedCasks: [Cask] {
-        casks.filter { [localHomebrew] in localHomebrew.isPresent($0) }
-    }
-
-    var installedCount: Int {
-        installedCasks.count
-    }
-
-    var adoptableCasks: [Cask] {
-        casks.filter { [localHomebrew] in localHomebrew.isAdoptable($0) }
-    }
-
-    var categoryCounts: [String: Int] {
-        let catalogTokens = Set(casks.map(\.token))
-        return categoryService.categoryTokenSets.mapValues {
-            $0.intersection(catalogTokens).count
-        }
-    }
-
-    // MARK: - Browse Sections
-
-    private static let browseSectionSize = 8
-
-    var browseSections: [BrowseSection] {
-        let counts = analyticsByPeriod[.days365] ?? [:]
-        func top(_ source: [Cask]) -> [Cask] {
-            Array(sortedByDownloads(source, using: counts).prefix(Self.browseSectionSize))
-        }
-
-        let recentTokens = recentlyAdded.recentTokens(within: recentlyAddedWindow.rawValue)
-        var sections = [
-            BrowseSection(
-                title: "Most Popular",
-                destination: .discover(.topCharts),
-                casks: top(casks)
-            ),
-            BrowseSection(
-                title: "Recently Added",
-                destination: .discover(.recentlyAdded),
-                casks: Array(sortedByNewest(casks.filter { recentTokens.contains($0.token) }).prefix(Self.browseSectionSize))
-            )
-        ]
-        for entry in categoryService.orderedCategories where entry.id != "other" {
-            let tokens = categoryService.tokens(in: entry.id)
-            sections.append(BrowseSection(
-                title: entry.definition.displayName,
-                destination: .category(entry.id),
-                casks: top(casks.filter { tokens.contains($0.token) })
-            ))
-        }
-        return sections.filter { !$0.casks.isEmpty }
-    }
-
-    // MARK: - Filtered Casks (3-stage pipeline)
-
-    var filteredCasks: [Cask] {
-        let sidebarFiltered = applySidebarFilter(to: casks)
-        let searched = applySearch(to: sidebarFiltered)
-        return applySort(to: searched)
-    }
-
-    private func applySidebarFilter(to casks: [Cask]) -> [Cask] {
-        switch selectedSidebar {
-        case .discover(.browse):
-            return casks
-
-        case .discover(.featured):
-            return Array(sortedByDownloads(casks, using: downloadCounts).prefix(100))
-
-        case .discover(.topCharts):
-            return casks
-
-        case .discover(.recentlyAdded):
-            let recentTokens = recentlyAdded.recentTokens(within: recentlyAddedWindow.rawValue)
-            return casks.filter { recentTokens.contains($0.token) }
-
-        case .library(.installed):
-            return installedCasks
-
-        case .library(.updates):
-            return updatableCasks
-
-        case .library(.adopt):
-            return adoptableCasks
-
-        case let .category(categoryID):
-            let tokens = categoryService.tokens(in: categoryID)
-            return casks.filter { tokens.contains($0.token) }
-        }
-    }
-
-    private func applySearch(to casks: [Cask]) -> [Cask] {
-        guard !searchText.isEmpty else { return casks }
-        let query = searchText.lowercased()
-        return casks.filter { cask in
-            cask.displayName.lowercased().contains(query)
-                || cask.token.lowercased().contains(query)
-                || (cask.desc?.lowercased().contains(query) ?? false)
-        }
-    }
-
-    private func sortedByDownloads(_ source: [Cask], using counts: [String: Int]) -> [Cask] {
-        source.sorted { (counts[$0.token] ?? 0) > (counts[$1.token] ?? 0) }
-    }
-
-    private func sortedByNewest(_ source: [Cask]) -> [Cask] {
-        source.sorted { (recentlyAdded.addedDate(for: $0.token) ?? "") > (recentlyAdded.addedDate(for: $1.token) ?? "") }
-    }
-
-    private func sortedByRecentlyInstalled(_ source: [Cask]) -> [Cask] {
-        source.sorted { lhs, rhs in
-            let lhsDate = localHomebrew.installedCasks[lhs.token]?.installedAt
-            let rhsDate = localHomebrew.installedCasks[rhs.token]?.installedAt
-            if lhsDate != rhsDate {
-                if let lhsDate, let rhsDate { return lhsDate > rhsDate }
-                return lhsDate != nil
-            }
-            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
-                == .orderedAscending
-        }
-    }
-
-    private func applySort(to casks: [Cask]) -> [Cask] {
-        switch sortOption {
-        case .mostPopular:
-            return sortedByDownloads(casks, using: downloadCounts)
-        case .nameAZ:
-            return casks.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
-        case .nameZA:
-            return casks.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedDescending }
-        case .recentlyInstalled:
-            return sortedByRecentlyInstalled(casks)
-        case .newest:
-            return sortedByNewest(casks)
-        case .oldest:
-            return casks.sorted { (recentlyAdded.addedDate(for: $0.token) ?? "9999") < (recentlyAdded.addedDate(for: $1.token) ?? "9999") }
         }
     }
 

--- a/CaskHub/ViewModels/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/CaskCatalogViewModel.swift
@@ -53,7 +53,7 @@ final class CaskCatalogViewModel {
     @ObservationIgnored let libraryCache =
         MemoizedValue<CatalogLibraryCacheKey, CatalogLibrarySnapshot>()
     @ObservationIgnored let filteredCache =
-        MemoizedValue<FilteredCatalogCacheKey, [Cask]>()
+        BoundedMemoizedValues<FilteredCatalogCacheKey, [Cask]>(capacity: 16)
     @ObservationIgnored let browseCache =
         MemoizedValue<BrowseCatalogCacheKey, [BrowseSection]>()
 

--- a/CaskHub/ViewModels/CatalogProjectionCache.swift
+++ b/CaskHub/ViewModels/CatalogProjectionCache.swift
@@ -9,6 +9,7 @@ struct CatalogLibrarySnapshot {
     let updatableCasks: [Cask]
     let installedCasks: [Cask]
     let adoptableCasks: [Cask]
+    let casksByCategory: [String: [Cask]]
     let categoryCounts: [String: Int]
     let localStates: [String: CaskLocalState]
 }
@@ -22,6 +23,32 @@ final class MemoizedValue<Key: Equatable, Value> {
         }
         let value = create()
         entry = (key, value)
+        return value
+    }
+}
+
+final class BoundedMemoizedValues<Key: Equatable, Value> {
+    private let capacity: Int
+    private var entries: [(key: Key, value: Value)] = []
+
+    init(capacity: Int) {
+        precondition(capacity > 0)
+        self.capacity = capacity
+        entries.reserveCapacity(capacity)
+    }
+
+    func value(for key: Key, create: () -> Value) -> Value {
+        if let index = entries.firstIndex(where: { $0.key == key }) {
+            let entry = entries.remove(at: index)
+            entries.append(entry)
+            return entry.value
+        }
+
+        let value = create()
+        if entries.count == capacity {
+            entries.removeFirst()
+        }
+        entries.append((key, value))
         return value
     }
 }

--- a/CaskHub/ViewModels/CatalogProjectionCache.swift
+++ b/CaskHub/ViewModels/CatalogProjectionCache.swift
@@ -1,0 +1,49 @@
+//
+//  CatalogProjectionCache.swift
+//  CaskHub
+//
+
+import Foundation
+
+struct CatalogLibrarySnapshot {
+    let updatableCasks: [Cask]
+    let installedCasks: [Cask]
+    let adoptableCasks: [Cask]
+    let categoryCounts: [String: Int]
+}
+
+final class MemoizedValue<Key: Equatable, Value> {
+    private var entry: (key: Key, value: Value)?
+
+    func value(for key: Key, create: () -> Value) -> Value {
+        if let entry, entry.key == key {
+            return entry.value
+        }
+        let value = create()
+        entry = (key, value)
+        return value
+    }
+}
+
+struct CatalogLibraryCacheKey: Equatable {
+    let catalogRevision: Int
+    let installationRevision: Int
+    let categoryRevision: Int
+}
+
+struct FilteredCatalogCacheKey: Equatable {
+    let library: CatalogLibraryCacheKey
+    let recentlyAddedRevision: Int
+    let analyticsPeriod: AnalyticsPeriod
+    let recentlyAddedWindow: RecentlyAddedWindow
+    let selectedSidebar: SidebarSelection
+    let searchText: String
+    let sortOption: SortOption
+}
+
+struct BrowseCatalogCacheKey: Equatable {
+    let catalogRevision: Int
+    let categoryRevision: Int
+    let recentlyAddedRevision: Int
+    let recentlyAddedWindow: RecentlyAddedWindow
+}

--- a/CaskHub/ViewModels/CatalogProjectionCache.swift
+++ b/CaskHub/ViewModels/CatalogProjectionCache.swift
@@ -10,6 +10,7 @@ struct CatalogLibrarySnapshot {
     let installedCasks: [Cask]
     let adoptableCasks: [Cask]
     let categoryCounts: [String: Int]
+    let localStates: [String: CaskLocalState]
 }
 
 final class MemoizedValue<Key: Equatable, Value> {

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -224,7 +224,8 @@ private extension ContentView {
                     HeroCard(
                         cask: hero,
                         downloads: viewModel.formattedDownloads(for: hero.token),
-                        categoryName: categoryInfo(for: hero)?.name
+                        categoryName: categoryInfo(for: hero)?.name,
+                        localState: viewModel.localState(for: hero)
                     )
                 }
                 if showsBrowseSections {
@@ -250,7 +251,8 @@ private extension ContentView {
                     cask: cask,
                     downloads: viewModel.formattedDownloads(for: cask.token),
                     category: categoryInfo(for: cask),
-                    onSelectCategory: { selectedSidebar = .category($0) }
+                    onSelectCategory: { selectedSidebar = .category($0) },
+                    localState: viewModel.localState(for: cask)
                 )
             }
         }
@@ -286,7 +288,8 @@ private extension ContentView {
                 ForEach(viewModel.filteredCasks) { cask in
                     CaskRowView(
                         cask: cask,
-                        downloads: viewModel.formattedDownloads(for: cask.token)
+                        downloads: viewModel.formattedDownloads(for: cask.token),
+                        localState: viewModel.localState(for: cask)
                     )
                     .padding(.vertical, 6)
 

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -11,12 +11,15 @@ enum ViewMode: String {
     case grid, list
 }
 
+private enum CatalogScrollAnchor: Hashable {
+    case top
+}
+
 struct ContentView: View {
     @Bindable var viewModel: CaskCatalogViewModel
     @Environment(CategoryService.self) private var categoryService
     @Environment(RecentlyAddedService.self) private var recentlyAdded
     @Environment(LocalHomebrewService.self) private var localHomebrew
-    @State private var selectedSidebar: SidebarSelection = .discover(.browse)
     @AppStorage("viewMode") private var viewMode: ViewMode = .grid
     @FocusState private var searchFocused: Bool
     @State private var showsResultsHeader = false
@@ -30,7 +33,10 @@ struct ContentView: View {
     var body: some View {
         NavigationSplitView {
             SidebarView(
-                selection: $selectedSidebar,
+                selection: Binding(
+                    get: { viewModel.selectedSidebar },
+                    set: { viewModel.selectedSidebar = $0 }
+                ),
                 categoryService: categoryService,
                 updatesCount: viewModel.updatesCount,
                 installedCount: viewModel.installedCount,
@@ -121,9 +127,8 @@ struct ContentView: View {
             async let addedDates: Void = recentlyAdded.refreshFromRemote()
             _ = await(catalog, local, categories, addedDates)
         }
-        .onChange(of: selectedSidebar) { _, newValue in
+        .onChange(of: viewModel.selectedSidebar) { _, newValue in
             Analytics.pageOpened(newValue)
-            viewModel.selectedSidebar = newValue
             if newValue == .discover(.topCharts) {
                 Task { await viewModel.selectAnalyticsPeriod(viewModel.analyticsPeriod) }
             }
@@ -186,6 +191,10 @@ struct ContentView: View {
         }
     }
 
+    private var selectedSidebar: SidebarSelection {
+        viewModel.selectedSidebar
+    }
+
     private var heroCask: Cask? {
         guard showsBrowseSections else { return nil }
         return viewModel.filteredCasks.first
@@ -218,30 +227,35 @@ struct ContentView: View {
 
 private extension ContentView {
     var gridView: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: CHSpace.s4) {
-                if let hero = heroCask {
-                    HeroCard(
-                        cask: hero,
-                        downloads: viewModel.formattedDownloads(for: hero.token),
-                        categoryName: categoryInfo(for: hero)?.name,
-                        localState: viewModel.localState(for: hero)
-                    )
-                }
-                if showsBrowseSections {
-                    ForEach(viewModel.browseSections) { section in
-                        browseSectionView(section)
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: CHSpace.s4) {
+                    if let hero = heroCask {
+                        HeroCard(
+                            cask: hero,
+                            downloads: viewModel.formattedDownloads(for: hero.token),
+                            categoryName: categoryInfo(for: hero)?.name,
+                            localState: viewModel.localState(for: hero)
+                        )
                     }
-                } else {
-                    caskGrid(viewModel.filteredCasks)
+                    if showsBrowseSections {
+                        ForEach(viewModel.browseSections) { section in
+                            browseSectionView(section)
+                        }
+                    } else {
+                        caskGrid(viewModel.filteredCasks)
+                    }
                 }
+                .id(CatalogScrollAnchor.top)
+                .frame(width: CHSize.contentWidth, alignment: .leading)
+                .frame(maxWidth: .infinity)
             }
-            .frame(width: CHSize.contentWidth, alignment: .leading)
-            .frame(maxWidth: .infinity)
+            .contentMargins(.bottom, 44, for: .scrollContent)
+            .scrollContentBackground(.hidden)
+            .onChange(of: selectedSidebar) {
+                resetScrollPosition(proxy)
+            }
         }
-        .contentMargins(.bottom, 44, for: .scrollContent)
-        .scrollContentBackground(.hidden)
-        .id(selectedSidebar)
     }
 
     func caskGrid(_ casks: [Cask]) -> some View {
@@ -251,7 +265,7 @@ private extension ContentView {
                     cask: cask,
                     downloads: viewModel.formattedDownloads(for: cask.token),
                     category: categoryInfo(for: cask),
-                    onSelectCategory: { selectedSidebar = .category($0) },
+                    onSelectCategory: { viewModel.selectedSidebar = .category($0) },
                     localState: viewModel.localState(for: cask)
                 )
             }
@@ -267,7 +281,7 @@ private extension ContentView {
                 Spacer()
                 Button {
                     Analytics.viewAllTapped(to: section.destination)
-                    selectedSidebar = section.destination
+                    viewModel.selectedSidebar = section.destination
                 } label: {
                     Text("View All")
                         .font(CHType.button)
@@ -283,26 +297,41 @@ private extension ContentView {
     // MARK: - List View
 
     var listView: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(viewModel.filteredCasks) { cask in
-                    CaskRowView(
-                        cask: cask,
-                        downloads: viewModel.formattedDownloads(for: cask.token),
-                        localState: viewModel.localState(for: cask)
-                    )
-                    .padding(.vertical, 6)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(viewModel.filteredCasks) { cask in
+                        CaskRowView(
+                            cask: cask,
+                            downloads: viewModel.formattedDownloads(for: cask.token),
+                            localState: viewModel.localState(for: cask)
+                        )
+                        .padding(.vertical, 6)
 
-                    Color.chHairline
-                        .frame(height: 1)
+                        Color.chHairline
+                            .frame(height: 1)
+                    }
                 }
+                .id(CatalogScrollAnchor.top)
+                .frame(width: CHSize.contentWidth)
+                .frame(maxWidth: .infinity)
             }
-            .frame(width: CHSize.contentWidth)
-            .frame(maxWidth: .infinity)
+            .contentMargins(.bottom, 44, for: .scrollContent)
+            .scrollContentBackground(.hidden)
+            .onChange(of: selectedSidebar) {
+                resetScrollPosition(proxy)
+            }
         }
-        .contentMargins(.bottom, 44, for: .scrollContent)
-        .scrollContentBackground(.hidden)
-        .id(selectedSidebar)
+    }
+
+    func resetScrollPosition(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.async {
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                proxy.scrollTo(CatalogScrollAnchor.top, anchor: .top)
+            }
+        }
     }
 
     // MARK: - Error View

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -104,11 +104,10 @@ struct ContentView: View {
                 .allowsHitTesting(false)
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            StatusBarView(
+            ObservedStatusBarView(
                 caskCount: viewModel.casks.count,
                 brewVersion: localHomebrew.brewVersion,
-                caskFlowRelease: categoryService.releaseTag,
-                operation: localHomebrew.statusBarOperation
+                caskFlowRelease: categoryService.releaseTag
             )
         }
         .containerBackground(for: .window) {

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -170,12 +170,7 @@ struct ContentView: View {
             errorView(error)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            switch viewMode {
-            case .grid:
-                gridView
-            case .list:
-                listView
-            }
+            catalogView
         }
     }
 
@@ -222,31 +217,63 @@ struct ContentView: View {
 // MARK: - Grid, List & Error Views
 
 private extension ContentView {
-    var gridView: some View {
+    var catalogView: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: CHSpace.s4) {
-                if let hero = heroCask {
-                    HeroCard(
-                        cask: hero,
-                        downloads: viewModel.formattedDownloads(for: hero.token),
-                        categoryName: categoryInfo(for: hero)?.name,
-                        localState: viewModel.localState(for: hero)
-                    )
-                }
-                if showsBrowseSections {
-                    ForEach(viewModel.browseSections) { section in
-                        browseSectionView(section)
-                    }
-                } else {
-                    caskGrid(viewModel.filteredCasks)
-                }
-            }
-            .frame(width: CHSize.contentWidth, alignment: .leading)
-            .frame(maxWidth: .infinity)
+            catalogContent
         }
         .contentMargins(.bottom, 44, for: .scrollContent)
         .scrollContentBackground(.hidden)
         .modifier(ResetScrollOnChange(trigger: selectedSidebar))
+    }
+
+    @ViewBuilder
+    var catalogContent: some View {
+        switch viewMode {
+        case .grid:
+            gridContent
+        case .list:
+            listContent
+        }
+    }
+
+    var gridContent: some View {
+        VStack(alignment: .leading, spacing: CHSpace.s4) {
+            if let hero = heroCask {
+                HeroCard(
+                    cask: hero,
+                    downloads: viewModel.formattedDownloads(for: hero.token),
+                    categoryName: categoryInfo(for: hero)?.name,
+                    localState: viewModel.localState(for: hero)
+                )
+            }
+            if showsBrowseSections {
+                ForEach(viewModel.browseSections) { section in
+                    browseSectionView(section)
+                }
+            } else {
+                caskGrid(viewModel.filteredCasks)
+            }
+        }
+        .frame(width: CHSize.contentWidth, alignment: .leading)
+        .frame(maxWidth: .infinity)
+    }
+
+    var listContent: some View {
+        LazyVStack(spacing: 0) {
+            ForEach(viewModel.filteredCasks) { cask in
+                CaskRowView(
+                    cask: cask,
+                    downloads: viewModel.formattedDownloads(for: cask.token),
+                    localState: viewModel.localState(for: cask)
+                )
+                .padding(.vertical, 6)
+
+                Color.chHairline
+                    .frame(height: 1)
+            }
+        }
+        .frame(width: CHSize.contentWidth)
+        .frame(maxWidth: .infinity)
     }
 
     func caskGrid(_ casks: [Cask]) -> some View {
@@ -283,31 +310,6 @@ private extension ContentView {
             caskGrid(section.casks)
         }
         .padding(.top, CHSpace.s3)
-    }
-
-    // MARK: - List View
-
-    var listView: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(viewModel.filteredCasks) { cask in
-                    CaskRowView(
-                        cask: cask,
-                        downloads: viewModel.formattedDownloads(for: cask.token),
-                        localState: viewModel.localState(for: cask)
-                    )
-                    .padding(.vertical, 6)
-
-                    Color.chHairline
-                        .frame(height: 1)
-                }
-            }
-            .frame(width: CHSize.contentWidth)
-            .frame(maxWidth: .infinity)
-        }
-        .contentMargins(.bottom, 44, for: .scrollContent)
-        .scrollContentBackground(.hidden)
-        .modifier(ResetScrollOnChange(trigger: selectedSidebar))
     }
 
     // MARK: - Error View

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -11,10 +11,6 @@ enum ViewMode: String {
     case grid, list
 }
 
-private enum CatalogScrollAnchor: Hashable {
-    case top
-}
-
 struct ContentView: View {
     @Bindable var viewModel: CaskCatalogViewModel
     @Environment(CategoryService.self) private var categoryService
@@ -227,35 +223,30 @@ struct ContentView: View {
 
 private extension ContentView {
     var gridView: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: CHSpace.s4) {
-                    if let hero = heroCask {
-                        HeroCard(
-                            cask: hero,
-                            downloads: viewModel.formattedDownloads(for: hero.token),
-                            categoryName: categoryInfo(for: hero)?.name,
-                            localState: viewModel.localState(for: hero)
-                        )
-                    }
-                    if showsBrowseSections {
-                        ForEach(viewModel.browseSections) { section in
-                            browseSectionView(section)
-                        }
-                    } else {
-                        caskGrid(viewModel.filteredCasks)
-                    }
+        ScrollView {
+            VStack(alignment: .leading, spacing: CHSpace.s4) {
+                if let hero = heroCask {
+                    HeroCard(
+                        cask: hero,
+                        downloads: viewModel.formattedDownloads(for: hero.token),
+                        categoryName: categoryInfo(for: hero)?.name,
+                        localState: viewModel.localState(for: hero)
+                    )
                 }
-                .id(CatalogScrollAnchor.top)
-                .frame(width: CHSize.contentWidth, alignment: .leading)
-                .frame(maxWidth: .infinity)
+                if showsBrowseSections {
+                    ForEach(viewModel.browseSections) { section in
+                        browseSectionView(section)
+                    }
+                } else {
+                    caskGrid(viewModel.filteredCasks)
+                }
             }
-            .contentMargins(.bottom, 44, for: .scrollContent)
-            .scrollContentBackground(.hidden)
-            .onChange(of: selectedSidebar) {
-                resetScrollPosition(proxy)
-            }
+            .frame(width: CHSize.contentWidth, alignment: .leading)
+            .frame(maxWidth: .infinity)
         }
+        .contentMargins(.bottom, 44, for: .scrollContent)
+        .scrollContentBackground(.hidden)
+        .modifier(ResetScrollOnChange(trigger: selectedSidebar))
     }
 
     func caskGrid(_ casks: [Cask]) -> some View {
@@ -297,41 +288,26 @@ private extension ContentView {
     // MARK: - List View
 
     var listView: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(viewModel.filteredCasks) { cask in
-                        CaskRowView(
-                            cask: cask,
-                            downloads: viewModel.formattedDownloads(for: cask.token),
-                            localState: viewModel.localState(for: cask)
-                        )
-                        .padding(.vertical, 6)
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.filteredCasks) { cask in
+                    CaskRowView(
+                        cask: cask,
+                        downloads: viewModel.formattedDownloads(for: cask.token),
+                        localState: viewModel.localState(for: cask)
+                    )
+                    .padding(.vertical, 6)
 
-                        Color.chHairline
-                            .frame(height: 1)
-                    }
+                    Color.chHairline
+                        .frame(height: 1)
                 }
-                .id(CatalogScrollAnchor.top)
-                .frame(width: CHSize.contentWidth)
-                .frame(maxWidth: .infinity)
             }
-            .contentMargins(.bottom, 44, for: .scrollContent)
-            .scrollContentBackground(.hidden)
-            .onChange(of: selectedSidebar) {
-                resetScrollPosition(proxy)
-            }
+            .frame(width: CHSize.contentWidth)
+            .frame(maxWidth: .infinity)
         }
-    }
-
-    func resetScrollPosition(_ proxy: ScrollViewProxy) {
-        DispatchQueue.main.async {
-            var transaction = Transaction()
-            transaction.disablesAnimations = true
-            withTransaction(transaction) {
-                proxy.scrollTo(CatalogScrollAnchor.top, anchor: .top)
-            }
-        }
+        .contentMargins(.bottom, 44, for: .scrollContent)
+        .scrollContentBackground(.hidden)
+        .modifier(ResetScrollOnChange(trigger: selectedSidebar))
     }
 
     // MARK: - Error View
@@ -348,6 +324,30 @@ private extension ContentView {
                 Task { await viewModel.fetchCasks() }
             }
         }
+    }
+}
+
+private struct ResetScrollOnChange<Trigger: Equatable>: ViewModifier {
+    let trigger: Trigger
+    @State private var position = ScrollPosition(edge: .top)
+    @State private var isAtTop = true
+
+    func body(content: Content) -> some View {
+        content
+            .scrollPosition($position)
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.contentOffset.y <= geometry.contentInsets.top + 1
+            } action: { _, newValue in
+                isAtTop = newValue
+            }
+            .onChange(of: trigger) {
+                guard !isAtTop else { return }
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    position.scrollTo(edge: .top)
+                }
+            }
     }
 }
 

--- a/CaskHub/Views/Shared/CaskCardView.swift
+++ b/CaskHub/Views/Shared/CaskCardView.swift
@@ -12,6 +12,7 @@ struct CaskCardView: View {
     var downloads: String?
     var category: (id: String, name: String)?
     var onSelectCategory: ((String) -> Void)?
+    var localState: CaskLocalState?
 
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @State private var showingInfo = false
@@ -23,7 +24,11 @@ struct CaskCardView: View {
             descriptionText
             metadataLine
             Spacer(minLength: 2)
-            CaskActionsView(cask: cask, onUninstall: canUninstall ? { showDeleteConfirmation = true } : nil)
+            CaskActionsView(
+                cask: cask,
+                localState: localState,
+                onUninstall: canUninstall ? { showDeleteConfirmation = true } : nil
+            )
         }
         .padding(.vertical, 14)
         .padding(.horizontal, 15)
@@ -33,7 +38,8 @@ struct CaskCardView: View {
     }
 
     private var canUninstall: Bool {
-        localHomebrew.isInstalled(token: cask.token)
+        localState?.isHomebrewInstalled
+            ?? localHomebrew.isInstalled(token: cask.token)
     }
 
     // MARK: - Header (icon well + name + info)

--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CaskRowView: View {
     let cask: Cask
     var downloads: String?
+    var localState: CaskLocalState?
 
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @State private var showDeleteConfirmation = false
@@ -62,6 +63,7 @@ struct CaskRowView: View {
     private var actionsControl: some View {
         CaskActionsView(
             cask: cask,
+            localState: localState,
             fullWidth: true,
             showsUninstallControl: false,
             usesIconOnlyOpenAndUpdate: true
@@ -96,15 +98,17 @@ struct CaskRowView: View {
     }
 
     private var hasAvailableUpdate: Bool {
-        localHomebrew.hasAvailableUpdate(
-            token: cask.token,
-            remoteVersion: cask.version,
-            autoUpdates: cask.autoUpdates
-        )
+        localState?.hasAvailableUpdate
+            ?? localHomebrew.hasAvailableUpdate(
+                token: cask.token,
+                remoteVersion: cask.version,
+                autoUpdates: cask.autoUpdates
+            )
     }
 
     private var uninstallAvailability: CaskUninstallAvailability {
-        localHomebrew.uninstallAvailability(for: cask)
+        localState?.uninstallAvailability
+            ?? localHomebrew.uninstallAvailability(for: cask)
     }
 
     private var isBusy: Bool {

--- a/CaskHubTests/CaskCatalogSortTests.swift
+++ b/CaskHubTests/CaskCatalogSortTests.swift
@@ -97,4 +97,71 @@ final class CaskCatalogSortTests: XCTestCase {
         XCTAssertEqual(vm.sortOption, .nameAZ)
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["able", "bravo"])
     }
+
+    @MainActor
+    func test_repeated_catalog_projection_performance() async {
+        let itemCount = 1_500
+        let casks = (0..<itemCount).map { makeCask("app-\($0)") }
+        let analytics = (0..<itemCount).map { ("app-\($0)", "\($0 + 1)") }
+        let (vm, _) = await makeSUT(casks: casks, analytics: analytics)
+        var checksum = 0
+
+        measure(metrics: [XCTClockMetric()]) {
+            var iterationChecksum = 0
+            for _ in 0..<20 {
+                iterationChecksum += vm.filteredCasks.count
+                iterationChecksum += vm.installedCount
+                iterationChecksum += vm.updatesCount
+                iterationChecksum += vm.adoptableCasks.count
+                iterationChecksum += vm.categoryCounts.count
+            }
+            checksum = iterationChecksum
+        }
+
+        XCTAssertEqual(checksum, itemCount * 20)
+    }
+
+    @MainActor
+    func test_cached_projections_invalidate_for_each_catalog_dependency() async {
+        let local = LocalHomebrewService(
+            defaults: makeScratchDefaults("projection-invalidation")
+        )
+        let categories = CategoryService()
+        let recentlyAdded = RecentlyAddedService()
+        let cask = makeCask("example", version: "2.0")
+        let (vm, _) = await makeSUT(
+            casks: [cask],
+            categories: categories,
+            recentlyAdded: recentlyAdded,
+            localHomebrew: local
+        )
+
+        XCTAssertEqual(vm.installedCount, 0)
+        local.installedCasks[cask.token] = installation(cask.token, version: "1.0")
+        XCTAssertEqual(vm.installedCount, 1)
+        XCTAssertEqual(vm.updatesCount, 1)
+
+        vm.selectedSidebar = .discover(.recentlyAdded)
+        XCTAssertTrue(vm.filteredCasks.isEmpty)
+        recentlyAdded.addedDates[cask.token] = dateString(daysAgo: 1)
+        XCTAssertEqual(vm.filteredCasks.map(\.token), [cask.token])
+
+        vm.selectedSidebar = .category("utilities")
+        XCTAssertTrue(vm.filteredCasks.isEmpty)
+        categories.applyData(CaskCategoryData(
+            version: 1,
+            generatedDate: "2026-07-25",
+            releaseTag: nil,
+            totalCasks: 1,
+            categories: [
+                "utilities": CategoryDefinition(displayName: "Utilities", icon: "wrench")
+            ],
+            tokenToCategory: [
+                cask.token: TokenCategoryMapping(primary: "utilities", secondary: [])
+            ],
+            iconTokens: nil
+        ))
+        XCTAssertEqual(vm.filteredCasks.map(\.token), [cask.token])
+        XCTAssertEqual(vm.categoryCounts["utilities"], 1)
+    }
 }

--- a/CaskHubTests/CaskCatalogSortTests.swift
+++ b/CaskHubTests/CaskCatalogSortTests.swift
@@ -20,6 +20,29 @@ final class CaskCatalogSortTests: XCTestCase {
     }
 
     @MainActor
+    private func alternatingCategories(for casks: [Cask]) -> CategoryService {
+        let categories = CategoryService()
+        categories.applyData(CaskCategoryData(
+            version: 1,
+            generatedDate: "2026-07-25",
+            releaseTag: nil,
+            totalCasks: casks.count,
+            categories: [
+                "even": CategoryDefinition(displayName: "Even", icon: "2.circle"),
+                "odd": CategoryDefinition(displayName: "Odd", icon: "1.circle")
+            ],
+            tokenToCategory: Dictionary(
+                uniqueKeysWithValues: casks.enumerated().map { index, cask in
+                    let category = index.isMultiple(of: 2) ? "even" : "odd"
+                    return (cask.token, TokenCategoryMapping(primary: category, secondary: []))
+                }
+            ),
+            iconTokens: nil
+        ))
+        return categories
+    }
+
+    @MainActor
     func test_sort_options_order_by_downloads_name_and_added_date() async {
         let recent = RecentlyAddedService()
         recent.addedDates = [
@@ -119,6 +142,65 @@ final class CaskCatalogSortTests: XCTestCase {
         }
 
         XCTAssertEqual(checksum, itemCount * 20)
+    }
+
+    @MainActor
+    func test_repeated_sidebar_projection_performance() async {
+        let itemCount = 1_500
+        let casks = (0 ..< itemCount).map { makeCask("app-\($0)") }
+        let analytics = (0 ..< itemCount).map { ("app-\($0)", "\($0 + 1)") }
+        let categories = alternatingCategories(for: casks)
+        let (vm, _) = await makeSUT(
+            casks: casks,
+            analytics: analytics,
+            categories: categories
+        )
+        let routes: [SidebarSelection] = [
+            .discover(.browse),
+            .category("even"),
+            .library(.installed),
+            .library(.adopt),
+            .category("odd"),
+            .discover(.recentlyAdded)
+        ]
+        for route in routes {
+            vm.selectedSidebar = route
+            _ = vm.filteredCasks.count
+        }
+        var checksum = 0
+
+        measure(metrics: [XCTClockMetric()]) {
+            var iterationChecksum = 0
+            for _ in 0 ..< 20 {
+                for route in routes {
+                    vm.selectedSidebar = route
+                    iterationChecksum += vm.filteredCasks.count
+                }
+            }
+            checksum = iterationChecksum
+        }
+
+        XCTAssertEqual(checksum, itemCount * 40)
+    }
+
+    func test_bounded_memoization_reuses_multiple_keys_and_evicts_lru() {
+        let cache = BoundedMemoizedValues<Int, String>(capacity: 2)
+        var buildCount = 0
+        func value(for key: Int) -> String {
+            cache.value(for: key) {
+                buildCount += 1
+                return "value-\(key)"
+            }
+        }
+
+        XCTAssertEqual(value(for: 1), "value-1")
+        XCTAssertEqual(value(for: 2), "value-2")
+        XCTAssertEqual(value(for: 1), "value-1")
+        XCTAssertEqual(buildCount, 2)
+
+        XCTAssertEqual(value(for: 3), "value-3")
+        XCTAssertEqual(value(for: 2), "value-2")
+        XCTAssertEqual(buildCount, 4)
     }
 
     @MainActor

--- a/CaskHubTests/CaskHubTests.swift
+++ b/CaskHubTests/CaskHubTests.swift
@@ -7,6 +7,7 @@
 
 @testable import CaskHub
 import SwiftUI
+import Synchronization
 import XCTest
 
 final class CaskHubTests: XCTestCase {
@@ -322,7 +323,9 @@ final class CaskHubTests: XCTestCase {
 }
 
 final class RequestRecordingProtocol: URLProtocol {
-    nonisolated(unsafe) static var requestedHosts: [String] = []
+    private static let requestedHosts = Mutex<[String]>([])
+    static func reset() { requestedHosts.withLock { $0.removeAll() } }
+    static func snapshot() -> [String] { requestedHosts.withLock { $0 } }
 
     override static func canInit(with _: URLRequest) -> Bool {
         true
@@ -334,7 +337,7 @@ final class RequestRecordingProtocol: URLProtocol {
 
     override func startLoading() {
         if let host = request.url?.host() {
-            Self.requestedHosts.append(host)
+            Self.requestedHosts.withLock { $0.append(host) }
         }
         client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
     }
@@ -361,32 +364,34 @@ final class ImageCacheManifestGateTests: XCTestCase {
     func test_cli_cask_missing_from_manifest_makes_no_request() async {
         let cache = makeCache()
         cache.knownIconTokens = { [] }
-        RequestRecordingProtocol.requestedHosts = []
+        RequestRecordingProtocol.reset()
 
         let image = await cache.image(for: cliCask("gate-cli-\(UUID().uuidString)"))
 
         XCTAssertNil(image)
-        XCTAssertEqual(RequestRecordingProtocol.requestedHosts, [])
+        XCTAssertEqual(RequestRecordingProtocol.snapshot(), [])
     }
 
     @MainActor
     func test_app_cask_missing_from_manifest_probes_only_appfair() async {
         let cache = makeCache()
         cache.knownIconTokens = { [] }
-        RequestRecordingProtocol.requestedHosts = []
+        RequestRecordingProtocol.reset()
 
         _ = await cache.image(for: Cask.preview(token: "gate-app-\(UUID().uuidString)"))
 
-        XCTAssertEqual(RequestRecordingProtocol.requestedHosts, ["github.com"])
+        let hosts = RequestRecordingProtocol.snapshot()
+        XCTAssertFalse(hosts.isEmpty)
+        XCTAssertEqual(Set(hosts), ["github.com"])
     }
 
     @MainActor
     func test_unknown_manifest_still_probes_caskflow() async {
         let cache = makeCache()
-        RequestRecordingProtocol.requestedHosts = []
+        RequestRecordingProtocol.reset()
 
         _ = await cache.image(for: cliCask("gate-probe-\(UUID().uuidString)"))
 
-        XCTAssertEqual(RequestRecordingProtocol.requestedHosts.first, "cdn.jsdelivr.net")
+        XCTAssertEqual(RequestRecordingProtocol.snapshot().first, "cdn.jsdelivr.net")
     }
 }

--- a/CaskHubTests/CaskOperationProgressTests.swift
+++ b/CaskHubTests/CaskOperationProgressTests.swift
@@ -182,6 +182,13 @@ final class CaskOperationProgressTests: XCTestCase {
                 operation: service.statusBarOperation
             )
         )
+        render(
+            ObservedStatusBarView(
+                caskCount: 3_781,
+                caskFlowRelease: "caskflow-v2026.07.18"
+            )
+            .environment(service)
+        )
     }
 
     @MainActor

--- a/CaskHubTests/ExternalApplicationOwnershipTests.swift
+++ b/CaskHubTests/ExternalApplicationOwnershipTests.swift
@@ -227,6 +227,77 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
         XCTAssertEqual(index.externalCLIPaths, ["tool": cliURL])
     }
 
+    func test_homebrew_application_state_is_resolved_during_the_scan() {
+        let signatures = [
+            CaskApplicationSignature(
+                token: "live",
+                currentBundleNames: ["Live.app"],
+                launchableBundleNames: ["Live.app"]
+            ),
+            CaskApplicationSignature(
+                token: "gone",
+                currentBundleNames: ["Gone.app"],
+                launchableBundleNames: ["Gone.app"]
+            )
+        ]
+        let liveApplication = DetectedApplication(
+            url: URL(fileURLWithPath: "/Applications/Live.app"),
+            bundleName: "Live.app",
+            bundleIdentifier: "com.example.live",
+            isMacAppStore: false,
+            isDirectlyInApplicationDirectory: true
+        )
+        let installed = [
+            "live": LocalCaskInstallation(
+                token: "live", installedVersion: "1.0", installedAt: nil,
+                appBundleNames: ["Live.app"], isZombie: false
+            ),
+            "gone": LocalCaskInstallation(
+                token: "gone", installedVersion: "1.0", installedAt: nil,
+                appBundleNames: ["Gone.app"], isZombie: true
+            )
+        ]
+
+        let result = LocalHomebrewService.resolveHomebrewApplicationState(
+            signatures: signatures,
+            applications: [liveApplication],
+            installedCasks: installed
+        )
+
+        XCTAssertEqual(result.launchableTokens, ["live"])
+        XCTAssertEqual(result.zombieTokens, ["gone"])
+    }
+
+    @MainActor
+    func test_local_state_uses_precomputed_launchability_and_zombie_verdicts() {
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("precomputed-local-state")
+        )
+        let cask = makeCask("gone", version: "2.0", appNames: ["Gone.app"])
+        service.installedCasks[cask.token] = LocalCaskInstallation(
+            token: cask.token,
+            installedVersion: "1.0",
+            installedAt: nil,
+            appBundleNames: ["Gone.app"],
+            isZombie: true
+        )
+        service.installationIndex = CaskInstallationIndex(
+            catalogTokens: [cask.token],
+            macAppStoreApplications: [:],
+            externalCLIPaths: [:],
+            launchableHomebrewTokens: [],
+            verifiedZombieTokens: [cask.token]
+        )
+
+        let state = service.localState(for: cask)
+
+        XCTAssertEqual(state.installationSource, .homebrew)
+        XCTAssertEqual(state.uninstallAvailability, .available)
+        XCTAssertTrue(state.isZombie)
+        XCTAssertFalse(state.canOpen)
+        XCTAssertFalse(state.hasAvailableUpdate)
+    }
+
     @MainActor
     func test_catalog_resolution_exposes_only_raycast_glaze_for_adoption() async throws {
         let root = FileManager.default.temporaryDirectory

--- a/CaskHubTests/ExternalApplicationOwnershipTests.swift
+++ b/CaskHubTests/ExternalApplicationOwnershipTests.swift
@@ -30,6 +30,35 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
         )
     ]
 
+    private func storeApplication(
+        named bundleName: String,
+        bundleIdentifier: String
+    ) -> DetectedApplication {
+        DetectedApplication(
+            url: URL(fileURLWithPath: "/Applications/\(bundleName)"),
+            bundleName: bundleName,
+            bundleIdentifier: bundleIdentifier,
+            isMacAppStore: true,
+            isDirectlyInApplicationDirectory: true
+        )
+    }
+
+    private func storeSignature(
+        token: String,
+        bundleName: String,
+        hasPackage: Bool,
+        applicationIdentifiers: [String] = [],
+        packageIdentifiers: [String] = []
+    ) -> MacAppStoreCaskSignature {
+        MacAppStoreCaskSignature(
+            token: token,
+            bundleNames: [bundleName],
+            hasPackageArtifact: hasPackage,
+            applicationBundleIdentifiers: applicationIdentifiers,
+            packageIdentifiers: packageIdentifiers
+        )
+    }
+
     func test_shared_app_name_resolves_to_exact_bundle_identifier_match() {
         let owners = LocalHomebrewService.resolveExternalApplicationOwners(
             signatures: glazeSignatures,
@@ -111,6 +140,93 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
         XCTAssertEqual(owners["unique"], application)
     }
 
+    func test_store_resolution_indexes_direct_and_bundle_family_matches() {
+        let applications = [
+            storeApplication(
+                named: "Canva.app",
+                bundleIdentifier: "com.canva.CanvaDesktop"
+            ),
+            storeApplication(
+                named: "Tailscale.app",
+                bundleIdentifier: "io.tailscale.ipn.macos"
+            ),
+            storeApplication(
+                named: "Shade.app",
+                bundleIdentifier: "com.limit-point.Shade"
+            )
+        ]
+        let signatures = [
+            storeSignature(
+                token: "canva",
+                bundleName: "Canva.app",
+                hasPackage: false
+            ),
+            storeSignature(
+                token: "tailscale-app",
+                bundleName: "Tailscale.app",
+                hasPackage: true,
+                applicationIdentifiers: ["io.tailscale.ipn.macsys"],
+                packageIdentifiers: ["com.tailscale.ipn.macsys"]
+            ),
+            storeSignature(
+                token: "shade",
+                bundleName: "Shade.app",
+                hasPackage: true,
+                packageIdentifiers: ["com.shade.shade"]
+            )
+        ]
+
+        let result = LocalHomebrewService.resolveMacAppStoreApplications(
+            signatures: signatures,
+            applications: applications,
+            installedCasks: [:]
+        )
+
+        XCTAssertEqual(Set(result.keys), ["canva", "tailscale-app"])
+        XCTAssertEqual(result["canva"], applications[0])
+        XCTAssertEqual(result["tailscale-app"], applications[1])
+    }
+
+    func test_installation_index_excludes_brew_owned_tokens_and_indexes_cli_paths() {
+        let installed = LocalCaskInstallation(
+            token: "store-app",
+            installedVersion: "1.0",
+            installedAt: nil,
+            appBundleNames: ["Store.app"]
+        )
+        let storeApplication = DetectedApplication(
+            url: URL(fileURLWithPath: "/Applications/Store.app"),
+            bundleName: "Store.app",
+            bundleIdentifier: "com.example.store",
+            isMacAppStore: true,
+            isDirectlyInApplicationDirectory: true
+        )
+        let cliURL = URL(fileURLWithPath: "/usr/local/bin/tool")
+
+        let index = LocalHomebrewService.buildInstallationIndex(
+            catalog: CaskInstallationCatalog(
+                tokens: ["store-app", "tool"],
+                macAppStoreSignatures: [
+                    storeSignature(
+                        token: "store-app",
+                        bundleName: "Store.app",
+                        hasPackage: false
+                    )
+                ],
+                binarySignatures: [
+                    BinaryCaskSignature(token: "tool", binaryNames: ["missing", "tool"])
+                ]
+            ),
+            applications: [storeApplication],
+            binaryPaths: ["tool": cliURL],
+            installedCasks: ["store-app": installed]
+        )
+
+        XCTAssertEqual(index.catalogTokens, ["store-app", "tool"])
+        XCTAssertTrue(index.macAppStoreApplications.isEmpty)
+        XCTAssertEqual(index.externalCLIPaths, ["tool": cliURL])
+    }
+
     @MainActor
     func test_catalog_resolution_exposes_only_raycast_glaze_for_adoption() async throws {
         let root = FileManager.default.temporaryDirectory
@@ -140,5 +256,50 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
             service.installationSource(for: raycastGlaze),
             .externalApplication
         )
+    }
+
+    @MainActor
+    func test_catalog_presence_lookup_performance() {
+        let itemCount = 500
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("catalog-presence-performance")
+        )
+        let casks = (0..<itemCount).map { index in
+            makeCask("store-\(index)", appNames: ["Store \(index).app"])
+        }
+        let applications = (0..<itemCount).map { index in
+            storeApplication(
+                named: "Store \(index).app",
+                bundleIdentifier: "com.example.store\(index)"
+            )
+        }
+        let storeSignatures = casks.map { cask in
+            storeSignature(
+                token: cask.token,
+                bundleName: cask.appArtifactNames[0],
+                hasPackage: false
+            )
+        }
+        service.installationIndex = LocalHomebrewService.buildInstallationIndex(
+            catalog: CaskInstallationCatalog(
+                tokens: Set(casks.map(\.token)),
+                macAppStoreSignatures: storeSignatures,
+                binarySignatures: []
+            ),
+            applications: applications,
+            binaryPaths: [:],
+            installedCasks: [:]
+        )
+
+        XCTAssertTrue(service.isPresent(casks[0]))
+        XCTAssertTrue(service.isPresent(casks[itemCount - 1]))
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<20 {
+                for cask in casks {
+                    _ = service.isPresent(cask)
+                }
+            }
+        }
     }
 }

--- a/CaskHubTests/ExternalInstallationTests.swift
+++ b/CaskHubTests/ExternalInstallationTests.swift
@@ -201,7 +201,19 @@ final class ExternalInstallationTests: XCTestCase {
             packageAppNames: ["Package App.app"]
         )
         let (vm, _) = await makeSUT(casks: [store, package], localHomebrew: local)
-        local.macAppStoreAppNames = ["Store App.app"]
+        local.installationIndex = CaskInstallationIndex(
+            catalogTokens: [store.token, package.token],
+            macAppStoreApplications: [
+                store.token: DetectedApplication(
+                    url: URL(fileURLWithPath: "/Applications/Store App.app"),
+                    bundleName: "Store App.app",
+                    bundleIdentifier: "com.example.store-app",
+                    isMacAppStore: true,
+                    isDirectlyInApplicationDirectory: true
+                )
+            ],
+            externalCLIPaths: [:]
+        )
         local.externalPackageInstallations[package.token] = ExternalPackageInstallation(
             receiptIdentifiers: ["com.example.package"],
             appBundleNames: ["Package App.app"]

--- a/script/analyze_cpu_trace.swift
+++ b/script/analyze_cpu_trace.swift
@@ -1,0 +1,334 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+struct Frame {
+    let name: String
+    let binary: String
+    let path: String
+    let sourcePath: String
+}
+
+struct Aggregate {
+    var inclusiveWeight = 0.0
+    var selfWeight = 0.0
+    var sampleCount = 0
+}
+
+enum TraceAnalysisError: Error, CustomStringConvertible {
+    case invalidDocument(String)
+    case usage
+
+    var description: String {
+        switch self {
+        case let .invalidDocument(message):
+            return "Invalid xctrace XML: \(message)"
+        case .usage:
+            return "Usage: script/analyze_cpu_trace.swift <exported-xml> [project-source-root]"
+        }
+    }
+}
+
+final class TraceReferences {
+    private(set) var backtraces: [String: [XMLElement]] = [:]
+    private(set) var binaries: [String: (name: String, path: String)] = [:]
+    private(set) var frames: [String: XMLElement] = [:]
+    private(set) var paths: [String: String] = [:]
+    private(set) var threads: [String: String] = [:]
+    private(set) var weights: [String: Double] = [:]
+
+    init(document: XMLDocument) throws {
+        try loadBinaries(document)
+        try loadPaths(document)
+        try loadFrames(document)
+        try loadBacktraces(document)
+        try loadThreads(document)
+        try loadWeights(document)
+    }
+
+    func resolvedFrames(from element: XMLElement) -> [Frame] {
+        let frameElements: [XMLElement]
+        if let reference = element.attribute(forName: "ref")?.stringValue {
+            frameElements = backtraces[reference] ?? []
+        } else if element.name == "tagged-backtrace",
+                  let nested = element.elements(forName: "backtrace").first {
+            return resolvedFrames(from: nested)
+        } else {
+            frameElements = element.children?.compactMap { $0 as? XMLElement }
+                .filter { $0.name == "frame" } ?? []
+        }
+        return frameElements.compactMap(resolveFrame)
+    }
+
+    func resolvedThreadName(from element: XMLElement?) -> String {
+        guard let element else { return "unknown" }
+        if let name = element.attribute(forName: "name")?.stringValue
+            ?? element.attribute(forName: "fmt")?.stringValue {
+            return name
+        }
+        if let reference = element.attribute(forName: "ref")?.stringValue {
+            return threads[reference] ?? "unknown"
+        }
+        return element.stringValue ?? "unknown"
+    }
+
+    func resolvedWeight(from element: XMLElement?) -> Double {
+        guard let element else { return 1 }
+        if let reference = element.attribute(forName: "ref")?.stringValue {
+            return weights[reference] ?? 1
+        }
+        return Self.parseWeight(
+            element.attribute(forName: "fmt")?.stringValue ?? element.stringValue
+        ) ?? 1
+    }
+
+    private func resolveFrame(_ element: XMLElement) -> Frame? {
+        let definition: XMLElement
+        if let reference = element.attribute(forName: "ref")?.stringValue {
+            guard let stored = frames[reference] else { return nil }
+            definition = stored
+        } else {
+            definition = element
+        }
+
+        let name = definition.attribute(forName: "name")?.stringValue
+            ?? definition.stringValue
+            ?? "unknown"
+        guard let binaryElement = definition.elements(forName: "binary").first else {
+            return Frame(
+                name: name,
+                binary: "unknown",
+                path: "",
+                sourcePath: sourcePath(from: definition)
+            )
+        }
+        let binary: (name: String, path: String)
+        if let reference = binaryElement.attribute(forName: "ref")?.stringValue {
+            binary = binaries[reference] ?? ("unknown", "")
+        } else {
+            let path = binaryElement.attribute(forName: "path")?.stringValue ?? ""
+            let name = binaryElement.attribute(forName: "name")?.stringValue
+                ?? URL(fileURLWithPath: path).lastPathComponent
+            binary = (name, path)
+        }
+        return Frame(
+            name: name,
+            binary: binary.name,
+            path: binary.path,
+            sourcePath: sourcePath(from: definition)
+        )
+    }
+
+    private func loadBinaries(_ document: XMLDocument) throws {
+        for element in try elements(document, xpath: "//binary[@id]") {
+            guard let identifier = element.attribute(forName: "id")?.stringValue else { continue }
+            let path = element.attribute(forName: "path")?.stringValue ?? ""
+            let name = element.attribute(forName: "name")?.stringValue
+                ?? URL(fileURLWithPath: path).lastPathComponent
+            binaries[identifier] = (name, path)
+        }
+    }
+
+    private func loadFrames(_ document: XMLDocument) throws {
+        for element in try elements(document, xpath: "//frame[@id]") {
+            guard let identifier = element.attribute(forName: "id")?.stringValue else { continue }
+            frames[identifier] = element
+        }
+    }
+
+    private func loadPaths(_ document: XMLDocument) throws {
+        for element in try elements(document, xpath: "//path[@id]") {
+            guard let identifier = element.attribute(forName: "id")?.stringValue,
+                  let value = element.stringValue else {
+                continue
+            }
+            paths[identifier] = value
+        }
+    }
+
+    private func loadBacktraces(_ document: XMLDocument) throws {
+        for element in try elements(document, xpath: "//backtrace[@id] | //stack[@id]") {
+            guard let identifier = element.attribute(forName: "id")?.stringValue else { continue }
+            backtraces[identifier] = element.children?.compactMap { $0 as? XMLElement }
+                .filter { $0.name == "frame" } ?? []
+        }
+        for element in try elements(document, xpath: "//tagged-backtrace[@id]") {
+            guard let identifier = element.attribute(forName: "id")?.stringValue,
+                  let nested = element.elements(forName: "backtrace").first else {
+                continue
+            }
+            backtraces[identifier] = nested.children?.compactMap { $0 as? XMLElement }
+                .filter { $0.name == "frame" } ?? []
+        }
+    }
+
+    private func loadThreads(_ document: XMLDocument) throws {
+        for element in try elements(document, xpath: "//thread[@id]") {
+            guard let identifier = element.attribute(forName: "id")?.stringValue else { continue }
+            threads[identifier] = element.attribute(forName: "name")?.stringValue
+                ?? element.attribute(forName: "fmt")?.stringValue
+                ?? element.stringValue
+                ?? "unknown"
+        }
+    }
+
+    private func loadWeights(_ document: XMLDocument) throws {
+        for name in ["weight", "cycle-weight"] {
+            for element in try elements(document, xpath: "//\(name)[@id]") {
+                guard let identifier = element.attribute(forName: "id")?.stringValue,
+                      let value = Self.parseWeight(
+                          element.attribute(forName: "fmt")?.stringValue ?? element.stringValue
+                      ) else {
+                    continue
+                }
+                weights[identifier] = value
+            }
+        }
+    }
+
+    private func elements(_ document: XMLDocument, xpath: String) throws -> [XMLElement] {
+        try document.nodes(forXPath: xpath).compactMap { $0 as? XMLElement }
+    }
+
+    private func sourcePath(from frame: XMLElement) -> String {
+        guard let pathElement = frame.elements(forName: "source").first?
+            .elements(forName: "path").first else {
+            return ""
+        }
+        if let reference = pathElement.attribute(forName: "ref")?.stringValue {
+            return paths[reference] ?? ""
+        }
+        return pathElement.stringValue ?? ""
+    }
+
+    private static func parseWeight(_ value: String?) -> Double? {
+        guard let value else { return nil }
+        let scanner = Scanner(string: value)
+        guard let number = scanner.scanDouble() else { return nil }
+        if value.contains("µs") { return number / 1_000 }
+        if value.contains("ns") { return number / 1_000_000 }
+        if value.contains(" s") { return number * 1_000 }
+        return number
+    }
+}
+
+struct ProfileSummary {
+    let projectSourceRoot: String
+    let references: TraceReferences
+    var aggregates: [String: Aggregate] = [:]
+    var mainThreadWeight = 0.0
+    var rowCount = 0
+    var totalWeight = 0.0
+    var userSampleCount = 0
+
+    mutating func record(row: XMLElement) {
+        let children = row.children?.compactMap { $0 as? XMLElement } ?? []
+        guard let stack = children.first(where: {
+            $0.name == "backtrace"
+                || $0.name == "stack"
+                || $0.name == "tagged-backtrace"
+        }) else {
+            return
+        }
+
+        let frames = references.resolvedFrames(from: stack)
+        let weightElement = children.first {
+            $0.name == "weight" || $0.name == "cycle-weight"
+        }
+        let weight = references.resolvedWeight(from: weightElement)
+        let threadName = references.resolvedThreadName(
+            from: children.first(where: { $0.name == "thread" })
+        )
+
+        rowCount += 1
+        totalWeight += weight
+        if threadName.localizedCaseInsensitiveContains("main") {
+            mainThreadWeight += weight
+        }
+
+        let userFrames = frames.filter(isUserFrame)
+        guard let selfFrame = userFrames.first else { return }
+        userSampleCount += 1
+
+        let selfKey = key(for: selfFrame)
+        aggregates[selfKey, default: Aggregate()].selfWeight += weight
+        aggregates[selfKey, default: Aggregate()].sampleCount += 1
+
+        for frame in uniqueFrames(userFrames) {
+            aggregates[key(for: frame), default: Aggregate()].inclusiveWeight += weight
+        }
+    }
+
+    func printReport(limit: Int = 30) {
+        print("support\tcpu-profile\t\(rowCount > 0 ? "available" : "partial")")
+        print("rows\t\(rowCount)")
+        print(String(format: "total_weight\t%.3f", totalWeight))
+        print("user_samples\t\(userSampleCount)")
+        let mainPercentage = totalWeight > 0 ? mainThreadWeight / totalWeight * 100 : 0
+        print(String(format: "main_thread_weight_pct\t%.2f", mainPercentage))
+        print("inclusive_pct\tself_pct\tsamples\tframe")
+
+        let sorted = aggregates.sorted {
+            if $0.value.inclusiveWeight != $1.value.inclusiveWeight {
+                return $0.value.inclusiveWeight > $1.value.inclusiveWeight
+            }
+            return $0.value.selfWeight > $1.value.selfWeight
+        }
+        for (name, aggregate) in sorted.prefix(limit) {
+            let inclusive = totalWeight > 0 ? aggregate.inclusiveWeight / totalWeight * 100 : 0
+            let selfPercentage = totalWeight > 0 ? aggregate.selfWeight / totalWeight * 100 : 0
+            print(String(
+                format: "%.2f\t%.2f\t%d\t%@",
+                inclusive,
+                selfPercentage,
+                aggregate.sampleCount,
+                name
+            ))
+        }
+    }
+
+    private func isUserFrame(_ frame: Frame) -> Bool {
+        frame.sourcePath.contains(projectSourceRoot)
+            || (frame.sourcePath.isEmpty && frame.binary == "CaskHub")
+    }
+
+    private func uniqueFrames(_ frames: [Frame]) -> [Frame] {
+        var seen: Set<String> = []
+        return frames.filter { seen.insert(key(for: $0)).inserted }
+    }
+
+    private func key(for frame: Frame) -> String {
+        "\(frame.binary): \(frame.name)"
+    }
+}
+
+func run() throws {
+    let arguments = CommandLine.arguments
+    guard arguments.count >= 2 else {
+        throw TraceAnalysisError.usage
+    }
+    let xmlURL = URL(fileURLWithPath: arguments[1])
+    let sourceRoot = arguments.count > 2
+        ? URL(fileURLWithPath: arguments[2]).standardizedFileURL.path
+        : URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("CaskHub")
+            .standardizedFileURL.path
+    let document = try XMLDocument(contentsOf: xmlURL, options: .nodePreserveAll)
+    guard document.rootElement() != nil else {
+        throw TraceAnalysisError.invalidDocument("missing root element")
+    }
+    let references = try TraceReferences(document: document)
+    var summary = ProfileSummary(projectSourceRoot: sourceRoot, references: references)
+    let rows = try document.nodes(forXPath: "//row").compactMap { $0 as? XMLElement }
+    for row in rows {
+        summary.record(row: row)
+    }
+    summary.printReport()
+}
+
+do {
+    try run()
+} catch {
+    fputs("analyze_cpu_trace: \(error)\n", stderr)
+    exit(EXIT_FAILURE)
+}

--- a/script/analyze_cpu_trace.swift
+++ b/script/analyze_cpu_trace.swift
@@ -216,6 +216,7 @@ struct ProfileSummary {
     let projectSourceRoot: String
     let references: TraceReferences
     var aggregates: [String: Aggregate] = [:]
+    var leafAggregates: [String: Aggregate] = [:]
     var mainThreadWeight = 0.0
     var rowCount = 0
     var totalWeight = 0.0
@@ -244,6 +245,12 @@ struct ProfileSummary {
         totalWeight += weight
         if threadName.localizedCaseInsensitiveContains("main") {
             mainThreadWeight += weight
+        }
+
+        if let leafFrame = frames.first {
+            let leafKey = key(for: leafFrame)
+            leafAggregates[leafKey, default: Aggregate()].selfWeight += weight
+            leafAggregates[leafKey, default: Aggregate()].sampleCount += 1
         }
 
         let userFrames = frames.filter(isUserFrame)
@@ -285,11 +292,31 @@ struct ProfileSummary {
                 name
             ))
         }
+
+        print("leaf_pct\tsamples\tleaf_frame")
+        for (name, aggregate) in leafAggregates.sorted(by: {
+            $0.value.selfWeight > $1.value.selfWeight
+        }).prefix(limit) {
+            let percentage = totalWeight > 0 ? aggregate.selfWeight / totalWeight * 100 : 0
+            print(String(
+                format: "%.2f\t%d\t%@",
+                percentage,
+                aggregate.sampleCount,
+                name
+            ))
+        }
     }
 
     private func isUserFrame(_ frame: Frame) -> Bool {
-        frame.sourcePath.contains(projectSourceRoot)
-            || (frame.sourcePath.isEmpty && frame.binary == "CaskHub")
+        guard !isAppEntryPoint(frame) else { return false }
+        return frame.sourcePath.contains(projectSourceRoot)
+            || (frame.sourcePath.isEmpty && frame.binary.hasPrefix("CaskHub"))
+    }
+
+    private func isAppEntryPoint(_ frame: Frame) -> Bool {
+        frame.name == "static CaskHubMain.main()"
+            || frame.name == "static CaskHubMain.$main()"
+            || frame.name == "__debug_main_executable_dylib_entry_point"
     }
 
     private func uniqueFrames(_ frames: [Frame]) -> [Frame] {

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-run}"
+APP_NAME="CaskHub"
+BUNDLE_ID="com.mag.caskhub"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DERIVED_DATA_DIR="${CASKHUB_DERIVED_DATA_DIR:-$ROOT_DIR/.build/DerivedData}"
+APP_BUNDLE="$DERIVED_DATA_DIR/Build/Products/Debug/$APP_NAME.app"
+APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+
+pkill -x "$APP_NAME" >/dev/null 2>&1 || true
+
+xcodebuild \
+  -project "$ROOT_DIR/CaskHub.xcodeproj" \
+  -scheme "$APP_NAME" \
+  -configuration Debug \
+  -destination "platform=macOS" \
+  -derivedDataPath "$DERIVED_DATA_DIR" \
+  build
+
+open_app() {
+  /usr/bin/open -n "$APP_BUNDLE"
+}
+
+case "$MODE" in
+  run)
+    open_app
+    ;;
+  --debug|debug)
+    lldb -- "$APP_BINARY"
+    ;;
+  --logs|logs)
+    open_app
+    /usr/bin/log stream --info --style compact --predicate "process == \"$APP_NAME\""
+    ;;
+  --telemetry|telemetry)
+    open_app
+    /usr/bin/log stream --info --style compact --predicate "subsystem == \"$BUNDLE_ID\""
+    ;;
+  --verify|verify)
+    open_app
+    sleep 1
+    pgrep -x "$APP_NAME" >/dev/null
+    ;;
+  *)
+    echo "usage: $0 [run|--debug|--logs|--telemetry|--verify]" >&2
+    exit 2
+    ;;
+esac

--- a/script/profile_ui.swift
+++ b/script/profile_ui.swift
@@ -118,13 +118,17 @@ struct AppDriver {
     }
 
     func sidebarButton(containing text: String) throws -> AXUIElement {
-        let query = text.lowercased()
         let sidebar = try sidebarScrollArea()
-        let candidates = descendants(of: sidebar).filter { role(of: $0) == kAXButtonRole }
+        return try button(containing: text, in: sidebar)
+    }
+
+    func button(containing text: String, in root: AXUIElement) throws -> AXUIElement {
+        let query = text.lowercased()
+        let candidates = descendants(of: root).filter { role(of: $0) == kAXButtonRole }
         guard let match = candidates.first(where: {
             semanticText(of: $0).lowercased().contains(query)
         }) else {
-            throw ProfileUIError.control("sidebar button containing “\(text)”")
+            throw ProfileUIError.control("button containing “\(text)”")
         }
         return match
     }
@@ -211,26 +215,6 @@ struct AppDriver {
         sleep(0.1)
     }
 
-    func click(at point: CGPoint) throws {
-        let source = CGEventSource(stateID: .combinedSessionState)
-        guard let down = CGEvent(
-            mouseEventSource: source,
-            mouseType: .leftMouseDown,
-            mouseCursorPosition: point,
-            mouseButton: .left
-        ),
-        let up = CGEvent(
-            mouseEventSource: source,
-            mouseType: .leftMouseUp,
-            mouseCursorPosition: point,
-            mouseButton: .left
-        ) else {
-            throw ProfileUIError.control("mouse click event")
-        }
-        down.post(tap: .cghidEventTap)
-        up.post(tap: .cghidEventTap)
-    }
-
     func scroll(at point: CGPoint, delta: Int32, eventCount: Int = 8) throws {
         try raise()
         let source = CGEventSource(stateID: .combinedSessionState)
@@ -309,7 +293,7 @@ func sleep(_ seconds: Double) {
 
 func resolvedSidebarControls(
     driver: AppDriver
-) throws -> [(label: String, point: CGPoint)] {
+) throws -> (sidebar: AXUIElement, labels: [String]) {
     let labels = [
         "Browse",
         "Installed",
@@ -319,31 +303,17 @@ func resolvedSidebarControls(
         "Recently Added"
     ]
     let sidebar = try driver.sidebarScrollArea()
-    guard let sidebarOrigin = driver.position(of: sidebar),
-          let sidebarSize = driver.size(of: sidebar) else {
-        throw ProfileUIError.control("sidebar geometry")
-    }
-    let visibleFrame = CGRect(origin: sidebarOrigin, size: sidebarSize)
-    let controls = labels.compactMap { label -> (String, CGPoint)? in
-        guard let element = try? driver.sidebarButton(containing: label) else {
+    let availableLabels = labels.compactMap { label -> String? in
+        guard (try? driver.button(containing: label, in: sidebar)) != nil else {
             print("missing_control\t\(label)")
             return nil
         }
-        guard let origin = driver.position(of: element), let size = driver.size(of: element) else {
-            print("missing_geometry\t\(label)")
-            return nil
-        }
-        let point = CGPoint(x: origin.x + size.width / 2, y: origin.y + size.height / 2)
-        guard visibleFrame.contains(point) else {
-            print("offscreen_control\t\(label)")
-            return nil
-        }
-        return (label, point)
+        return label
     }
-    guard controls.count >= 3 else {
+    guard availableLabels.count >= 3 else {
         throw ProfileUIError.control("at least three sidebar destinations")
     }
-    return controls
+    return (sidebar, availableLabels)
 }
 
 func runCatalogWorkload(
@@ -377,9 +347,9 @@ func runSidebarWorkload(
     try driver.raise()
     sleep(startDelay)
     for _ in 0 ..< cycles {
-        for control in controls {
-            try driver.click(at: control.point)
-            print("click\t\(control.label)")
+        for label in controls.labels {
+            let button = try driver.button(containing: label, in: controls.sidebar)
+            try driver.timedPress(button, label: label)
             sleep(settleDelay)
         }
     }

--- a/script/profile_ui.swift
+++ b/script/profile_ui.swift
@@ -1,0 +1,472 @@
+#!/usr/bin/env swift
+
+// swiftlint:disable file_length
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+enum ProfileUIError: Error, CustomStringConvertible {
+    case accessibilityPermission
+    case action(String, AXError)
+    case attribute(String, AXError)
+    case control(String)
+    case invalidPID(String)
+    case usage
+
+    var description: String {
+        switch self {
+        case .accessibilityPermission:
+            return "Accessibility permission is required for the terminal running this script."
+        case let .action(name, error):
+            return "Accessibility action \(name) failed with error \(error.rawValue)."
+        case let .attribute(name, error):
+            return "Accessibility attribute \(name) failed with error \(error.rawValue)."
+        case let .control(name):
+            return "Could not find the \(name) control."
+        case let .invalidPID(value):
+            return "Invalid process identifier: \(value)"
+        case .usage:
+            return """
+            Usage: script/profile_ui.swift <mode> <pid> [cycles] [start-delay]
+
+              inspect              Print semantic buttons and scroll areas.
+              state                Print the selected view mode.
+              scroll-position      Print the main content scroll position.
+              press-grid           Select grid mode.
+              press-list           Select list mode.
+              scroll-down          Scroll the main catalog down.
+              scroll-up            Scroll the main catalog up.
+              workload             Alternate grid/list and scroll.
+              sidebar-workload     Cycle through sidebar destinations.
+              sidebar-benchmark    Time sidebar AXPress actions without a start delay.
+            """
+        }
+    }
+}
+
+struct AppDriver {
+    let app: AXUIElement
+    let pid: pid_t
+
+    init(pid: pid_t) throws {
+        guard AXIsProcessTrusted() else {
+            throw ProfileUIError.accessibilityPermission
+        }
+        self.pid = pid
+        app = AXUIElementCreateApplication(pid)
+    }
+
+    func attribute(_ name: String, of element: AXUIElement) throws -> CFTypeRef {
+        var value: CFTypeRef?
+        let error = AXUIElementCopyAttributeValue(element, name as CFString, &value)
+        guard error == .success, let value else {
+            throw ProfileUIError.attribute(name, error)
+        }
+        return value
+    }
+
+    func optionalAttribute(_ name: String, of element: AXUIElement) -> CFTypeRef? {
+        try? attribute(name, of: element)
+    }
+
+    func stringAttribute(_ name: String, of element: AXUIElement) -> String? {
+        optionalAttribute(name, of: element) as? String
+    }
+
+    func children(of element: AXUIElement) -> [AXUIElement] {
+        optionalAttribute(kAXChildrenAttribute, of: element) as? [AXUIElement] ?? []
+    }
+
+    func descendants(of root: AXUIElement) -> [AXUIElement] {
+        var pending = children(of: root)
+        var result: [AXUIElement] = []
+        while let element = pending.popLast() {
+            result.append(element)
+            pending.append(contentsOf: children(of: element))
+        }
+        return result
+    }
+
+    func semanticText(of element: AXUIElement) -> String {
+        let attributes = [
+            kAXTitleAttribute,
+            kAXDescriptionAttribute,
+            kAXHelpAttribute,
+            kAXValueAttribute
+        ]
+        let ownText = attributes.compactMap { stringAttribute($0, of: element) }
+        let childText = descendants(of: element).flatMap { child in
+            attributes.compactMap { stringAttribute($0, of: child) }
+        }
+        return (ownText + childText).joined(separator: " | ")
+    }
+
+    func role(of element: AXUIElement) -> String? {
+        stringAttribute(kAXRoleAttribute, of: element)
+    }
+
+    func button(containing text: String) throws -> AXUIElement {
+        let query = text.lowercased()
+        let candidates = descendants(of: app).filter { role(of: $0) == kAXButtonRole }
+        guard let match = candidates.first(where: {
+            semanticText(of: $0).lowercased().contains(query)
+        }) else {
+            throw ProfileUIError.control("button containing “\(text)”")
+        }
+        return match
+    }
+
+    func sidebarButton(containing text: String) throws -> AXUIElement {
+        let query = text.lowercased()
+        let sidebar = try sidebarScrollArea()
+        let candidates = descendants(of: sidebar).filter { role(of: $0) == kAXButtonRole }
+        guard let match = candidates.first(where: {
+            semanticText(of: $0).lowercased().contains(query)
+        }) else {
+            throw ProfileUIError.control("sidebar button containing “\(text)”")
+        }
+        return match
+    }
+
+    func position(of element: AXUIElement) -> CGPoint? {
+        guard let rawValue = optionalAttribute(kAXPositionAttribute, of: element),
+              CFGetTypeID(rawValue) == AXValueGetTypeID() else {
+            return nil
+        }
+        let value = unsafeBitCast(rawValue, to: AXValue.self)
+        var point = CGPoint.zero
+        return AXValueGetValue(value, .cgPoint, &point) ? point : nil
+    }
+
+    func size(of element: AXUIElement) -> CGSize? {
+        guard let rawValue = optionalAttribute(kAXSizeAttribute, of: element),
+              CFGetTypeID(rawValue) == AXValueGetTypeID() else {
+            return nil
+        }
+        let value = unsafeBitCast(rawValue, to: AXValue.self)
+        var size = CGSize.zero
+        return AXValueGetValue(value, .cgSize, &size) ? size : nil
+    }
+
+    func mainScrollArea() throws -> AXUIElement {
+        let areas = descendants(of: app).filter { role(of: $0) == kAXScrollAreaRole }
+        guard let area = areas.max(by: {
+            (size(of: $0)?.width ?? 0) < (size(of: $1)?.width ?? 0)
+        }) else {
+            throw ProfileUIError.control("main content scroll area")
+        }
+        return area
+    }
+
+    func sidebarScrollArea() throws -> AXUIElement {
+        let candidates = descendants(of: app).filter {
+            guard role(of: $0) == kAXScrollAreaRole, let size = size(of: $0) else {
+                return false
+            }
+            return size.width >= 180 && size.width <= 400 && size.height >= 300
+        }
+        guard let area = candidates.max(by: {
+            (size(of: $0)?.height ?? 0) < (size(of: $1)?.height ?? 0)
+        }) else {
+            throw ProfileUIError.control("sidebar scroll area")
+        }
+        return area
+    }
+
+    func mainScrollCenter() throws -> CGPoint {
+        let area = try mainScrollArea()
+        guard let origin = position(of: area), let size = size(of: area) else {
+            throw ProfileUIError.control("main content scroll area geometry")
+        }
+        return CGPoint(x: origin.x + size.width / 2, y: origin.y + size.height / 2)
+    }
+
+    func perform(_ action: String, on element: AXUIElement) throws {
+        let error = AXUIElementPerformAction(element, action as CFString)
+        guard error == .success else {
+            throw ProfileUIError.action(action, error)
+        }
+    }
+
+    @discardableResult
+    func timedPress(_ element: AXUIElement, label: String) throws -> Double {
+        let start = ContinuousClock.now
+        try perform(kAXPressAction, on: element)
+        let elapsed = start.duration(to: .now)
+        let milliseconds = Double(elapsed.components.seconds) * 1_000
+            + Double(elapsed.components.attoseconds) / 1_000_000_000_000_000
+        print(String(format: "press_ms\t%@\t%.3f", label, milliseconds))
+        return milliseconds
+    }
+
+    func raise() throws {
+        if AXUIElementPerformAction(app, kAXRaiseAction as CFString) == .success {
+            return
+        }
+        guard let application = NSRunningApplication(processIdentifier: pid) else {
+            throw ProfileUIError.control("running application")
+        }
+        application.activate(options: [.activateAllWindows])
+        sleep(0.1)
+    }
+
+    func click(at point: CGPoint) throws {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let down = CGEvent(
+            mouseEventSource: source,
+            mouseType: .leftMouseDown,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ),
+        let up = CGEvent(
+            mouseEventSource: source,
+            mouseType: .leftMouseUp,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ) else {
+            throw ProfileUIError.control("mouse click event")
+        }
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
+    }
+
+    func scroll(at point: CGPoint, delta: Int32, eventCount: Int = 8) throws {
+        try raise()
+        let source = CGEventSource(stateID: .combinedSessionState)
+        for _ in 0 ..< eventCount {
+            guard let event = CGEvent(
+                scrollWheelEvent2Source: source,
+                units: .pixel,
+                wheelCount: 1,
+                wheel1: delta,
+                wheel2: 0,
+                wheel3: 0
+            ) else {
+                throw ProfileUIError.control("scroll event")
+            }
+            event.location = point
+            event.post(tap: .cghidEventTap)
+            Thread.sleep(forTimeInterval: 0.08)
+        }
+    }
+
+    func scrollPosition() throws -> String {
+        let area = try mainScrollArea()
+        guard let rawScrollbar = optionalAttribute(kAXVerticalScrollBarAttribute, of: area),
+              CFGetTypeID(rawScrollbar) == AXUIElementGetTypeID() else {
+            throw ProfileUIError.control("main content vertical scrollbar")
+        }
+        let scrollbar = unsafeBitCast(rawScrollbar, to: AXUIElement.self)
+        guard let value = optionalAttribute(kAXValueAttribute, of: scrollbar) else {
+            throw ProfileUIError.control("main content vertical scrollbar value")
+        }
+        return String(describing: value)
+    }
+
+    func inspect() {
+        for element in descendants(of: app) {
+            guard let role = role(of: element),
+                  role == kAXButtonRole || role == kAXScrollAreaRole else {
+                continue
+            }
+            let sizeDescription = size(of: element).map {
+                String(format: "%.0fx%.0f", $0.width, $0.height)
+            } ?? "unknown"
+            print("\(role)\t\(sizeDescription)\t\(semanticText(of: element))")
+        }
+    }
+
+    func selectedViewMode() throws -> String {
+        let grid = try button(containing: "Grid view")
+        let list = try button(containing: "List")
+        if isSelected(grid) { return "grid" }
+        if isSelected(list) { return "list" }
+        if let stored = UserDefaults(suiteName: "com.mag.caskhub")?.string(forKey: "viewMode") {
+            return stored
+        }
+        return "unknown"
+    }
+
+    private func isSelected(_ element: AXUIElement) -> Bool {
+        for attribute in [kAXSelectedAttribute, kAXValueAttribute] {
+            guard let value = optionalAttribute(attribute, of: element) else { continue }
+            if let number = value as? NSNumber, number.boolValue {
+                return true
+            }
+            if let string = value as? String, string == "1" {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+func sleep(_ seconds: Double) {
+    guard seconds > 0 else { return }
+    Thread.sleep(forTimeInterval: seconds)
+}
+
+func resolvedSidebarControls(
+    driver: AppDriver
+) throws -> [(label: String, point: CGPoint)] {
+    let labels = [
+        "Browse",
+        "Installed",
+        "Adopt Apps",
+        "Browsers",
+        "AI & LLMs",
+        "Recently Added"
+    ]
+    let sidebar = try driver.sidebarScrollArea()
+    guard let sidebarOrigin = driver.position(of: sidebar),
+          let sidebarSize = driver.size(of: sidebar) else {
+        throw ProfileUIError.control("sidebar geometry")
+    }
+    let visibleFrame = CGRect(origin: sidebarOrigin, size: sidebarSize)
+    let controls = labels.compactMap { label -> (String, CGPoint)? in
+        guard let element = try? driver.sidebarButton(containing: label) else {
+            print("missing_control\t\(label)")
+            return nil
+        }
+        guard let origin = driver.position(of: element), let size = driver.size(of: element) else {
+            print("missing_geometry\t\(label)")
+            return nil
+        }
+        let point = CGPoint(x: origin.x + size.width / 2, y: origin.y + size.height / 2)
+        guard visibleFrame.contains(point) else {
+            print("offscreen_control\t\(label)")
+            return nil
+        }
+        return (label, point)
+    }
+    guard controls.count >= 3 else {
+        throw ProfileUIError.control("at least three sidebar destinations")
+    }
+    return controls
+}
+
+func runCatalogWorkload(
+    driver: AppDriver,
+    cycles: Int,
+    startDelay: Double
+) throws {
+    let grid = try driver.button(containing: "Grid view")
+    let list = try driver.button(containing: "List")
+    let scrollCenter = try driver.mainScrollCenter()
+    sleep(startDelay)
+    for _ in 0 ..< cycles {
+        try driver.timedPress(list, label: "List view")
+        sleep(0.35)
+        try driver.scroll(at: scrollCenter, delta: -180)
+        try driver.scroll(at: scrollCenter, delta: 180)
+        try driver.timedPress(grid, label: "Grid view")
+        sleep(0.35)
+        try driver.scroll(at: scrollCenter, delta: -180)
+        try driver.scroll(at: scrollCenter, delta: 180)
+    }
+}
+
+func runSidebarWorkload(
+    driver: AppDriver,
+    cycles: Int,
+    startDelay: Double,
+    settleDelay: Double
+) throws {
+    let controls = try resolvedSidebarControls(driver: driver)
+    try driver.raise()
+    sleep(startDelay)
+    for _ in 0 ..< cycles {
+        for control in controls {
+            try driver.click(at: control.point)
+            print("click\t\(control.label)")
+            sleep(settleDelay)
+        }
+    }
+}
+
+func runSidebarBenchmark(driver: AppDriver, cycles: Int) throws {
+    let labels = [
+        "Browse",
+        "Installed",
+        "Adopt Apps",
+        "Browsers",
+        "Recently Added"
+    ]
+    try driver.raise()
+    for _ in 0 ..< cycles {
+        for label in labels {
+            let element = try driver.sidebarButton(containing: label)
+            try driver.timedPress(element, label: label)
+            sleep(0.25)
+        }
+    }
+}
+
+func runSimpleMode(_ mode: String, driver: AppDriver) throws -> Bool {
+    switch mode {
+    case "inspect":
+        driver.inspect()
+    case "state":
+        print(try driver.selectedViewMode())
+    case "scroll-position":
+        print(try driver.scrollPosition())
+    case "press-grid":
+        try driver.timedPress(driver.button(containing: "Grid view"), label: "Grid view")
+    case "press-list":
+        try driver.timedPress(driver.button(containing: "List"), label: "List view")
+    case "scroll-down":
+        try driver.scroll(at: driver.mainScrollCenter(), delta: -180)
+    case "scroll-up":
+        try driver.scroll(at: driver.mainScrollCenter(), delta: 180)
+    default:
+        return false
+    }
+    return true
+}
+
+func runWorkloadMode(
+    _ mode: String,
+    driver: AppDriver,
+    cycles: Int,
+    startDelay: Double
+) throws {
+    switch mode {
+    case "workload":
+        try runCatalogWorkload(driver: driver, cycles: cycles, startDelay: startDelay)
+    case "sidebar-workload":
+        try runSidebarWorkload(
+            driver: driver,
+            cycles: cycles,
+            startDelay: startDelay,
+            settleDelay: 0.45
+        )
+    case "sidebar-benchmark":
+        try runSidebarBenchmark(driver: driver, cycles: cycles)
+    default:
+        throw ProfileUIError.usage
+    }
+}
+
+func run() throws {
+    let arguments = CommandLine.arguments
+    guard arguments.count >= 3 else {
+        throw ProfileUIError.usage
+    }
+    let mode = arguments[1]
+    guard let pid = pid_t(arguments[2]) else {
+        throw ProfileUIError.invalidPID(arguments[2])
+    }
+    let cycles = arguments.count > 3 ? max(Int(arguments[3]) ?? 1, 1) : 1
+    let startDelay = arguments.count > 4 ? max(Double(arguments[4]) ?? 0, 0) : 0
+    let driver = try AppDriver(pid: pid)
+    guard try !runSimpleMode(mode, driver: driver) else { return }
+    try runWorkloadMode(mode, driver: driver, cycles: cycles, startDelay: startDelay)
+}
+
+do {
+    try run()
+} catch {
+    fputs("profile_ui: \(error)\n", stderr)
+    exit(EXIT_FAILURE)
+}


### PR DESCRIPTION
## Summary

- Index local installation and external-app state once per revision and precompute per-cask state
- Memoize catalog and route projections with explicit revision keys and bounded retention
- Isolate high-frequency operation progress updates from the catalog root
- Preserve SwiftUI detail and scroll identity across sidebar and grid/list switches
- Add reproducible build, Accessibility workload, and xctrace analysis tooling

## Performance validation

- Sidebar workload: 895 ms sampled CPU and 11 hitches (7 severe at 250–400 ms) reduced to 100 ms and 0 hitches
- Grid/list workload: sampled CPU reduced from 585 ms to 285 ms (51%)
- Final three Debug hitch runs: severe-hitch counts of 0, 1, and 0, with one 166 ms outlier

## Validation

- 192 unit tests pass
- SwiftLint passes with 0 violations across 72 files
- profiling scripts type-check
- signed Debug build launches successfully
- Accessibility-driven sidebar, scrolling, and grid/list smoke checks pass
- repeated Time Profiler and SwiftUI Hitches captures completed

## Notes

- targets develop
- Sentry app-hang threshold and symbolication settings are unchanged
- related Sentry hang groups should be resolved for the release and monitored separately by stack fingerprint