### PR TITLE
fix: Launch detection for variant-named package apps

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B130028F9F00608C7A /* CaskHubTests.swift */; };
 		C15000000000000000000001 /* ExternalInstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15000000000000000000001 /* ExternalInstallationTests.swift */; };
 		C26000000000000000000001 /* ExternalApplicationOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26000000000000000000001 /* ExternalApplicationOwnershipTests.swift */; };
+		F34000000000000000000002 /* HomebrewPackageLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34000000000000000000001 /* HomebrewPackageLaunchTests.swift */; };
 		41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */; };
 		F25000000000000000000001 /* CaskCatalogSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25000000000000000000001 /* CaskCatalogSortTests.swift */; };
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
@@ -214,6 +215,7 @@
 		41DFD4B130028F9F00608C7A /* CaskHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubTests.swift; sourceTree = "<group>"; };
 		D15000000000000000000001 /* ExternalInstallationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalInstallationTests.swift; sourceTree = "<group>"; };
 		D26000000000000000000001 /* ExternalApplicationOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalApplicationOwnershipTests.swift; sourceTree = "<group>"; };
+		F34000000000000000000001 /* HomebrewPackageLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewPackageLaunchTests.swift; sourceTree = "<group>"; };
 		41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogViewModelTests.swift; sourceTree = "<group>"; };
 		E25000000000000000000001 /* CaskCatalogSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogSortTests.swift; sourceTree = "<group>"; };
 		41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
@@ -656,6 +658,7 @@
 				D26000000000000000000001 /* ExternalApplicationOwnershipTests.swift */,
 				D15000000000000000000001 /* ExternalInstallationTests.swift */,
 				E2900000000000000000000B /* InstallationSnapshotTests.swift */,
+				F34000000000000000000001 /* HomebrewPackageLaunchTests.swift */,
 				B12000000000000000000004 /* ZombieDetectionTests.swift */,
 			);
 			path = Detection;
@@ -942,6 +945,7 @@
 				F25000000000000000000001 /* CaskCatalogSortTests.swift in Sources */,
 				C26000000000000000000001 /* ExternalApplicationOwnershipTests.swift in Sources */,
 				C15000000000000000000001 /* ExternalInstallationTests.swift in Sources */,
+				F34000000000000000000002 /* HomebrewPackageLaunchTests.swift in Sources */,
 				41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */,
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -129,6 +129,7 @@ nonisolated struct PackageInstallationCandidate {
     let signature: PackageCaskSignature
     let appBundleNames: Set<String>
     let score: Int
+    let isHomebrewInstalled: Bool
 }
 
 nonisolated struct ExternalPackageInstallation: Hashable, Sendable {

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
@@ -60,7 +60,8 @@ nonisolated struct HomebrewInstallationScanner: InstalledSoftwareScanning {
             )
             let packages = packageReceiptResolver.scan(
                 signatures: request.packageSignatures,
-                availableAppNames: applications.nonStoreNames
+                availableAppNames: applications.nonStoreNames,
+                homebrewInstalledTokens: Set(installedCasks.keys)
             )
             let components = ScanComponents(
                 applications: applications,
@@ -91,7 +92,8 @@ nonisolated struct HomebrewInstallationScanner: InstalledSoftwareScanning {
             let packages = request.packageSignatures.isEmpty ? [:] :
                 packageReceiptResolver.scan(
                     signatures: request.packageSignatures,
-                    availableAppNames: applications.nonStoreNames
+                    availableAppNames: applications.nonStoreNames,
+                    homebrewInstalledTokens: Set(current.installedCasks.keys)
                 )
             let components = ScanComponents(
                 applications: applications,
@@ -121,7 +123,8 @@ nonisolated struct HomebrewInstallationScanner: InstalledSoftwareScanning {
             catalog: request.catalog,
             applications: components.applications.applications,
             binaryPaths: components.binaryPaths,
-            installedCasks: components.installedCasks
+            installedCasks: components.installedCasks,
+            packageInstallations: components.packages
         )
         return InstallationSnapshot(
             installedCasks: components.installedCasks,

--- a/CaskHub/Services/Homebrew/Infrastructure/InstallationIndexBuilder.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/InstallationIndexBuilder.swift
@@ -32,12 +32,14 @@ nonisolated struct InstallationIndexBuilder: Sendable {
         catalog: CaskInstallationCatalog,
         applications: [DetectedApplication],
         binaryPaths: [String: URL],
-        installedCasks: [String: LocalCaskInstallation]
+        installedCasks: [String: LocalCaskInstallation],
+        packageInstallations: [String: ExternalPackageInstallation] = [:]
     ) -> CaskInstallationIndex {
         let homebrewApplications = resolveHomebrewApplicationState(
             signatures: catalog.applicationSignatures,
             applications: applications,
-            installedCasks: installedCasks
+            installedCasks: installedCasks,
+            packageInstallations: packageInstallations
         )
         return CaskInstallationIndex(
             catalogTokens: catalog.tokens,
@@ -99,7 +101,8 @@ nonisolated struct InstallationIndexBuilder: Sendable {
     func resolveHomebrewApplicationState(
         signatures: [CaskApplicationSignature],
         applications: [DetectedApplication],
-        installedCasks: [String: LocalCaskInstallation]
+        installedCasks: [String: LocalCaskInstallation],
+        packageInstallations: [String: ExternalPackageInstallation] = [:]
     ) -> (launchableTokens: Set<String>, zombieTokens: Set<String>) {
         let signaturesByToken = Dictionary(
             signatures.map { ($0.token, $0) },
@@ -113,6 +116,7 @@ nonisolated struct InstallationIndexBuilder: Sendable {
             guard let signature = signaturesByToken[token] else { continue }
             let launchableNames = Set(installation.appBundleNames)
                 .union(signature.launchableBundleNames)
+                .union(packageInstallations[token]?.appBundleNames ?? [])
             if !launchableNames.isDisjoint(with: validBundleNames) {
                 launchableTokens.insert(token)
             }

--- a/CaskHub/Services/Homebrew/Infrastructure/PackageReceiptResolver.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/PackageReceiptResolver.swift
@@ -20,7 +20,8 @@ nonisolated struct PackageReceiptResolver: Sendable {
     /// at least one application from the package payload still exists.
     func scan(
         signatures: [PackageCaskSignature],
-        availableAppNames: Set<String>
+        availableAppNames: Set<String>,
+        homebrewInstalledTokens: Set<String> = []
     ) -> [String: ExternalPackageInstallation] {
         guard !signatures.isEmpty,
               let receiptOutput = query(["--pkgs"])
@@ -44,7 +45,8 @@ nonisolated struct PackageReceiptResolver: Sendable {
             signatures: signatures,
             installedReceipts: installedReceipts,
             packageFileLists: fileLists,
-            availableAppNames: availableAppNames
+            availableAppNames: availableAppNames,
+            homebrewInstalledTokens: homebrewInstalledTokens
         )
     }
 
@@ -53,17 +55,22 @@ nonisolated struct PackageReceiptResolver: Sendable {
         signatures: [PackageCaskSignature],
         installedReceipts: Set<String>,
         packageFileLists: [String: String],
-        availableAppNames: Set<String>
+        availableAppNames: Set<String>,
+        homebrewInstalledTokens: Set<String> = []
     ) -> [String: ExternalPackageInstallation] {
         var candidates = signatures.compactMap {
             candidate(
                 for: $0,
                 installedReceipts: installedReceipts,
                 packageFileLists: packageFileLists,
-                availableAppNames: availableAppNames
+                availableAppNames: availableAppNames,
+                isHomebrewInstalled: homebrewInstalledTokens.contains($0.token)
             )
         }
         candidates.sort {
+            if $0.isHomebrewInstalled != $1.isHomebrewInstalled {
+                return $0.isHomebrewInstalled
+            }
             if $0.score != $1.score { return $0.score > $1.score }
             if $0.signature.token.count != $1.signature.token.count {
                 return $0.signature.token.count < $1.signature.token.count
@@ -88,7 +95,8 @@ nonisolated struct PackageReceiptResolver: Sendable {
         for signature: PackageCaskSignature,
         installedReceipts: Set<String>,
         packageFileLists: [String: String],
-        availableAppNames: Set<String>
+        availableAppNames: Set<String>,
+        isHomebrewInstalled: Bool
     ) -> PackageInstallationCandidate? {
         let matchingReceipts = Set(installedReceipts.filter { receipt in
             signature.receiptPatterns.contains {
@@ -108,7 +116,8 @@ nonisolated struct PackageReceiptResolver: Sendable {
         .filter {
             Self.payloadAppName(
                 $0,
-                matches: signature.appNameCandidates
+                matches: signature.appNameCandidates,
+                allowingVariantDifference: isHomebrewInstalled
             )
         }
         let existingApps = declaredApps.union(payloadApps)
@@ -124,13 +133,15 @@ nonisolated struct PackageReceiptResolver: Sendable {
         return PackageInstallationCandidate(
             signature: signature,
             appBundleNames: existingApps,
-            score: score
+            score: score,
+            isHomebrewInstalled: isHomebrewInstalled
         )
     }
 
     static func payloadAppName(
         _ appName: String,
-        matches candidates: [String]
+        matches candidates: [String],
+        allowingVariantDifference: Bool = false
     ) -> Bool {
         let actualTokens = nameTokens(appName)
         let variantTokens: Set = [
@@ -138,9 +149,14 @@ nonisolated struct PackageReceiptResolver: Sendable {
         ]
         return candidates.contains { candidate in
             let candidateTokens = nameTokens(candidate)
-            guard actualTokens.intersection(variantTokens)
-                == candidateTokens.intersection(variantTokens)
-            else { return false }
+            // A Caskroom entry establishes ownership even when the vendor adds
+            // a variant suffix without changing the Homebrew token. External
+            // package detection remains variant-exact.
+            if !allowingVariantDifference {
+                guard actualTokens.intersection(variantTokens)
+                    == candidateTokens.intersection(variantTokens)
+                else { return false }
+            }
             return actualTokens.isSubset(of: candidateTokens)
                 || candidateTokens.isSubset(of: actualTokens)
         }

--- a/CaskHubTests/Homebrew/Detection/HomebrewPackageLaunchTests.swift
+++ b/CaskHubTests/Homebrew/Detection/HomebrewPackageLaunchTests.swift
@@ -33,11 +33,7 @@ final class HomebrewPackageLaunchTests: XCTestCase {
     }
 
     private func makeSUT(in root: URL) throws -> SUT {
-        let variantApp = try makeApplicationBundle(
-            in: root,
-            named: "Example App Beta.app",
-            bundleIdentifier: "com.example.app.beta"
-        )
+        let variantApp = try makeInstalledApplicationBundle(in: root)
         let applications = ApplicationDiscovery()
             .scan(fileManager: .default, directories: [root])
             .applications
@@ -82,6 +78,14 @@ final class HomebrewPackageLaunchTests: XCTestCase {
             cask: cask,
             launcher: launcher,
             service: service
+        )
+    }
+
+    private func makeInstalledApplicationBundle(in root: URL) throws -> URL {
+        try makeApplicationBundle(
+            in: root,
+            named: "Example App Beta.app",
+            bundleIdentifier: "com.example.app.beta"
         )
     }
 

--- a/CaskHubTests/Homebrew/Detection/HomebrewPackageLaunchTests.swift
+++ b/CaskHubTests/Homebrew/Detection/HomebrewPackageLaunchTests.swift
@@ -1,0 +1,102 @@
+//
+//  HomebrewPackageLaunchTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 29/07/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+@MainActor
+final class HomebrewPackageLaunchTests: XCTestCase {
+    private struct SUT {
+        let variantApp: URL
+        let cask: Cask
+        let launcher: RecordingApplicationLauncher
+        let service: LocalHomebrewService
+    }
+
+    func test_homebrew_owned_cask_opens_variant_named_package_payload() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("homebrew-package-variant-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let sut = try makeSUT(in: root)
+
+        XCTAssertTrue(sut.service.localState(for: sut.cask).canOpen)
+
+        sut.service.open(sut.cask)
+        XCTAssertEqual(
+            sut.launcher.lastOpenedURL?.standardizedFileURL,
+            sut.variantApp.standardizedFileURL
+        )
+    }
+
+    private func makeSUT(in root: URL) throws -> SUT {
+        let variantApp = try makeApplicationBundle(
+            in: root,
+            named: "Example App Beta.app",
+            bundleIdentifier: "com.example.app.beta"
+        )
+        let applications = ApplicationDiscovery()
+            .scan(fileManager: .default, directories: [root])
+            .applications
+        let cask = makeCask(
+            "example-app", name: "Example App",
+            packageIdentifiers: ["com.example.pkg.app"],
+            packageAppNames: ["Example App.app"]
+        )
+        let registration = InstallationCatalogBuilder().build([cask])
+        let installed = LocalCaskInstallation(
+            token: cask.token,
+            installedVersion: "2.0",
+            installedAt: nil,
+            appBundleNames: []
+        )
+        let packages = packageInstallations(
+            registration: registration,
+            token: cask.token
+        )
+        let index = InstallationIndexBuilder().build(
+            catalog: registration.installationCatalog,
+            applications: applications,
+            binaryPaths: [:],
+            installedCasks: [cask.token: installed],
+            packageInstallations: packages
+        )
+        let launcher = RecordingApplicationLauncher()
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("homebrew-package-variant")
+        ) {
+            $0.applicationDirectories = [root]
+            $0.applicationLauncher = launcher
+        }
+        updateInstallationSnapshot(of: service) {
+            $0.installedCasks = [cask.token: installed]
+            $0.detectedApplications = applications
+            $0.externalPackageInstallations = packages
+            $0.installationIndex = index
+        }
+        return SUT(
+            variantApp: variantApp,
+            cask: cask,
+            launcher: launcher,
+            service: service
+        )
+    }
+
+    private func packageInstallations(
+        registration: InstallationCatalogRegistration,
+        token: String
+    ) -> [String: ExternalPackageInstallation] {
+        PackageReceiptResolver().resolve(
+            signatures: registration.packageSignatures,
+            installedReceipts: ["com.example.pkg.app"],
+            packageFileLists: [
+                "com.example.pkg.app": "Applications/Example App Beta.app"
+            ],
+            availableAppNames: ["Example App Beta.app"],
+            homebrewInstalledTokens: [token]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Treat an existing Caskroom entry as ownership evidence when a package payload adds a variant suffix
- Include resolved package bundle names in the precomputed Homebrew launchability index
- Preserve variant-exact matching for external package adoption
- Add a generic regression covering variant-named package payload launching

## Validation
- strict SwiftLint passed for production and the new regression suite
- full macOS test suite passed
- generic package launch regression and external-variant guard passed
- signed Debug build and app-launch smoke check passed