### PR TITLE
enhancement: Confirm on app close and Update All actions

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		41DFD48A30028F7D00608C7A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 41DFD48430028F7D00608C7A /* Assets.xcassets */; };
 		41DFD48B30028F7D00608C7A /* Askpass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD44E30028F7D00608C7A /* Askpass.swift */; };
 		41DFD48C30028F7D00608C7A /* CaskHubApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD44F30028F7D00608C7A /* CaskHubApp.swift */; };
+		A29000000000000000000002 /* ApplicationTerminationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29000000000000000000001 /* ApplicationTerminationCoordinator.swift */; };
 		41DFD48D30028F7D00608C7A /* BarrelMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45130028F7D00608C7A /* BarrelMark.swift */; };
 		41DFD48E30028F7D00608C7A /* CaskActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45230028F7D00608C7A /* CaskActionsView.swift */; };
 		F24000000000000000000002 /* CaskOperationCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000002 /* CaskOperationCapsule.swift */; };
@@ -115,6 +116,7 @@
 		C12000000000000000000001 /* BrewProcessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12000000000000000000001 /* BrewProcessRunner.swift */; };
 		C12000000000000000000002 /* added_dates.json in Resources */ = {isa = PBXBuildFile; fileRef = D12000000000000000000002 /* added_dates.json */; };
 		ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */; };
+		A29000000000000000000004 /* ApplicationTerminationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29000000000000000000003 /* ApplicationTerminationCoordinatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -134,6 +136,7 @@
 		41AD10302F68D00100BEABB8 /* UpdaterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterService.swift; sourceTree = "<group>"; };
 		41DFD44E30028F7D00608C7A /* Askpass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Askpass.swift; sourceTree = "<group>"; };
 		41DFD44F30028F7D00608C7A /* CaskHubApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubApp.swift; sourceTree = "<group>"; };
+		A29000000000000000000001 /* ApplicationTerminationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationCoordinator.swift; sourceTree = "<group>"; };
 		41DFD45130028F7D00608C7A /* BarrelMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarrelMark.swift; sourceTree = "<group>"; };
 		41DFD45230028F7D00608C7A /* CaskActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskActionsView.swift; sourceTree = "<group>"; };
 		E24000000000000000000002 /* CaskOperationCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskOperationCapsule.swift; sourceTree = "<group>"; };
@@ -236,6 +239,7 @@
 		D12000000000000000000001 /* BrewProcessRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewProcessRunner.swift; sourceTree = "<group>"; };
 		D12000000000000000000002 /* added_dates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = added_dates.json; sourceTree = "<group>"; };
 		ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewTests.swift; sourceTree = "<group>"; };
+		A29000000000000000000003 /* ApplicationTerminationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationCoordinatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -262,6 +266,7 @@
 		41DFD45030028F7D00608C7A /* App */ = {
 			isa = PBXGroup;
 			children = (
+				A29000000000000000000001 /* ApplicationTerminationCoordinator.swift */,
 				41DFD44E30028F7D00608C7A /* Askpass.swift */,
 				41DFD44F30028F7D00608C7A /* CaskHubApp.swift */,
 			);
@@ -567,6 +572,7 @@
 		41DFD4B230028F9F00608C7A /* CaskHubTests */ = {
 			isa = PBXGroup;
 			children = (
+				A29000000000000000000005 /* App */,
 				F32000000000000000000020 /* Support */,
 				F32000000000000000000021 /* Telemetry */,
 				F32000000000000000000022 /* Catalog */,
@@ -575,6 +581,14 @@
 				F32000000000000000000025 /* Homebrew */,
 			);
 			path = CaskHubTests;
+			sourceTree = "<group>";
+		};
+		A29000000000000000000005 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				A29000000000000000000003 /* ApplicationTerminationCoordinatorTests.swift */,
+			);
+			path = App;
 			sourceTree = "<group>";
 		};
 		F32000000000000000000020 /* Support */ = {
@@ -856,6 +870,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A29000000000000000000002 /* ApplicationTerminationCoordinator.swift in Sources */,
 				41DFD48B30028F7D00608C7A /* Askpass.swift in Sources */,
 				41DFD48C30028F7D00608C7A /* CaskHubApp.swift in Sources */,
 				41DFD48D30028F7D00608C7A /* BarrelMark.swift in Sources */,
@@ -939,6 +954,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A29000000000000000000004 /* ApplicationTerminationCoordinatorTests.swift in Sources */,
 				41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */,
 				41AD10162F68B00700BEABB8 /* CrashReporterTests.swift in Sources */,
 				41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */,

--- a/CaskHub/App/ApplicationTerminationCoordinator.swift
+++ b/CaskHub/App/ApplicationTerminationCoordinator.swift
@@ -6,28 +6,35 @@
 //
 
 import AppKit
-import Combine
 
 @MainActor
-final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate, ObservableObject {
+final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate {
     typealias ActiveOperationsProvider = @MainActor () -> Bool
     typealias TerminationRequester = @MainActor () -> Void
-    typealias TerminationReplier = @MainActor (Bool) -> Void
-
-    @Published var showsQuitConfirmation = false
+    typealias QuitConfirmationPresenter = @MainActor () -> Bool
 
     private var hasActiveOperations: ActiveOperationsProvider
     private let requestApplicationTermination: TerminationRequester
-    private let replyToApplicationTermination: TerminationReplier
-    private var isAwaitingTerminationReply = false
+    private let presentQuitConfirmation: QuitConfirmationPresenter
 
     override init() {
         hasActiveOperations = { false }
         requestApplicationTermination = {
             NSApplication.shared.terminate(nil)
         }
-        replyToApplicationTermination = { shouldTerminate in
-            NSApplication.shared.reply(toApplicationShouldTerminate: shouldTerminate)
+        presentQuitConfirmation = {
+            let alert = NSAlert()
+            alert.messageText = "Quit CaskHub?"
+            alert.informativeText = """
+            A Homebrew operation is still in progress. Quitting while Homebrew is \
+            working may leave the affected app in an incomplete state.
+            """
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Quit CaskHub")
+            alert.addButton(withTitle: "Keep Running")
+            alert.buttons.first?.hasDestructiveAction = true
+            alert.buttons.last?.keyEquivalent = "\u{1b}"
+            return alert.runModal() == .alertFirstButtonReturn
         }
         super.init()
     }
@@ -35,11 +42,11 @@ final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate, 
     init(
         hasActiveOperations: @escaping ActiveOperationsProvider,
         requestApplicationTermination: @escaping TerminationRequester,
-        replyToApplicationTermination: @escaping TerminationReplier
+        presentQuitConfirmation: @escaping QuitConfirmationPresenter
     ) {
         self.hasActiveOperations = hasActiveOperations
         self.requestApplicationTermination = requestApplicationTermination
-        self.replyToApplicationTermination = replyToApplicationTermination
+        self.presentQuitConfirmation = presentQuitConfirmation
         super.init()
     }
 
@@ -51,29 +58,11 @@ final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate, 
         requestApplicationTermination()
     }
 
-    func keepRunning() {
-        finishPendingTermination(shouldTerminate: false)
-    }
-
-    func confirmTermination() {
-        finishPendingTermination(shouldTerminate: true)
-    }
-
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard hasActiveOperations() else {
             return .terminateNow
         }
 
-        isAwaitingTerminationReply = true
-        showsQuitConfirmation = true
-        return .terminateLater
-    }
-
-    private func finishPendingTermination(shouldTerminate: Bool) {
-        guard isAwaitingTerminationReply else { return }
-
-        isAwaitingTerminationReply = false
-        showsQuitConfirmation = false
-        replyToApplicationTermination(shouldTerminate)
+        return presentQuitConfirmation() ? .terminateNow : .terminateCancel
     }
 }

--- a/CaskHub/App/ApplicationTerminationCoordinator.swift
+++ b/CaskHub/App/ApplicationTerminationCoordinator.swift
@@ -1,0 +1,79 @@
+//
+//  ApplicationTerminationCoordinator.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 29/07/2026.
+//
+
+import AppKit
+import Combine
+
+@MainActor
+final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate, ObservableObject {
+    typealias ActiveOperationsProvider = @MainActor () -> Bool
+    typealias TerminationRequester = @MainActor () -> Void
+    typealias TerminationReplier = @MainActor (Bool) -> Void
+
+    @Published var showsQuitConfirmation = false
+
+    private var hasActiveOperations: ActiveOperationsProvider
+    private let requestApplicationTermination: TerminationRequester
+    private let replyToApplicationTermination: TerminationReplier
+    private var isAwaitingTerminationReply = false
+
+    override init() {
+        hasActiveOperations = { false }
+        requestApplicationTermination = {
+            NSApplication.shared.terminate(nil)
+        }
+        replyToApplicationTermination = { shouldTerminate in
+            NSApplication.shared.reply(toApplicationShouldTerminate: shouldTerminate)
+        }
+        super.init()
+    }
+
+    init(
+        hasActiveOperations: @escaping ActiveOperationsProvider,
+        requestApplicationTermination: @escaping TerminationRequester,
+        replyToApplicationTermination: @escaping TerminationReplier
+    ) {
+        self.hasActiveOperations = hasActiveOperations
+        self.requestApplicationTermination = requestApplicationTermination
+        self.replyToApplicationTermination = replyToApplicationTermination
+        super.init()
+    }
+
+    func configure(hasActiveOperations: @escaping ActiveOperationsProvider) {
+        self.hasActiveOperations = hasActiveOperations
+    }
+
+    func requestTermination() {
+        requestApplicationTermination()
+    }
+
+    func keepRunning() {
+        finishPendingTermination(shouldTerminate: false)
+    }
+
+    func confirmTermination() {
+        finishPendingTermination(shouldTerminate: true)
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard hasActiveOperations() else {
+            return .terminateNow
+        }
+
+        isAwaitingTerminationReply = true
+        showsQuitConfirmation = true
+        return .terminateLater
+    }
+
+    private func finishPendingTermination(shouldTerminate: Bool) {
+        guard isAwaitingTerminationReply else { return }
+
+        isAwaitingTerminationReply = false
+        showsQuitConfirmation = false
+        replyToApplicationTermination(shouldTerminate)
+    }
+}

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -22,6 +22,8 @@ enum CaskHubMain {
 
 struct CaskHubApp: App {
     @AppStorage("appTheme") private var selectedTheme: String = AppTheme.system.rawValue
+    @NSApplicationDelegateAdaptor(ApplicationTerminationCoordinator.self)
+    private var terminationCoordinator
 
     @State private var updaterService = UpdaterService()
 
@@ -30,7 +32,6 @@ struct CaskHubApp: App {
     @State private var localHomebrew: LocalHomebrewService
     @State private var imageCache: ImageCacheService
     @State private var catalog: CaskCatalogViewModel
-    @State private var showsQuitConfirmation = false
 
     init() {
         // Tooltip delay in ms; registered (not set) so it never persists to prefs.
@@ -57,6 +58,9 @@ struct CaskHubApp: App {
             recentlyAdded: recent,
             localHomebrew: homebrew
         ))
+        terminationCoordinator.configure {
+            homebrew.hasActiveOperations
+        }
     }
 
     var body: some Scene {
@@ -65,22 +69,26 @@ struct CaskHubApp: App {
                 .frame(minWidth: 1380, minHeight: 640)
                 .background {
                     WindowCloseButtonConfigurator {
-                        if localHomebrew.hasActiveOperations {
-                            showsQuitConfirmation = true
-                        } else {
-                            NSApplication.shared.terminate(nil)
-                        }
+                        terminationCoordinator.requestTermination()
                     }
                 }
-                .alert("Quit CaskHub?", isPresented: $showsQuitConfirmation) {
-                    Button("Keep Running", role: .cancel) {}
+                .alert(
+                    "Quit CaskHub?",
+                    isPresented: Binding(
+                        get: { terminationCoordinator.showsQuitConfirmation },
+                        set: { terminationCoordinator.showsQuitConfirmation = $0 }
+                    )
+                ) {
+                    Button("Keep Running", role: .cancel) {
+                        terminationCoordinator.keepRunning()
+                    }
                     Button("Quit CaskHub", role: .destructive) {
-                        NSApplication.shared.terminate(nil)
+                        terminationCoordinator.confirmTermination()
                     }
                 } message: {
                     Text("""
-                    A Homebrew operation is still in progress. Quitting now will stop it \
-                    and may leave the affected app in an incomplete state.
+                    A Homebrew operation is still in progress. Quitting while Homebrew is \
+                    working may leave the affected app in an incomplete state.
                     """)
                 }
                 .onChange(of: selectedTheme, initial: true) { _, newValue in

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -58,9 +58,6 @@ struct CaskHubApp: App {
             recentlyAdded: recent,
             localHomebrew: homebrew
         ))
-        terminationCoordinator.configure {
-            homebrew.hasActiveOperations
-        }
     }
 
     var body: some Scene {
@@ -72,24 +69,10 @@ struct CaskHubApp: App {
                         terminationCoordinator.requestTermination()
                     }
                 }
-                .alert(
-                    "Quit CaskHub?",
-                    isPresented: Binding(
-                        get: { terminationCoordinator.showsQuitConfirmation },
-                        set: { terminationCoordinator.showsQuitConfirmation = $0 }
-                    )
-                ) {
-                    Button("Keep Running", role: .cancel) {
-                        terminationCoordinator.keepRunning()
+                .onAppear {
+                    terminationCoordinator.configure {
+                        localHomebrew.hasActiveOperations
                     }
-                    Button("Quit CaskHub", role: .destructive) {
-                        terminationCoordinator.confirmTermination()
-                    }
-                } message: {
-                    Text("""
-                    A Homebrew operation is still in progress. Quitting while Homebrew is \
-                    working may leave the affected app in an incomplete state.
-                    """)
                 }
                 .onChange(of: selectedTheme, initial: true) { _, newValue in
                     AppTheme.apply(newValue)

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -5,6 +5,7 @@
 //  Created by Ali Elsokary on 08/02/2026.
 //
 
+import AppKit
 import SwiftUI
 
 @main
@@ -29,6 +30,7 @@ struct CaskHubApp: App {
     @State private var localHomebrew: LocalHomebrewService
     @State private var imageCache: ImageCacheService
     @State private var catalog: CaskCatalogViewModel
+    @State private var showsQuitConfirmation = false
 
     init() {
         // Tooltip delay in ms; registered (not set) so it never persists to prefs.
@@ -61,6 +63,26 @@ struct CaskHubApp: App {
         WindowGroup {
             ContentView(viewModel: catalog)
                 .frame(minWidth: 1380, minHeight: 640)
+                .background {
+                    WindowCloseButtonConfigurator {
+                        if localHomebrew.hasActiveOperations {
+                            showsQuitConfirmation = true
+                        } else {
+                            NSApplication.shared.terminate(nil)
+                        }
+                    }
+                }
+                .alert("Quit CaskHub?", isPresented: $showsQuitConfirmation) {
+                    Button("Keep Running", role: .cancel) {}
+                    Button("Quit CaskHub", role: .destructive) {
+                        NSApplication.shared.terminate(nil)
+                    }
+                } message: {
+                    Text("""
+                    A Homebrew operation is still in progress. Quitting now will stop it \
+                    and may leave the affected app in an incomplete state.
+                    """)
+                }
                 .onChange(of: selectedTheme, initial: true) { _, newValue in
                     AppTheme.apply(newValue)
                 }
@@ -82,6 +104,87 @@ struct CaskHubApp: App {
                 .environment(updaterService)
                 .environment(imageCache)
                 .environment(localHomebrew)
+        }
+    }
+}
+
+@MainActor
+struct WindowCloseButtonConfigurator: NSViewRepresentable {
+    typealias CloseAction = @MainActor @Sendable () -> Void
+
+    let onClose: CloseAction
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onClose: onClose)
+    }
+
+    func makeNSView(context: Context) -> WindowObservationView {
+        let view = WindowObservationView()
+        view.coordinator = context.coordinator
+        return view
+    }
+
+    func updateNSView(_ view: WindowObservationView, context: Context) {
+        view.coordinator = context.coordinator
+        context.coordinator.onClose = onClose
+        if let window = view.window {
+            context.coordinator.attach(to: window)
+        }
+    }
+
+    static func dismantleNSView(_ view: WindowObservationView, coordinator: Coordinator) {
+        view.coordinator = nil
+        coordinator.detach()
+    }
+
+    @MainActor
+    final class WindowObservationView: NSView {
+        weak var coordinator: Coordinator?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if let window {
+                coordinator?.attach(to: window)
+            }
+        }
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var onClose: CloseAction
+
+        private weak var closeButton: NSButton?
+        private weak var originalTarget: AnyObject?
+        private var originalAction: Selector?
+
+        init(onClose: @escaping CloseAction) {
+            self.onClose = onClose
+        }
+
+        func detach() {
+            guard let closeButton, closeButton.target === self else { return }
+            closeButton.target = originalTarget
+            closeButton.action = originalAction
+            self.closeButton = nil
+            originalTarget = nil
+            originalAction = nil
+        }
+
+        func attach(to window: NSWindow) {
+            guard let button = window.standardWindowButton(.closeButton) else { return }
+            guard closeButton !== button || button.target !== self else { return }
+
+            detach()
+            closeButton = button
+            originalTarget = button.target
+            originalAction = button.action
+            button.target = self
+            button.action = #selector(closeButtonPressed)
+        }
+
+        @objc
+        private func closeButtonPressed() {
+            onClose()
         }
     }
 }

--- a/CaskHub/DesignSystem/Components/TopBarView.swift
+++ b/CaskHub/DesignSystem/Components/TopBarView.swift
@@ -20,6 +20,7 @@ struct TopBarView: View {
     var recentWindow: RecentlyAddedWindow?
     var onSelectWindow: ((RecentlyAddedWindow) -> Void)?
     var onUpdateAll: (() -> Void)?
+    var updateAllCount = 0
     var isUpdatingAll = false
     var greedyUpdates: Bool?
     var onToggleGreedy: ((Bool) -> Void)?
@@ -28,6 +29,7 @@ struct TopBarView: View {
 
     @State private var showSortMenu = false
     @State private var showPeriodMenu = false
+    @State private var showUpdateAllConfirmation = false
 
     var body: some View {
         HStack(spacing: 10) {
@@ -71,7 +73,7 @@ struct TopBarView: View {
 
     private var updateAllChip: some View {
         Button {
-            onUpdateAll?()
+            showUpdateAllConfirmation = true
         } label: {
             HStack(spacing: 6) {
                 if isUpdatingAll {
@@ -92,6 +94,7 @@ struct TopBarView: View {
         }
         .buttonStyle(.plain)
         .disabled(isUpdatingAll)
+        .updateAllConfirmation($showUpdateAllConfirmation, count: updateAllCount, onConfirm: onUpdateAll)
     }
 
     // MARK: - Greedy updates chip
@@ -279,5 +282,39 @@ struct TopBarView: View {
         .frame(width: 240)
         .background(Capsule().fill(Color.chSurfaceField))
         .overlay(Capsule().strokeBorder(Color.chHairlineStrong, lineWidth: 1))
+    }
+}
+
+private struct UpdateAllConfirmationModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let count: Int
+    let onConfirm: (() -> Void)?
+
+    func body(content: Content) -> some View {
+        content.alert("Update All Apps?", isPresented: $isPresented) {
+            Button("Cancel", role: .cancel) {}
+            Button("Update All") {
+                onConfirm?()
+            }
+        } message: {
+            Text("""
+            CaskHub will update all \(count) apps currently listed on \
+            the Updates page using Homebrew.
+            """)
+        }
+    }
+}
+
+private extension View {
+    func updateAllConfirmation(
+        _ isPresented: Binding<Bool>,
+        count: Int,
+        onConfirm: (() -> Void)?
+    ) -> some View {
+        modifier(UpdateAllConfirmationModifier(
+            isPresented: isPresented,
+            count: count,
+            onConfirm: onConfirm
+        ))
     }
 }

--- a/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
@@ -57,6 +57,10 @@ final class CaskOperationStore {
         }
     }
 
+    var hasActiveOperations: Bool {
+        isUpdatingAll || states.values.contains { $0.action != nil }
+    }
+
     var status: CaskOperationStatus? {
         CaskOperationStatus.make(
             operations: states.values.compactMap(\.progress),

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService.swift
@@ -48,6 +48,10 @@ final class LocalHomebrewService {
         operationStore.isUpdatingAll
     }
 
+    var hasActiveOperations: Bool {
+        operationStore.hasActiveOperations
+    }
+
     private(set) var brewVersion: String?
 
     private(set) var customBrewPrefix: String?

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -66,6 +66,7 @@ struct ContentView: View {
                             localHomebrew.send(.updateAll(tokens: tokens))
                         }
                         : nil,
+                    updateAllCount: viewModel.updatesCount,
                     isUpdatingAll: localHomebrew.isUpdatingAll,
                     greedyUpdates: selectedSidebar == .library(.updates) ? localHomebrew.greedyUpdates : nil,
                     onToggleGreedy: { enabled in

--- a/CaskHubTests/App/ApplicationTerminationCoordinatorTests.swift
+++ b/CaskHubTests/App/ApplicationTerminationCoordinatorTests.swift
@@ -1,0 +1,89 @@
+//
+//  ApplicationTerminationCoordinatorTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 29/07/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+final class ApplicationTerminationCoordinatorTests: XCTestCase {
+    @MainActor
+    private final class Probe {
+        var hasActiveOperations = false
+        var requestCount = 0
+        var replies: [Bool] = []
+    }
+
+    @MainActor
+    private func makeCoordinator(
+        probe: Probe
+    ) -> ApplicationTerminationCoordinator {
+        ApplicationTerminationCoordinator(
+            hasActiveOperations: { probe.hasActiveOperations },
+            requestApplicationTermination: { probe.requestCount += 1 },
+            replyToApplicationTermination: { probe.replies.append($0) }
+        )
+    }
+
+    @MainActor
+    func test_request_termination_uses_the_application_termination_path() {
+        let probe = Probe()
+        let coordinator = makeCoordinator(probe: probe)
+
+        coordinator.requestTermination()
+
+        XCTAssertEqual(probe.requestCount, 1)
+    }
+
+    @MainActor
+    func test_termination_proceeds_immediately_without_active_operations() {
+        let probe = Probe()
+        let coordinator = makeCoordinator(probe: probe)
+
+        let reply = coordinator.applicationShouldTerminate(.shared)
+
+        XCTAssertEqual(reply, .terminateNow)
+        XCTAssertFalse(coordinator.showsQuitConfirmation)
+        XCTAssertTrue(probe.replies.isEmpty)
+    }
+
+    @MainActor
+    func test_termination_waits_for_confirmation_during_an_active_operation() {
+        let probe = Probe()
+        probe.hasActiveOperations = true
+        let coordinator = makeCoordinator(probe: probe)
+
+        let reply = coordinator.applicationShouldTerminate(.shared)
+
+        XCTAssertEqual(reply, .terminateLater)
+        XCTAssertTrue(coordinator.showsQuitConfirmation)
+    }
+
+    @MainActor
+    func test_keep_running_cancels_a_pending_termination() {
+        let probe = Probe()
+        probe.hasActiveOperations = true
+        let coordinator = makeCoordinator(probe: probe)
+        _ = coordinator.applicationShouldTerminate(.shared)
+
+        coordinator.keepRunning()
+
+        XCTAssertEqual(probe.replies, [false])
+        XCTAssertFalse(coordinator.showsQuitConfirmation)
+    }
+
+    @MainActor
+    func test_confirmation_completes_a_pending_termination() {
+        let probe = Probe()
+        probe.hasActiveOperations = true
+        let coordinator = makeCoordinator(probe: probe)
+        _ = coordinator.applicationShouldTerminate(.shared)
+
+        coordinator.confirmTermination()
+
+        XCTAssertEqual(probe.replies, [true])
+        XCTAssertFalse(coordinator.showsQuitConfirmation)
+    }
+}

--- a/CaskHubTests/App/ApplicationTerminationCoordinatorTests.swift
+++ b/CaskHubTests/App/ApplicationTerminationCoordinatorTests.swift
@@ -13,7 +13,8 @@ final class ApplicationTerminationCoordinatorTests: XCTestCase {
     private final class Probe {
         var hasActiveOperations = false
         var requestCount = 0
-        var replies: [Bool] = []
+        var confirmationResult = false
+        var confirmationCount = 0
     }
 
     @MainActor
@@ -23,7 +24,10 @@ final class ApplicationTerminationCoordinatorTests: XCTestCase {
         ApplicationTerminationCoordinator(
             hasActiveOperations: { probe.hasActiveOperations },
             requestApplicationTermination: { probe.requestCount += 1 },
-            replyToApplicationTermination: { probe.replies.append($0) }
+            presentQuitConfirmation: {
+                probe.confirmationCount += 1
+                return probe.confirmationResult
+            }
         )
     }
 
@@ -45,45 +49,52 @@ final class ApplicationTerminationCoordinatorTests: XCTestCase {
         let reply = coordinator.applicationShouldTerminate(.shared)
 
         XCTAssertEqual(reply, .terminateNow)
-        XCTAssertFalse(coordinator.showsQuitConfirmation)
-        XCTAssertTrue(probe.replies.isEmpty)
+        XCTAssertEqual(probe.confirmationCount, 0)
     }
 
     @MainActor
-    func test_termination_waits_for_confirmation_during_an_active_operation() {
+    func test_termination_is_cancelled_when_the_user_keeps_an_active_operation_running() {
         let probe = Probe()
         probe.hasActiveOperations = true
         let coordinator = makeCoordinator(probe: probe)
 
         let reply = coordinator.applicationShouldTerminate(.shared)
 
-        XCTAssertEqual(reply, .terminateLater)
-        XCTAssertTrue(coordinator.showsQuitConfirmation)
+        XCTAssertEqual(reply, .terminateCancel)
+        XCTAssertEqual(probe.confirmationCount, 1)
     }
 
     @MainActor
-    func test_keep_running_cancels_a_pending_termination() {
+    func test_termination_proceeds_when_the_user_confirms_during_an_active_operation() {
         let probe = Probe()
         probe.hasActiveOperations = true
+        probe.confirmationResult = true
         let coordinator = makeCoordinator(probe: probe)
-        _ = coordinator.applicationShouldTerminate(.shared)
 
-        coordinator.keepRunning()
+        let reply = coordinator.applicationShouldTerminate(.shared)
 
-        XCTAssertEqual(probe.replies, [false])
-        XCTAssertFalse(coordinator.showsQuitConfirmation)
+        XCTAssertEqual(reply, .terminateNow)
+        XCTAssertEqual(probe.confirmationCount, 1)
     }
 
     @MainActor
-    func test_confirmation_completes_a_pending_termination() {
+    func test_configured_operation_provider_is_used_after_launch() {
         let probe = Probe()
-        probe.hasActiveOperations = true
-        let coordinator = makeCoordinator(probe: probe)
-        _ = coordinator.applicationShouldTerminate(.shared)
+        let coordinator = ApplicationTerminationCoordinator(
+            hasActiveOperations: { false },
+            requestApplicationTermination: {},
+            presentQuitConfirmation: {
+                probe.confirmationCount += 1
+                return false
+            }
+        )
+        coordinator.configure {
+            true
+        }
 
-        coordinator.confirmTermination()
+        let reply = coordinator.applicationShouldTerminate(.shared)
 
-        XCTAssertEqual(probe.replies, [true])
-        XCTAssertFalse(coordinator.showsQuitConfirmation)
+        XCTAssertEqual(reply, .terminateCancel)
+        XCTAssertEqual(probe.confirmationCount, 1)
     }
 }

--- a/CaskHubTests/Homebrew/Coordination/CaskOperationStoreTests.swift
+++ b/CaskHubTests/Homebrew/Coordination/CaskOperationStoreTests.swift
@@ -66,6 +66,39 @@ final class CaskOperationStoreTests: XCTestCase {
         XCTAssertEqual(store.state(for: "firefox"), .queued(.updating))
     }
 
+    func test_active_operations_include_queued_and_running_work() {
+        let store = CaskOperationStore()
+        let progress = CaskOperationProgress(
+            token: "zoom",
+            displayName: "Zoom",
+            action: .uninstalling,
+            phase: .performing
+        )
+
+        XCTAssertFalse(store.hasActiveOperations)
+
+        store.send(.enqueue(.installing), for: "firefox")
+        XCTAssertTrue(store.hasActiveOperations)
+
+        store.send(.begin(progress, canCancel: false), for: "zoom")
+        XCTAssertTrue(store.hasActiveOperations)
+
+        store.send(.clear, for: "firefox")
+        store.send(.clear, for: "zoom")
+        XCTAssertFalse(store.hasActiveOperations)
+    }
+
+    func test_confirmation_and_failure_states_are_not_active_operations() {
+        let store = CaskOperationStore()
+        let failure = CaskOperationFailure(kind: .brewCommand, message: "failed")
+
+        store.send(.awaitPermission(force: false), for: "canva")
+        store.send(.awaitPackageAdoption, for: "zoom")
+        store.send(.fail(failure), for: "tabby")
+
+        XCTAssertFalse(store.hasActiveOperations)
+    }
+
     func test_status_is_derived_from_operation_state() {
         let store = CaskOperationStore()
         let progress = CaskOperationProgress(
@@ -91,6 +124,7 @@ final class CaskOperationStoreTests: XCTestCase {
 
         XCTAssertTrue(store.beginUpdateAll())
         XCTAssertFalse(store.beginUpdateAll())
+        XCTAssertTrue(store.hasActiveOperations)
 
         store.setUpdateAllProgress(progress)
         XCTAssertTrue(store.isUpdatingAll)
@@ -99,6 +133,7 @@ final class CaskOperationStoreTests: XCTestCase {
         store.finishUpdateAll()
         XCTAssertFalse(store.isUpdatingAll)
         XCTAssertNil(store.updateAllProgress)
+        XCTAssertFalse(store.hasActiveOperations)
     }
 
     func test_update_all_progress_is_ignored_outside_an_active_batch() {

--- a/CaskHubTests/Views/ContentViewTests.swift
+++ b/CaskHubTests/Views/ContentViewTests.swift
@@ -20,7 +20,13 @@ final class ContentViewTests: XCTestCase {
 
     @MainActor
     private final class CloseProbe {
-        var requested = false
+        var terminationCoordinator: ApplicationTerminationCoordinator?
+        var confirmationCount = 0
+        var terminationReply: NSApplication.TerminateReply?
+
+        func requestTermination() {
+            terminationReply = terminationCoordinator?.applicationShouldTerminate(.shared)
+        }
     }
 
     // MARK: - Harness
@@ -127,8 +133,17 @@ final class ContentViewTests: XCTestCase {
     }
 
     @MainActor
-    func test_close_button_invokes_the_configured_app_close_request() throws {
+    func test_close_button_routes_through_active_operation_confirmation() throws {
         let probe = CloseProbe()
+        let terminationCoordinator = ApplicationTerminationCoordinator(
+            hasActiveOperations: { true },
+            requestApplicationTermination: { probe.requestTermination() },
+            presentQuitConfirmation: {
+                probe.confirmationCount += 1
+                return false
+            }
+        )
+        probe.terminationCoordinator = terminationCoordinator
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
             styleMask: [.titled, .closable],
@@ -137,7 +152,7 @@ final class ContentViewTests: XCTestCase {
         )
         window.isReleasedWhenClosed = false
         window.contentView = NSHostingView(rootView: WindowCloseButtonConfigurator {
-            probe.requested = true
+            terminationCoordinator.requestTermination()
         })
         window.orderFrontRegardless()
 
@@ -151,7 +166,8 @@ final class ContentViewTests: XCTestCase {
 
         closeButton.performClick(nil)
 
-        XCTAssertTrue(probe.requested)
+        XCTAssertEqual(probe.confirmationCount, 1)
+        XCTAssertEqual(probe.terminationReply, .terminateCancel)
         window.contentView = NSView()
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
         window.close()

--- a/CaskHubTests/Views/ContentViewTests.swift
+++ b/CaskHubTests/Views/ContentViewTests.swift
@@ -18,6 +18,11 @@ final class ContentViewTests: XCTestCase {
         func resign() { resignCount += 1 }
     }
 
+    @MainActor
+    private final class CloseProbe {
+        var requested = false
+    }
+
     // MARK: - Harness
 
     @MainActor
@@ -119,6 +124,37 @@ final class ContentViewTests: XCTestCase {
         click(at: NSPoint(x: 20, y: 20), in: window)
 
         XCTAssertEqual(probe.resignCount, 0)
+    }
+
+    @MainActor
+    func test_close_button_invokes_the_configured_app_close_request() throws {
+        let probe = CloseProbe()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: WindowCloseButtonConfigurator {
+            probe.requested = true
+        })
+        window.orderFrontRegardless()
+
+        let closeButton = try XCTUnwrap(window.standardWindowButton(.closeButton))
+        let deadline = Date().addingTimeInterval(2)
+        while !(closeButton.target is WindowCloseButtonConfigurator.Coordinator),
+              Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertTrue(closeButton.target is WindowCloseButtonConfigurator.Coordinator)
+
+        closeButton.performClick(nil)
+
+        XCTAssertTrue(probe.requested)
+        window.contentView = NSView()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        window.close()
     }
 }
 


### PR DESCRIPTION
## Summary

- make the standard window close button quit CaskHub
- require confirmation before quitting while Homebrew operations are active
- require confirmation before starting Update All and show the affected app count
- cover active-operation tracking and close-button interception with tests

## Validation

- swiftlint lint --strict --no-cache --quiet
- xcodebuild test -project CaskHub.xcodeproj -scheme CaskHub -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/CaskHubCloseConfirmDerivedData