### PR TITLE
perf: Decode catalog JSON off the main actor

### DIFF
--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ArtifactStanza: Decodable, Hashable {
+nonisolated struct ArtifactStanza: Decodable, Hashable {
     let keys: Set<String>
     let appNames: [String]
     let binaryNames: [String]
@@ -147,7 +147,7 @@ struct ArtifactStanza: Decodable, Hashable {
 
 }
 
-struct Cask: Decodable, Identifiable, Hashable {
+nonisolated struct Cask: Decodable, Identifiable, Hashable {
     let token: String
     let fullToken: String?
     let tap: String?

--- a/CaskHub/Models/CaskAnalytics.swift
+++ b/CaskHub/Models/CaskAnalytics.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum AnalyticsPeriod: String, CaseIterable, Identifiable {
+nonisolated enum AnalyticsPeriod: String, CaseIterable, Identifiable {
     case days30 = "30d"
     case days90 = "90d"
     case days365 = "365d"
@@ -25,11 +25,11 @@ enum AnalyticsPeriod: String, CaseIterable, Identifiable {
     }
 }
 
-struct CaskAnalyticsResponse: Decodable {
+nonisolated struct CaskAnalyticsResponse: Decodable {
     let items: [CaskAnalyticsItem]
 }
 
-struct CaskAnalyticsItem: Decodable {
+nonisolated struct CaskAnalyticsItem: Decodable {
     let cask: String
     let count: String
 

--- a/CaskHub/Services/Catalog/BrewAPIClient.swift
+++ b/CaskHub/Services/Catalog/BrewAPIClient.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-protocol BrewAPIClientProtocol {
+nonisolated protocol BrewAPIClientProtocol {
     func fetchAllCasks() async throws -> [Cask]
     func fetchAnalytics(period: AnalyticsPeriod) async throws -> CaskAnalyticsResponse
 }
 
-final class BrewAPIClient: BrewAPIClientProtocol {
+nonisolated final class BrewAPIClient: BrewAPIClientProtocol {
     struct HTTPError: LocalizedError {
         let statusCode: Int
 
@@ -20,12 +20,6 @@ final class BrewAPIClient: BrewAPIClientProtocol {
             "formulae.brew.sh returned HTTP \(statusCode)."
         }
     }
-
-    private let decoder: JSONDecoder = {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return decoder
-    }()
 
     func fetchAllCasks() async throws -> [Cask] {
         try await fetch(URL(string: "https://formulae.brew.sh/api/cask.json")!)
@@ -37,11 +31,15 @@ final class BrewAPIClient: BrewAPIClientProtocol {
         )!)
     }
 
-    private func fetch<T: Decodable>(_ url: URL) async throws -> T {
+    // @concurrent keeps the multi-megabyte decode off the caller's actor;
+    // plain nonisolated async would inherit MainActor and hang the UI.
+    @concurrent private func fetch<T: Decodable & Sendable>(_ url: URL) async throws -> T {
         let (data, response) = try await URLSession.shared.data(from: url)
         if let http = response as? HTTPURLResponse, !(200 ..< 300).contains(http.statusCode) {
             throw HTTPError(statusCode: http.statusCode)
         }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
         return try decoder.decode(T.self, from: data)
     }
 }

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -11,19 +11,19 @@ import Foundation
 // MARK: - Mock API
 
 @MainActor
-final class MockBrewAPIClient: BrewAPIClientProtocol {
+final class MockBrewAPIClient: @MainActor BrewAPIClientProtocol {
     var casks: [Cask] = []
     var casksError: Error?
     var analyticsResponses: [AnalyticsPeriod: CaskAnalyticsResponse] = [:]
     var analyticsError: Error?
     private(set) var analyticsFetches: [AnalyticsPeriod] = []
 
-    func fetchAllCasks() async throws -> [Cask] {
+    @MainActor func fetchAllCasks() async throws -> [Cask] {
         if let casksError { throw casksError }
         return casks
     }
 
-    func fetchAnalytics(period: AnalyticsPeriod) async throws -> CaskAnalyticsResponse {
+    @MainActor func fetchAnalytics(period: AnalyticsPeriod) async throws -> CaskAnalyticsResponse {
         analyticsFetches.append(period)
         if let analyticsError { throw analyticsError }
         return analyticsResponses[period]


### PR DESCRIPTION
## Summary
Fixes the app hang reported in Sentry [CASKHUB-17](https://caskhub.sentry.io/issues/CASKHUB-17) (`App hanging for at least 2000 ms`, culprit `ArtifactStanza.artifactNames` under `BrewAPIClient.fetch`).

`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` makes every unannotated type MainActor-isolated — including `BrewAPIClient`. Decoding the ~25MB `cask.json` (with the lenient multi-probe `ArtifactStanza` decoder) therefore ran on the main thread on every catalog refresh. Fast Macs stayed under Sentry's 2s hang threshold; the reporting device (2018 Intel MBP, low power mode) did not.

## Changes
- `BrewAPIClient` + protocol marked `nonisolated`; `fetch` marked `@concurrent` so the network read + decode always run on the concurrent executor. Plain `nonisolated async` is not enough — with `SWIFT_APPROACHABLE_CONCURRENCY` it inherits the caller's actor (MainActor).
- `Cask`, `ArtifactStanza`, `CaskAnalyticsResponse`/`Item`, `AnalyticsPeriod` marked `nonisolated` so their `Decodable` conformances are usable off-main and the values are `Sendable` back to the view model.
- `JSONDecoder` created per fetch instead of stored (non-Sendable stored state on a nonisolated class).
- `MockBrewAPIClient` methods pinned `@MainActor` with an isolated conformance so test state stays actor-safe.

## Testing
- Full test suite: **TEST SUCCEEDED** (all unit tests pass).
- Debug build + SwiftLint clean.