### PR TITLE
perf: Keep filesystem probes out of the render-path state resolver

### DIFF
--- a/CaskHub/Services/Homebrew/Coordination/CaskLocalStateResolver.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskLocalStateResolver.swift
@@ -140,39 +140,45 @@ struct CaskLocalStateResolver {
             && isOutdated(token: token, remoteVersion: remoteVersion)
     }
 
+    // isZombie and canOpen run for every cask during view updates. Before the
+    // installation index has reconciled the catalog they answer from in-memory
+    // scan results instead of probing bundles on disk, which hung the main
+    // thread (Sentry CASKHUB-Z). Zombie verdicts wait for the verified index:
+    // a false positive offers repairing an app that is alive.
     func isZombie(_ cask: Cask) -> Bool {
         guard let installation = snapshot.installedCasks[cask.token],
               installation.isZombie,
               !cask.appArtifactNames.isEmpty
         else { return false }
-        if snapshot.installationIndex.catalogTokens.contains(cask.token) {
-            return snapshot.installationIndex.verifiedZombieTokens.contains(
-                cask.token
-            )
+        guard snapshot.installationIndex.catalogTokens.contains(cask.token) else {
+            return false
         }
-        return existingBundleURL(named: cask.appArtifactNames) == nil
+        return snapshot.installationIndex.verifiedZombieTokens.contains(
+            cask.token
+        )
     }
 
     func canOpen(_ cask: Cask) -> Bool {
-        if snapshot.installationIndex.catalogTokens.contains(cask.token) {
-            if isInstalled(token: cask.token) {
+        if isInstalled(token: cask.token) {
+            if snapshot.installationIndex.catalogTokens.contains(cask.token) {
                 return snapshot.installationIndex.launchableHomebrewTokens.contains(
                     cask.token
                 )
             }
+            let bundleNames = Set(launchableBundleNames(for: cask))
+            return snapshot.detectedApplications.contains {
+                bundleNames.contains($0.bundleName)
+            }
+        }
+        if snapshot.installationIndex.catalogTokens.contains(cask.token) {
             return snapshot.installationIndex
                 .macAppStoreApplications[cask.token] != nil
                 || snapshot.externalApplicationOwners[cask.token] != nil
                 || snapshot.externalPackageInstallations[cask.token] != nil
         }
-        if !isInstalled(token: cask.token),
-           let application = macAppStoreApplication(for: cask) {
-            return applicationDiscovery.metadata(
-                at: application.url,
-                fileManager: fileManager
-            ) != nil
-        }
-        return launchURL(for: cask) != nil
+        return macAppStoreApplication(for: cask) != nil
+            || snapshot.externalApplicationOwners[cask.token] != nil
+            || snapshot.externalPackageInstallations[cask.token] != nil
     }
 
     func launchURL(for cask: Cask) -> URL? {

--- a/CaskHub/Services/Homebrew/Coordination/CaskLocalStateResolver.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskLocalStateResolver.swift
@@ -140,11 +140,6 @@ struct CaskLocalStateResolver {
             && isOutdated(token: token, remoteVersion: remoteVersion)
     }
 
-    // isZombie and canOpen run for every cask during view updates. Before the
-    // installation index has reconciled the catalog they answer from in-memory
-    // scan results instead of probing bundles on disk, which hung the main
-    // thread (Sentry CASKHUB-Z). Zombie verdicts wait for the verified index:
-    // a false positive offers repairing an app that is alive.
     func isZombie(_ cask: Cask) -> Bool {
         guard let installation = snapshot.installedCasks[cask.token],
               installation.isZombie,
@@ -170,13 +165,10 @@ struct CaskLocalStateResolver {
                 bundleNames.contains($0.bundleName)
             }
         }
-        if snapshot.installationIndex.catalogTokens.contains(cask.token) {
-            return snapshot.installationIndex
-                .macAppStoreApplications[cask.token] != nil
-                || snapshot.externalApplicationOwners[cask.token] != nil
-                || snapshot.externalPackageInstallations[cask.token] != nil
-        }
-        return macAppStoreApplication(for: cask) != nil
+        let hasStoreApp = snapshot.installationIndex.catalogTokens.contains(cask.token)
+            ? snapshot.installationIndex.macAppStoreApplications[cask.token] != nil
+            : macAppStoreApplication(for: cask) != nil
+        return hasStoreApp
             || snapshot.externalApplicationOwners[cask.token] != nil
             || snapshot.externalPackageInstallations[cask.token] != nil
     }

--- a/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
@@ -239,7 +239,7 @@ final class ZombieDetectionTests: XCTestCase {
     }
 
     @MainActor
-    func test_zombie_verdict_holds_when_current_cask_app_is_gone_too() {
+    func test_zombie_verdict_holds_when_current_cask_app_is_gone_too() async {
         let service = LocalHomebrewService(
             defaults: makeScratchDefaults("zombie-holds")
         ) {
@@ -249,12 +249,9 @@ final class ZombieDetectionTests: XCTestCase {
             token: "mole-app", installedVersion: "1.0", installedAt: nil,
             appBundleNames: ["Mole.app"], isZombie: true
         ), in: service)
-        XCTAssertTrue(
-            service.localState(for: makeCask(
-                "mole-app",
-                appNames: ["Mole.app"]
-            )).isZombie
-        )
+        let cask = makeCask("mole-app", appNames: ["Mole.app"])
+        await service.updatePackageCatalog([cask])
+        XCTAssertTrue(service.localState(for: cask).isZombie)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
Fixes the worst of the App Hanging issues in Sentry: [CASKHUB-Z](https://caskhub.sentry.io/issues/CASKHUB-Z). Production stack: `ContentView.body` → `updatesCount` → `librarySnapshot` → `LocalHomebrewService.localStates` → `canOpen` → `existingBundleURL` → `Data(contentsOf: Info.plist)` + Unicode-normalized `Set.contains` per candidate, per cask.

`librarySnapshot` computes `localStates(for:)` for the entire catalog (~thousands of casks) synchronously during body evaluation. In the window between the catalog arriving and `updatePackageCatalog` committing the reconciled installation index, **every** cask took the resolver's fallback path: scan `detectedApplications` plus read `Contents/Info.plist` off disk per bundle-name candidate. Thousands of synchronous file reads on the main thread.

## Approach
- `canOpen` pre-index now answers from the in-memory scan results (`detectedApplications`, `externalApplicationOwners`, `externalPackageInstallations`), mirroring exactly what `InstallationIndexBuilder` computes — same verdicts, no disk.
- `isZombie` pre-index returns `false` and waits for the verified index (`verifiedZombieTokens`). Deliberate safety direction: a false-positive zombie badge offers repairing an app that is alive on disk. The badge appears once reconciliation lands (seconds after catalog load).
- Disk probes are untouched on user-initiated action paths (`open`, `openExternalApp`, adoption preflight) — one cask, user-driven, correct place for ground truth.
- `test_zombie_verdict_holds_when_current_cask_app_is_gone_too` now registers the catalog first, exercising the real index path; the sibling `clears` test locks the new pre-index conservative behavior.

## Behavior change
During the brief pre-reconcile window on cold start, Open buttons for installed casks resolve from the machine scan instead of disk, and zombie badges appear only after index verification. No steady-state behavior changes.

## Testing
- Full test suite: **TEST SUCCEEDED** — including the zombie-verdict pair and the external-installation (Zoom PKG / nested Mac App Store / Tailscale bundle-family) tests that pin the pre-index fallback verdicts.