### PR TITLE
perf: Drop the per-row AppKit bridge from the actions menu button

### DIFF
--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -115,7 +115,10 @@ struct CaskRowView: View {
     }
 }
 
-struct CaskRowActionsMenuButton: NSViewRepresentable {
+// A plain SwiftUI button popping an NSMenu on click. Hosting an
+// NSViewRepresentable per row made every NSHostingView layout pass walk an
+// AppKit bridge for each visible row (Sentry CASKHUB-18).
+struct CaskRowActionsMenuButton: View {
     let showsUpdate: Bool
     let isBusy: Bool
     let uninstallAvailability: CaskUninstallAvailability
@@ -123,30 +126,25 @@ struct CaskRowActionsMenuButton: NSViewRepresentable {
     let onUpdate: () -> Void
     let onUninstall: () -> Void
 
+    var body: some View {
+        Button {
+            // popUp is synchronous, so the coordinator outlives the menu
+            // session even as a local.
+            makeCoordinator().showMenu()
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 13, weight: .regular))
+                .foregroundStyle(Color.chTextMuted)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("More actions")
+        .accessibilityLabel("More actions")
+    }
+
     func makeCoordinator() -> Coordinator {
         Coordinator(configuration: self)
-    }
-
-    func makeNSView(context: Context) -> NSButton {
-        let button = NSButton()
-        button.isBordered = false
-        button.imagePosition = .imageOnly
-        button.imageScaling = .scaleProportionallyDown
-        button.image = NSImage(
-            systemSymbolName: "ellipsis.circle",
-            accessibilityDescription: "More actions"
-        )?.withSymbolConfiguration(.init(pointSize: 13, weight: .regular))
-        button.contentTintColor = NSColor(Color.chTextMuted)
-        button.focusRingType = .none
-        button.toolTip = "More actions"
-        button.target = context.coordinator
-        button.action = #selector(Coordinator.showMenu(_:))
-        button.setAccessibilityLabel("More actions")
-        return button
-    }
-
-    func updateNSView(_ button: NSButton, context: Context) {
-        context.coordinator.configuration = self
     }
 
     @MainActor
@@ -157,12 +155,11 @@ struct CaskRowActionsMenuButton: NSViewRepresentable {
             self.configuration = configuration
         }
 
-        @objc func showMenu(_ sender: NSButton) {
-            let menu = makeMenu()
-            menu.popUp(
+        func showMenu() {
+            makeMenu().popUp(
                 positioning: nil,
-                at: NSPoint(x: sender.bounds.minX, y: sender.bounds.minY - 4),
-                in: sender
+                at: NSEvent.mouseLocation,
+                in: nil
             )
         }
 

--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -115,9 +115,6 @@ struct CaskRowView: View {
     }
 }
 
-// A plain SwiftUI button popping an NSMenu on click. Hosting an
-// NSViewRepresentable per row made every NSHostingView layout pass walk an
-// AppKit bridge for each visible row (Sentry CASKHUB-18).
 struct CaskRowActionsMenuButton: View {
     let showsUpdate: Bool
     let isBusy: Bool
@@ -125,13 +122,12 @@ struct CaskRowActionsMenuButton: View {
     let onInfo: () -> Void
     let onUpdate: () -> Void
     let onUninstall: () -> Void
+    var presentMenu: (NSMenu) -> Void = { menu in
+        menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
+    }
 
     var body: some View {
-        Button {
-            // popUp is synchronous, so the coordinator outlives the menu
-            // session even as a local.
-            makeCoordinator().showMenu()
-        } label: {
+        Button(action: presentActionsMenu) {
             Image(systemName: "ellipsis.circle")
                 .font(.system(size: 13, weight: .regular))
                 .foregroundStyle(Color.chTextMuted)
@@ -147,20 +143,16 @@ struct CaskRowActionsMenuButton: View {
         Coordinator(configuration: self)
     }
 
+    func presentActionsMenu() {
+        presentMenu(makeCoordinator().makeMenu())
+    }
+
     @MainActor
     final class Coordinator: NSObject {
         var configuration: CaskRowActionsMenuButton
 
         init(configuration: CaskRowActionsMenuButton) {
             self.configuration = configuration
-        }
-
-        func showMenu() {
-            makeMenu().popUp(
-                positioning: nil,
-                at: NSEvent.mouseLocation,
-                in: nil
-            )
         }
 
         @objc func showInfo() {

--- a/CaskHubTests/Homebrew/Presentation/CaskListActionTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskListActionTests.swift
@@ -115,6 +115,24 @@ final class CaskListActionTests: XCTestCase {
         XCTAssertEqual(menu.items[3].toolTip, expectedHint)
     }
 
+    func test_menu_button_press_presents_the_actions_menu() {
+        var presentedTitles: [String]?
+        let button = CaskRowActionsMenuButton(
+            showsUpdate: true,
+            isBusy: false,
+            uninstallAvailability: .available,
+            onInfo: {},
+            onUpdate: {},
+            onUninstall: {},
+            presentMenu: { presentedTitles = $0.items.map(\.title) }
+        )
+
+        render(button)
+        button.presentActionsMenu()
+
+        XCTAssertEqual(presentedTitles, ["Info", "Update", "", "Uninstall"])
+    }
+
     func test_row_action_menu_preserves_unavailable_uninstall_hint() {
         let hint = "Adopt this app first so CaskHub can manage/uninstall it."
         let coordinator = menuButton(


### PR DESCRIPTION
## Summary
Addresses Sentry [CASKHUB-18](https://caskhub.sentry.io/issues/CASKHUB-18) (`App hanging for at least 2000 ms`, culprit `CaskRowActionsMenuButton` inside `NSHostingView.layout` → `PlatformViewRepresentableAdaptor`).

Every list row hosted an `NSViewRepresentable`-wrapped `NSButton` just to trigger a context menu. The menu itself is built lazily on click and was never the cost — the cost was walking an AppKit bridge per visible row on every layout pass.

## Approach
- Trigger is now a plain SwiftUI `Button` with the same ellipsis glyph, size, color, tooltip, and accessibility label.
- `Coordinator.makeMenu()` — the NSMenu with item icons, disabled states, and tooltip hints (which SwiftUI `Menu` items can't replicate) — is untouched and pops at the cursor. `popUp` is synchronous, so the coordinator outlives the menu session as a local.
- All four `CaskListActionTests` menu tests pass **unchanged** since `makeCoordinator()`/`makeMenu()` kept their shape.

## Testing
- Full test suite: **TEST SUCCEEDED**.