### PR TITLE
test: Exercise the index path in the zombie-clears verdict

### DIFF
--- a/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
@@ -217,7 +217,7 @@ final class ZombieDetectionTests: XCTestCase {
     /// The Codex→ChatGPT rename: receipt says Codex.app (gone), but the cask's
     /// current artifact ChatGPT.app is alive on disk. Never offer deletion then.
     @MainActor
-    func test_zombie_verdict_clears_when_current_cask_app_exists() throws {
+    func test_zombie_verdict_clears_when_current_cask_app_exists() async throws {
         try makeApplicationBundle(
             in: appsDir, named: "ChatGPT.app", bundleIdentifier: "com.openai.chat"
         )
@@ -230,12 +230,9 @@ final class ZombieDetectionTests: XCTestCase {
             token: "chatgpt", installedVersion: "26.623", installedAt: nil,
             appBundleNames: ["Codex.app"], isZombie: true
         ), in: service)
-        XCTAssertFalse(
-            service.localState(for: makeCask(
-                "chatgpt",
-                appNames: ["ChatGPT.app"]
-            )).isZombie
-        )
+        let cask = makeCask("chatgpt", appNames: ["ChatGPT.app"])
+        await service.updatePackageCatalog([cask])
+        XCTAssertFalse(service.localState(for: cask).isZombie)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
Follow-up to #113, from this session's code-review pass. `test_zombie_verdict_clears_when_current_cask_app_exists` became vacuous after the resolver stopped probing disk pre-index: with no catalog registered, `isZombie` returns `false` unconditionally, so the test passed even with the `makeApplicationBundle` line deleted — it no longer verified the Codex→ChatGPT rename cross-check its comment describes.

Now registers the catalog via `updatePackageCatalog`, so the verdict flows through `InstallationIndexBuilder`'s `verifiedZombieTokens` (current artifact ChatGPT.app detected on disk → not a zombie), matching how the sibling "holds" test was updated in #113. Deleting the bundle line now fails the test — coverage restored.

## Testing
- `ZombieDetectionTests`: all 14 pass, including both verdict tests through the index path.