### PR TITLE
feat: Treat unmined catalog tokens as recently added

### DIFF
--- a/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
@@ -98,7 +98,9 @@ enum CatalogProjector {
                 title: "Recently Added",
                 destination: .discover(.recentlyAdded),
                 casks: Array(sortedByNewest(
-                    input.casks.filter { input.recentTokens.contains($0.token) },
+                    input.casks.filter {
+                        isRecent($0.token, in: input.recentTokens, addedDates: input.addedDates)
+                    },
                     addedDates: input.addedDates
                 ).prefix(sectionSize))
             )
@@ -135,7 +137,9 @@ enum CatalogProjector {
         case .discover(.topCharts):
             return input.casks
         case .discover(.recentlyAdded):
-            return input.casks.filter { input.recentTokens.contains($0.token) }
+            return input.casks.filter {
+                isRecent($0.token, in: input.recentTokens, addedDates: input.addedDates)
+            }
         case .library(.installed):
             return input.library.installedCasks
         case .library(.updates):
@@ -206,12 +210,23 @@ enum CatalogProjector {
         casks.sorted { (counts[$0.token] ?? 0) > (counts[$1.token] ?? 0) }
     }
 
+    // Catalog tokens absent from the mined dates postdate the last mine, so they
+    // are the newest casks; an empty dictionary means the data never loaded.
+    private static func isRecent(
+        _ token: String,
+        in recentTokens: Set<String>,
+        addedDates: [String: String]
+    ) -> Bool {
+        recentTokens.contains(token)
+            || (!addedDates.isEmpty && addedDates[token] == nil)
+    }
+
     private static func sortedByNewest(
         _ casks: [Cask],
         addedDates: [String: String]
     ) -> [Cask] {
         casks.sorted {
-            (addedDates[$0.token] ?? "") > (addedDates[$1.token] ?? "")
+            (addedDates[$0.token] ?? "9999") > (addedDates[$1.token] ?? "9999")
         }
     }
 }

--- a/CaskHubTests/Catalog/CaskCatalogSortTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogSortTests.swift
@@ -115,7 +115,7 @@ final class CaskCatalogSortTests: XCTestCase {
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["charlie", "bravo", "alpha"])
 
         vm.sortOption = .newest
-        XCTAssertEqual(vm.filteredCasks.map(\.token), ["bravo", "alpha", "charlie"])
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["charlie", "bravo", "alpha"])
 
         vm.sortOption = .oldest
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["alpha", "bravo", "charlie"])

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -148,9 +148,28 @@ final class CaskCatalogViewModelTests: XCTestCase {
 
         vm.selectedSidebar = .discover(.recentlyAdded)
 
-        XCTAssertEqual(vm.filteredCasks.map(\.token), ["new-app"])
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["undated-app", "new-app"])
         vm.selectRecentlyAddedWindow(.days90)
-        XCTAssertEqual(Set(vm.filteredCasks.map(\.token)), ["new-app"])
+        XCTAssertEqual(Set(vm.filteredCasks.map(\.token)), ["undated-app", "new-app"])
+    }
+
+    @MainActor
+    func test_unmined_tokens_count_as_recently_added_until_dates_refresh() async {
+        let recent = RecentlyAddedService()
+        recent.addedDates = ["old-app": dateString(daysAgo: 100)]
+        let (vm, _) = await makeSUT(
+            casks: [makeCask("old-app"), makeCask("brand-new")],
+            recentlyAdded: recent
+        )
+
+        vm.selectedSidebar = .discover(.recentlyAdded)
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["brand-new"])
+
+        let shelf = vm.browseSections.first { $0.title == "Recently Added" }
+        XCTAssertEqual(shelf?.casks.map(\.token), ["brand-new"])
+
+        recent.addedDates["brand-new"] = dateString(daysAgo: 1)
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["brand-new"])
     }
 
     // MARK: Browse sections


### PR DESCRIPTION
## Why

New casks merged to homebrew-cask appear in browse/search right away (live catalog from formulae.brew.sh) but were missing from Recently Added until the next daily CaskFlow release mined their added dates.

## What

Any catalog token absent from the mined `added_dates.json` by definition postdates the last mine, so the projector now counts it as recently added:

- `CatalogProjector`: new `isRecent` helper applied to both the Recently Added browse shelf and the Recently Added page filter. Guarded by `!addedDates.isEmpty` so an unloaded dictionary never flags the whole catalog.
- `sortedByNewest` defaults unknown tokens to `"9999"` so they sort first (consistent with `.oldest`, which already defaults them last).
- Self-healing: unmined tokens get their real dates with the next daily release.

## Tests

- New: `test_unmined_tokens_count_as_recently_added_until_dates_refresh` (page filter, browse shelf, and post-refresh behavior).
- Updated expectations in `test_recently_added_page_respects_window` and `.newest` ordering in `test_sort_options_order_by_downloads_name_and_added_date`.
- Empty-dictionary guard already covered by `test_cached_projections_invalidate_for_each_catalog_dependency`.
- Full suite: **TEST SUCCEEDED**.