### PR TITLE
feat: Refresh the catalog when the app becomes active

### DIFF
--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -119,7 +119,11 @@ final class CaskCatalogViewModel {
 
     // MARK: - Data Fetching
 
+    var lastLoadedAt: Date?
+
     func load() async {
+        // Stamped up front so activations during a load don't start another.
+        lastLoadedAt = .now
         async let catalog: Void = fetchCasks()
         async let local: Void = localHomebrew.refresh()
         async let categories: Void = categoryService.refreshFromRemote()
@@ -127,8 +131,16 @@ final class CaskCatalogViewModel {
         _ = await (catalog, local, categories, addedDates)
     }
 
+    func refreshIfStale(maxAge: TimeInterval = 3600) async {
+        guard let lastLoadedAt,
+              Date.now.timeIntervalSince(lastLoadedAt) >= maxAge
+        else { return }
+        await load()
+    }
+
     func fetchCasks() async {
-        isLoading = true
+        // A background refresh keeps showing the catalog it already has.
+        isLoading = casks.isEmpty
         errorMessage = nil
         let span = CrashReporter.span(name: "catalog.fetch", operation: "http")
 
@@ -150,7 +162,7 @@ final class CaskCatalogViewModel {
             }
             span.finish()
         } catch {
-            errorMessage = error.localizedDescription
+            if casks.isEmpty { errorMessage = error.localizedDescription }
             span.finish(error: error)
             CrashReporter.capture(error)
         }

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -119,6 +119,13 @@ struct ContentView: View {
         .task {
             await viewModel.load()
         }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: NSApplication.didBecomeActiveNotification
+            )
+        ) { _ in
+            Task { await viewModel.refreshIfStale() }
+        }
         .onChange(of: viewModel.selectedSidebar) { _, newValue in
             Analytics.pageOpened(newValue)
             if newValue == .discover(.topCharts) {

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -154,6 +154,34 @@ final class CaskCatalogViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_background_fetch_stays_silent_when_catalog_present() async {
+        let (vm, api) = await makeSUT(casks: [makeCask("first")])
+
+        api.casks = [makeCask("first"), makeCask("second")]
+        await vm.fetchCasks()
+        XCTAssertEqual(vm.casks.count, 2)
+
+        api.casksError = URLError(.notConnectedToInternet)
+        await vm.fetchCasks()
+        XCTAssertEqual(vm.casks.count, 2)
+        XCTAssertNil(vm.errorMessage)
+        XCTAssertFalse(vm.isLoading)
+    }
+
+    @MainActor
+    func test_refresh_if_stale_throttles_within_max_age_and_before_first_load() async {
+        let (vm, api) = await makeSUT(casks: [makeCask("first")])
+        api.casks = [makeCask("first"), makeCask("second")]
+
+        await vm.refreshIfStale(maxAge: 0)
+        XCTAssertEqual(vm.casks.count, 1)
+
+        vm.lastLoadedAt = .now
+        await vm.refreshIfStale()
+        XCTAssertEqual(vm.casks.count, 1)
+    }
+
+    @MainActor
     func test_unmined_tokens_count_as_recently_added_until_dates_refresh() async {
         let recent = RecentlyAddedService()
         recent.addedDates = ["old-app": dateString(daysAgo: 100)]


### PR DESCRIPTION
## Why

All remote data (catalog, categories, added dates) and the local install scan ran once, at window load. A user who keeps CaskHub open never sees new casks or pipeline updates - every freshness improvement upstream collapses to app-launch granularity.

## What

- `CaskCatalogViewModel.refreshIfStale(maxAge:)` - re-runs `load()` when the last load is older than an hour; `lastLoadedAt` is stamped at load start so activations during a load don't start another, and a refresh before the first load is a no-op.
- `ContentView` triggers it on `NSApplication.didBecomeActiveNotification`.
- Silent refresh: `fetchCasks` only shows the loading spinner (`isLoading`) and the error screen (`errorMessage`) while no catalog is loaded - a failed background refresh (e.g. waking offline) keeps the catalog on screen.

## Tests

- `test_background_fetch_stays_silent_when_catalog_present`
- `test_refresh_if_stale_throttles_within_max_age_and_before_first_load`
- Full suite: **TEST SUCCEEDED**. The stale path itself calls `load()` (real network + disk scan), so it is exercised via the throttle-gate tests and manual run rather than an end-to-end test.