### PR TITLE
feat: Add GoatCounter analytics to landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -333,6 +333,7 @@
     .hero { padding-top: 40px; }
   }
 </style>
+<script data-goatcounter="https://caskhub.goatcounter.com/count" async src="https://gc.zgo.at/count.v5.js" integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ" crossorigin="anonymous"></script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
Adds privacy-friendly GoatCounter analytics to caskhub.app so site visits are finally measurable (GitHub Pages provides no visitor stats).

- Single script tag in `docs/index.html` pointing to `caskhub.goatcounter.com`
- Pinned to the immutable `count.v5.js` with SRI (`integrity` + `crossorigin`) to guard against CDN compromise
- No cookies, no personal data collected and no consent banner needed