### PR TITLE
fix: Retry manifest-vouched icon misses within minutes

### DIFF
--- a/CaskHub/Services/Images/ImageCacheService.swift
+++ b/CaskHub/Services/Images/ImageCacheService.swift
@@ -24,6 +24,10 @@ final class ImageCacheService {
     var knownIconTokens: () -> Set<String>? = { nil }
 
     private static let missRetryInterval: TimeInterval = 24 * 60 * 60
+    // The manifest vouches the icon exists, so a recorded miss is publication
+    // or CDN lag, not absence - misses recorded before the manifest gained the
+    // token would otherwise hide the icon for a full day.
+    private static let vouchedMissRetryInterval: TimeInterval = 15 * 60
 
     init(session: URLSession = .shared, diskCache: IconDiskCache = .shared) {
         self.session = session
@@ -65,7 +69,9 @@ final class ImageCacheService {
 
         if await diskCache.hasRecentMiss(
             token: token,
-            retryInterval: Self.missRetryInterval
+            retryInterval: inManifest
+                ? Self.vouchedMissRetryInterval
+                : Self.missRetryInterval
         ) {
             return nil
         }

--- a/CaskHubTests/Views/SettingsViewTests.swift
+++ b/CaskHubTests/Views/SettingsViewTests.swift
@@ -293,6 +293,70 @@ final class ImageCacheManifestGateTests: XCTestCase {
 
         XCTAssertEqual(RequestRecordingProtocol.snapshot().first, "cdn.jsdelivr.net")
     }
+
+    @MainActor
+    func test_vouched_token_retries_a_stale_miss_sooner_than_a_day() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("icon-miss-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let diskCache = IconDiskCache(directory: directory)
+        let cache = makeCache(diskCache: diskCache)
+        let token = "gate-vouched-\(UUID().uuidString)"
+        cache.knownIconTokens = { [token] }
+
+        try await seedMiss(token, in: directory, diskCache: diskCache, age: 16 * 60)
+        RequestRecordingProtocol.reset()
+        _ = await cache.image(for: Cask.preview(token: token))
+        XCTAssertEqual(RequestRecordingProtocol.snapshot().first, "cdn.jsdelivr.net")
+
+        try await seedMiss(token, in: directory, diskCache: diskCache, age: 60)
+        RequestRecordingProtocol.reset()
+        _ = await cache.image(for: Cask.preview(token: token))
+        XCTAssertEqual(RequestRecordingProtocol.snapshot(), [])
+    }
+
+    @MainActor
+    func test_unvouched_token_keeps_the_daily_miss_retry() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("icon-miss-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let diskCache = IconDiskCache(directory: directory)
+        let cache = makeCache(diskCache: diskCache)
+        let token = "gate-unvouched-\(UUID().uuidString)"
+        cache.knownIconTokens = { [] }
+
+        try await seedMiss(token, in: directory, diskCache: diskCache, age: 16 * 60)
+        RequestRecordingProtocol.reset()
+        _ = await cache.image(for: Cask.preview(token: token))
+
+        XCTAssertEqual(RequestRecordingProtocol.snapshot(), [])
+    }
+
+    @MainActor
+    private func makeCache(diskCache: IconDiskCache) -> ImageCacheService {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RequestRecordingProtocol.self]
+        return ImageCacheService(
+            session: URLSession(configuration: config),
+            diskCache: diskCache
+        )
+    }
+
+    private func seedMiss(
+        _ token: String,
+        in directory: URL,
+        diskCache: IconDiskCache,
+        age: TimeInterval
+    ) async throws {
+        try await diskCache.recordMiss(
+            token: token,
+            generation: diskCache.currentGeneration()
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-age)],
+            ofItemAtPath: directory.appendingPathComponent("\(token).miss").path
+        )
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Why

Every new cask hits this window: the app probes for its icon before the PNG is published, records a `.miss` marker, and then suppresses re-fetching for 24 hours - even after the `iconTokens` manifest starts vouching the icon exists. 

## What

When the manifest contains the token, a recorded miss is treated as publication/CDN lag and retried after 15 minutes; tokens the manifest does not vouch for keep the 24-hour interval. Worst case for a vouched-but-genuinely-404 token is one probe per 15 minutes - each failed probe re-records the marker.

## Tests

- `test_vouched_token_retries_a_stale_miss_sooner_than_a_day` (stale marker probes, fresh marker still suppresses)
- `test_unvouched_token_keeps_the_daily_miss_retry`
- Full suite: **TEST SUCCEEDED**.