### PR TITLE
perf: catalog performance pass - projection, observation, launch

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		41DFD4AA30028F7D00608C7A /* CaskCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47B30028F7D00608C7A /* CaskCardView.swift */; };
 		41DFD4AB30028F7D00608C7A /* CaskIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47C30028F7D00608C7A /* CaskIconView.swift */; };
 		41DFD4AC30028F7D00608C7A /* CaskInfoPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47D30028F7D00608C7A /* CaskInfoPopover.swift */; };
+		A29100000000000000000207 /* CatalogScrollSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000206 /* CatalogScrollSupport.swift */; };
 		41DFD4AD30028F7D00608C7A /* CaskRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47E30028F7D00608C7A /* CaskRowView.swift */; };
 		41DFD4AE30028F7D00608C7A /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD48030028F7D00608C7A /* SidebarView.swift */; };
 		41DFD4AF30028F7D00608C7A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD48230028F7D00608C7A /* ContentView.swift */; };
@@ -215,6 +216,7 @@
 		41DFD47B30028F7D00608C7A /* CaskCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCardView.swift; sourceTree = "<group>"; };
 		41DFD47C30028F7D00608C7A /* CaskIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskIconView.swift; sourceTree = "<group>"; };
 		41DFD47D30028F7D00608C7A /* CaskInfoPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskInfoPopover.swift; sourceTree = "<group>"; };
+		A29100000000000000000206 /* CatalogScrollSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogScrollSupport.swift; sourceTree = "<group>"; };
 		41DFD47E30028F7D00608C7A /* CaskRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskRowView.swift; sourceTree = "<group>"; };
 		41DFD48030028F7D00608C7A /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		41DFD48230028F7D00608C7A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -537,6 +539,7 @@
 				41DFD47B30028F7D00608C7A /* CaskCardView.swift */,
 				41DFD47C30028F7D00608C7A /* CaskIconView.swift */,
 				41DFD47D30028F7D00608C7A /* CaskInfoPopover.swift */,
+				A29100000000000000000206 /* CatalogScrollSupport.swift */,
 				41DFD47E30028F7D00608C7A /* CaskRowView.swift */,
 			);
 			path = Shared;
@@ -962,6 +965,7 @@
 				41DFD4AA30028F7D00608C7A /* CaskCardView.swift in Sources */,
 				41DFD4AB30028F7D00608C7A /* CaskIconView.swift in Sources */,
 				41DFD4AC30028F7D00608C7A /* CaskInfoPopover.swift in Sources */,
+				A29100000000000000000207 /* CatalogScrollSupport.swift in Sources */,
 				41DFD4AD30028F7D00608C7A /* CaskRowView.swift in Sources */,
 				41DFD4AE30028F7D00608C7A /* SidebarView.swift in Sources */,
 				41DFD4AF30028F7D00608C7A /* ContentView.swift in Sources */,

--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		F31000000000000000000002 /* HomebrewMutationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31000000000000000000001 /* HomebrewMutationCoordinator.swift */; };
 		F31000000000000000000004 /* CaskOperationFailureFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31000000000000000000003 /* CaskOperationFailureFactory.swift */; };
 		F31000000000000000000006 /* HomebrewOutputDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31000000000000000000005 /* HomebrewOutputDiagnostics.swift */; };
+		A29100000000000000000307 /* BrewOutputAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000306 /* BrewOutputAggregator.swift */; };
 		F31000000000000000000008 /* ApplicationLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31000000000000000000007 /* ApplicationLauncher.swift */; };
 		F3100000000000000000000A /* CaskLocalStateResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31000000000000000000009 /* CaskLocalStateResolver.swift */; };
 		F33000000000000000000002 /* LocalHomebrewDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33000000000000000000001 /* LocalHomebrewDependencies.swift */; };
@@ -195,6 +196,7 @@
 		F31000000000000000000001 /* HomebrewMutationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewMutationCoordinator.swift; sourceTree = "<group>"; };
 		F31000000000000000000003 /* CaskOperationFailureFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskOperationFailureFactory.swift; sourceTree = "<group>"; };
 		F31000000000000000000005 /* HomebrewOutputDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewOutputDiagnostics.swift; sourceTree = "<group>"; };
+		A29100000000000000000306 /* BrewOutputAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewOutputAggregator.swift; sourceTree = "<group>"; };
 		F31000000000000000000007 /* ApplicationLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLauncher.swift; sourceTree = "<group>"; };
 		F31000000000000000000009 /* CaskLocalStateResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskLocalStateResolver.swift; sourceTree = "<group>"; };
 		F33000000000000000000001 /* LocalHomebrewDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewDependencies.swift; sourceTree = "<group>"; };
@@ -496,6 +498,7 @@
 				E2900000000000000000000F /* HomebrewInstallationScanner.swift */,
 				F30000000000000000000005 /* HomebrewLocator.swift */,
 				F31000000000000000000005 /* HomebrewOutputDiagnostics.swift */,
+				A29100000000000000000306 /* BrewOutputAggregator.swift */,
 				F30000000000000000000007 /* HomebrewVersionLoader.swift */,
 				F28000000000000000000001 /* InstallationIndexBuilder.swift */,
 				F30000000000000000000003 /* PackageReceiptResolver.swift */,
@@ -945,6 +948,7 @@
 				F31000000000000000000002 /* HomebrewMutationCoordinator.swift in Sources */,
 				F31000000000000000000004 /* CaskOperationFailureFactory.swift in Sources */,
 				F31000000000000000000006 /* HomebrewOutputDiagnostics.swift in Sources */,
+				A29100000000000000000307 /* BrewOutputAggregator.swift in Sources */,
 				F31000000000000000000008 /* ApplicationLauncher.swift in Sources */,
 				F3100000000000000000000A /* CaskLocalStateResolver.swift in Sources */,
 				F33000000000000000000002 /* LocalHomebrewDependencies.swift in Sources */,

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -41,8 +41,7 @@ struct CaskHubApp: App {
         Analytics.start()
         AppTheme.apply(UserDefaults.standard.string(forKey: "appTheme") ?? AppTheme.system.rawValue)
 
-        // ~920KB of bundled JSON — decoded off the MainActor after the first
-        // frame instead of blocking launch inside App.init.
+        // ~920KB of bundled JSON — keep it off the launch path.
         let categories = CategoryService()
         let recent = RecentlyAddedService()
         Task {

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -41,10 +41,14 @@ struct CaskHubApp: App {
         Analytics.start()
         AppTheme.apply(UserDefaults.standard.string(forKey: "appTheme") ?? AppTheme.system.rawValue)
 
+        // ~920KB of bundled JSON — decoded off the MainActor after the first
+        // frame instead of blocking launch inside App.init.
         let categories = CategoryService()
-        categories.loadCategories()
         let recent = RecentlyAddedService()
-        recent.loadBundledDates()
+        Task {
+            await categories.loadBundledCategoriesAsync()
+            await recent.loadBundledDatesAsync()
+        }
         let homebrew = LocalHomebrewService()
         let images = ImageCacheService()
         images.knownIconTokens = { categories.iconTokens }

--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -224,6 +224,11 @@ nonisolated struct Cask: Decodable, Identifiable, Hashable {
         name.first ?? token
     }
 
+    /// Newline separators keep a query from matching across field boundaries.
+    var searchKey: String {
+        "\(displayName)\n\(token)\n\(desc ?? "")".lowercased()
+    }
+
     var displayVersion: String {
         let base = version.split(separator: ",", maxSplits: 1).first.map(String.init) ?? version
 

--- a/CaskHub/Services/Catalog/CaskFlowReleases.swift
+++ b/CaskHub/Services/Catalog/CaskFlowReleases.swift
@@ -12,7 +12,9 @@ enum CaskFlowReleases {
         string: "https://github.com/alielsokary/CaskFlow/releases/latest/download/"
     )!
 
-    static func fetch<T: Decodable>(_: T.Type, asset: String) async -> T? {
+    // @concurrent keeps the ~1MB asset decode off the MainActor on every
+    // foreground refresh; plain static async would inherit it.
+    @concurrent static func fetch<T: Decodable & Sendable>(_: T.Type, asset: String) async -> T? {
         var request = URLRequest(url: baseURL.appendingPathComponent(asset))
         request.timeoutInterval = 10
 

--- a/CaskHub/Services/Catalog/CaskFlowReleases.swift
+++ b/CaskHub/Services/Catalog/CaskFlowReleases.swift
@@ -12,8 +12,7 @@ enum CaskFlowReleases {
         string: "https://github.com/alielsokary/CaskFlow/releases/latest/download/"
     )!
 
-    // @concurrent keeps the ~1MB asset decode off the MainActor on every
-    // foreground refresh; plain static async would inherit it.
+    // @concurrent: plain static async would inherit MainActor for the ~1MB decode.
     @concurrent static func fetch<T: Decodable & Sendable>(_: T.Type, asset: String) async -> T? {
         var request = URLRequest(url: baseURL.appendingPathComponent(asset))
         request.timeoutInterval = 10

--- a/CaskHub/Services/Catalog/CategoryService.swift
+++ b/CaskHub/Services/Catalog/CategoryService.swift
@@ -62,8 +62,7 @@ final class CategoryService {
         applyData(catalog)
     }
 
-    /// Launch-path variant: decodes the ~400KB bundle off the MainActor and
-    /// never overwrites data a faster remote refresh already applied.
+    /// Off-main decode; never overwrites fresher remote data.
     func loadBundledCategoriesAsync() async {
         guard let catalog = await Self.decodeBundledCategories(),
               catalog.generatedDate > generatedDate

--- a/CaskHub/Services/Catalog/CategoryService.swift
+++ b/CaskHub/Services/Catalog/CategoryService.swift
@@ -10,17 +10,17 @@ import Observation
 
 typealias CategoryID = String
 
-struct CategoryDefinition: Codable, Hashable {
+nonisolated struct CategoryDefinition: Codable, Hashable {
     let displayName: String
     let icon: String
 }
 
-struct TokenCategoryMapping: Codable, Hashable {
+nonisolated struct TokenCategoryMapping: Codable, Hashable {
     let primary: CategoryID
     let secondary: [CategoryID]
 }
 
-struct CaskCategoryData: Decodable {
+nonisolated struct CaskCategoryData: Decodable {
     let version: Int
     let generatedDate: String
     let releaseTag: String?
@@ -60,6 +60,22 @@ final class CategoryService {
             return
         }
         applyData(catalog)
+    }
+
+    /// Launch-path variant: decodes the ~400KB bundle off the MainActor and
+    /// never overwrites data a faster remote refresh already applied.
+    func loadBundledCategoriesAsync() async {
+        guard let catalog = await Self.decodeBundledCategories(),
+              catalog.generatedDate > generatedDate
+        else { return }
+        applyData(catalog)
+    }
+
+    @concurrent private static func decodeBundledCategories() async -> CaskCategoryData? {
+        guard let url = Bundle.main.url(forResource: "categories", withExtension: "json"),
+              let data = try? Data(contentsOf: url)
+        else { return nil }
+        return try? JSONDecoder().decode(CaskCategoryData.self, from: data)
     }
 
     func refreshFromRemote() async {

--- a/CaskHub/Services/Catalog/RecentlyAddedService.swift
+++ b/CaskHub/Services/Catalog/RecentlyAddedService.swift
@@ -49,8 +49,7 @@ final class RecentlyAddedService {
         apply(bundled)
     }
 
-    /// Launch-path variant: decodes the ~500KB bundle off the MainActor and
-    /// never overwrites data a faster remote refresh already applied.
+    /// Off-main decode; never overwrites fresher remote data.
     func loadBundledDatesAsync() async {
         guard let bundled = await Self.decodeBundledDates(),
               bundled.version == Self.schemaVersion,

--- a/CaskHub/Services/Catalog/RecentlyAddedService.swift
+++ b/CaskHub/Services/Catalog/RecentlyAddedService.swift
@@ -25,7 +25,7 @@ enum RecentlyAddedWindow: Int, CaseIterable, Identifiable {
 @MainActor
 @Observable
 final class RecentlyAddedService {
-    private struct AddedDatesData: Decodable {
+    private nonisolated struct AddedDatesData: Decodable {
         let version: Int
         let generatedDate: String
         let tokenAddedDates: [String: String]
@@ -47,6 +47,23 @@ final class RecentlyAddedService {
         else { return }
 
         apply(bundled)
+    }
+
+    /// Launch-path variant: decodes the ~500KB bundle off the MainActor and
+    /// never overwrites data a faster remote refresh already applied.
+    func loadBundledDatesAsync() async {
+        guard let bundled = await Self.decodeBundledDates(),
+              bundled.version == Self.schemaVersion,
+              bundled.generatedDate > generatedDate
+        else { return }
+        apply(bundled)
+    }
+
+    @concurrent private static func decodeBundledDates() async -> AddedDatesData? {
+        guard let url = Bundle.main.url(forResource: "added_dates", withExtension: "json"),
+              let data = try? Data(contentsOf: url)
+        else { return nil }
+        return try? JSONDecoder().decode(AddedDatesData.self, from: data)
     }
 
     func refreshFromRemote() async {

--- a/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
@@ -7,9 +7,7 @@
 
 import Observation
 
-/// Per-token Observable identity: rows subscribe to their own box's `state`,
-/// so a progress tick for one cask never invalidates the other visible cells.
-/// Mirrors the isolation `ObservedStatusBarView` already does for the status bar.
+/// Per-token Observable identity: a progress tick invalidates one row, not all.
 @MainActor
 @Observable
 final class CaskOperationBox {
@@ -19,8 +17,6 @@ final class CaskOperationBox {
 @MainActor
 @Observable
 final class CaskOperationStore {
-    /// Mutated only when a token sees its first operation — per-tick updates
-    /// touch only that token's box.
     private(set) var boxes: [String: CaskOperationBox] = [:]
     private(set) var isUpdatingAll = false
     private(set) var updateAllProgress: CaskUpdateAllProgress?

--- a/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
@@ -7,22 +7,39 @@
 
 import Observation
 
+/// Per-token Observable identity: rows subscribe to their own box's `state`,
+/// so a progress tick for one cask never invalidates the other visible cells.
+/// Mirrors the isolation `ObservedStatusBarView` already does for the status bar.
+@MainActor
+@Observable
+final class CaskOperationBox {
+    fileprivate(set) var state: CaskOperationState?
+}
+
 @MainActor
 @Observable
 final class CaskOperationStore {
-    private(set) var states: [String: CaskOperationState] = [:]
+    /// Mutated only when a token sees its first operation — per-tick updates
+    /// touch only that token's box.
+    private(set) var boxes: [String: CaskOperationBox] = [:]
     private(set) var isUpdatingAll = false
     private(set) var updateAllProgress: CaskUpdateAllProgress?
 
     func state(for token: String) -> CaskOperationState? {
-        states[token]
+        boxes[token]?.state
     }
 
     func send(_ event: CaskOperationEvent, for token: String) {
-        let current = states[token]
-        let next = CaskOperationStateMachine.transition(from: current, on: event)
-        guard next != current else { return }
-        states[token] = next
+        let box: CaskOperationBox
+        if let existing = boxes[token] {
+            box = existing
+        } else {
+            box = CaskOperationBox()
+            boxes[token] = box
+        }
+        let next = CaskOperationStateMachine.transition(from: box.state, on: event)
+        guard next != box.state else { return }
+        box.state = next
     }
 
     func beginUpdateAll() -> Bool {
@@ -44,26 +61,26 @@ final class CaskOperationStore {
     }
 
     func canBeginOperation(for token: String) -> Bool {
-        guard let state = states[token] else { return true }
+        guard let state = boxes[token]?.state else { return true }
         if case .running = state { return false }
         return true
     }
 
     var pendingPermissions: [String: Bool] {
-        states.reduce(into: [:]) { result, entry in
-            if case let .awaitingPermission(force) = entry.value {
+        boxes.reduce(into: [:]) { result, entry in
+            if case let .awaitingPermission(force) = entry.value.state {
                 result[entry.key] = force
             }
         }
     }
 
     var hasActiveOperations: Bool {
-        isUpdatingAll || states.values.contains { $0.action != nil }
+        isUpdatingAll || boxes.values.contains { $0.state?.action != nil }
     }
 
     var status: CaskOperationStatus? {
         CaskOperationStatus.make(
-            operations: states.values.compactMap(\.progress),
+            operations: boxes.values.compactMap(\.state?.progress),
             updateAll: updateAllProgress
         )
     }

--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -29,10 +29,7 @@ final class HomebrewMutationCoordinator {
     private let brewBinaryProvider: () -> URL?
     private let fileManager: FileManager
 
-    private var outputBuffers: [String: String] = [:]
-    private var lastProgressUpdates: [String: Date] = [:]
-
-    private static let phaseMarkers = ["==>", "Verifying", "Already downloaded:"]
+    private let outputAggregator: BrewOutputAggregator
 
     init(
         operationStore: CaskOperationStore,
@@ -44,6 +41,7 @@ final class HomebrewMutationCoordinator {
         self.commandExecutor = commandExecutor
         self.brewBinaryProvider = brewBinaryProvider
         self.fileManager = fileManager
+        outputAggregator = BrewOutputAggregator(fileManager: fileManager)
     }
 
     func run(
@@ -157,35 +155,38 @@ final class HomebrewMutationCoordinator {
     }
 
     func clearOperationResources(token: String) {
-        outputBuffers[token] = nil
-        lastProgressUpdates[token] = nil
+        outputAggregator.clear(token: token)
     }
 
     func consumeBrewOutput(_ output: String, token: String) {
+        outputAggregator.ingest(output, token: token) { [weak self] parsed in
+            self?.applyParsedOutput(parsed, token: token)
+        }
+    }
+
+    func awaitPendingOutput() async {
+        await outputAggregator.drain()
+    }
+
+    func applyParsedOutput(_ parsed: BrewOutputAggregator.Parsed, token: String) {
         guard var progress = operationStore.state(for: token)?.progress,
               progress.phase != .canceling
         else { return }
 
-        let buffered = String(((outputBuffers[token] ?? "") + output).suffix(6_000))
-        outputBuffers[token] = buffered
-
-        // The pty redraws the progress bar dozens of times per second; parsing
-        // the buffer tail for every redraw hangs the main thread. Skipped
-        // chunks stay buffered, so the next parse sees their state.
-        let hasPhaseMarker = Self.phaseMarkers.contains(where: output.contains)
-        if !hasPhaseMarker,
-           let lastUpdate = lastProgressUpdates[token],
-           Date.now.timeIntervalSince(lastUpdate) < 0.10 {
-            return
-        }
-
-        let update = BrewProgressParser.parse(buffered)
+        let update = parsed.update
         if update.phase == .checkingDownload {
             progress.completedBytes = nil
             progress.totalBytes = nil
         }
-        applyByteProgress(update, to: &progress, token: token)
-        applyCachedDownload(update, to: &progress)
+        if let bytes = update.byteProgress {
+            progress.phase = .downloading
+            progress.completedBytes = bytes.completed
+            progress.totalBytes = bytes.total
+        }
+        if update.phase == .usingCachedDownload {
+            progress.completedBytes = parsed.cachedDownloadBytes
+            progress.totalBytes = parsed.cachedDownloadBytes
+        }
         if let phase = update.phase {
             progress.phase = phase
             if phase == .performing {
@@ -232,40 +233,6 @@ final class HomebrewMutationCoordinator {
                 )
             }
         }
-    }
-
-    private func applyByteProgress(
-        _ update: BrewProgressParser.Update,
-        to progress: inout CaskOperationProgress,
-        token: String
-    ) {
-        guard let bytes = update.byteProgress else { return }
-        let now = Date.now
-        let shouldPublish = lastProgressUpdates[token].map {
-            now.timeIntervalSince($0) >= 0.10
-        } ?? true
-        guard shouldPublish || bytes.completed >= bytes.total else { return }
-
-        progress.phase = .downloading
-        progress.completedBytes = bytes.completed
-        progress.totalBytes = bytes.total
-        lastProgressUpdates[token] = now
-    }
-
-    private func applyCachedDownload(
-        _ update: BrewProgressParser.Update,
-        to progress: inout CaskOperationProgress
-    ) {
-        guard update.phase == .usingCachedDownload else { return }
-        progress.completedBytes = nil
-        progress.totalBytes = nil
-        guard let path = update.cachedDownloadPath,
-              let attributes = try? fileManager.attributesOfItem(atPath: path),
-              let size = attributes[.size] as? NSNumber,
-              size.int64Value > 0
-        else { return }
-        progress.completedBytes = size.int64Value
-        progress.totalBytes = size.int64Value
     }
 
     private func handleFailure(

--- a/CaskHub/Services/Homebrew/Infrastructure/BrewOutputAggregator.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/BrewOutputAggregator.swift
@@ -1,0 +1,83 @@
+//
+//  BrewOutputAggregator.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 03/08/2026.
+//
+
+import Foundation
+
+/// Parses brew's pty output off the MainActor; main receives updates at ~10/s.
+nonisolated final class BrewOutputAggregator: @unchecked Sendable {
+    struct Parsed: Sendable {
+        let update: BrewProgressParser.Update
+        let cachedDownloadBytes: Int64?
+    }
+
+    private let queue = DispatchQueue(label: "com.caskhub.brew-parse", qos: .userInitiated)
+    private let fileManager: FileManager
+    private var buffers: [String: String] = [:]
+    private var lastParses: [String: Date] = [:]
+
+    private static let phaseMarkers = ["==>", "Verifying", "Already downloaded:"]
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func ingest(
+        _ output: String,
+        token: String,
+        deliver: @escaping @MainActor @Sendable (Parsed) -> Void
+    ) {
+        queue.async { [self] in
+            let buffered = String(((buffers[token] ?? "") + output).suffix(6_000))
+            buffers[token] = buffered
+
+            // Skipped chunks stay buffered, so the next parse sees their state.
+            let hasPhaseMarker = Self.phaseMarkers.contains(where: output.contains)
+            if !hasPhaseMarker,
+               let lastParse = lastParses[token],
+               Date.now.timeIntervalSince(lastParse) < 0.10 {
+                return
+            }
+
+            let update = BrewProgressParser.parse(buffered)
+            // Marker parses must never throttle the byte line after them.
+            if update.byteProgress != nil {
+                lastParses[token] = Date.now
+            }
+            let parsed = Parsed(
+                update: update,
+                cachedDownloadBytes: cachedDownloadBytes(for: update)
+            )
+            Task { @MainActor in deliver(parsed) }
+        }
+    }
+
+    func clear(token: String) {
+        queue.async { [self] in
+            buffers[token] = nil
+            lastParses[token] = nil
+        }
+    }
+
+    /// Resolves after all previously enqueued deliveries land on the MainActor.
+    func drain() async {
+        await withCheckedContinuation { continuation in
+            queue.async {
+                Task { @MainActor in continuation.resume() }
+            }
+        }
+    }
+
+    private func cachedDownloadBytes(for update: BrewProgressParser.Update) -> Int64? {
+        guard update.phase == .usingCachedDownload,
+              let path = update.cachedDownloadPath,
+              let attributes = try? fileManager.attributesOfItem(atPath: path),
+              let size = attributes[.size] as? NSNumber,
+              size.int64Value > 0
+        else { return nil }
+        return size.int64Value
+    }
+}

--- a/CaskHub/Services/Homebrew/Infrastructure/BrewOutputCollector.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/BrewOutputCollector.swift
@@ -77,13 +77,23 @@ nonisolated final class BrewOutputCollector: @unchecked Sendable {
         continuation = nil
     }
 
+    // Compiled once — `.regularExpression` re-compiles per call, and chunks
+    // arrive many times per second during a download.
+    private static let ansiEscapes = try? NSRegularExpression(
+        pattern: "\u{001B}\\[[0-?]*[ -/]*[@-~]"
+    )
+
     private static func plainText(_ text: String) -> String {
-        text
-            .replacingOccurrences(
-                of: "\u{001B}\\[[0-?]*[ -/]*[@-~]",
-                with: "",
-                options: .regularExpression
+        let stripped: String
+        if let ansiEscapes {
+            stripped = ansiEscapes.stringByReplacingMatches(
+                in: text,
+                range: NSRange(text.startIndex..., in: text),
+                withTemplate: ""
             )
-            .replacingOccurrences(of: "\r", with: "\n")
+        } else {
+            stripped = text
+        }
+        return stripped.replacingOccurrences(of: "\r", with: "\n")
     }
 }

--- a/CaskHub/Services/Homebrew/Infrastructure/BrewOutputCollector.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/BrewOutputCollector.swift
@@ -77,8 +77,6 @@ nonisolated final class BrewOutputCollector: @unchecked Sendable {
         continuation = nil
     }
 
-    // Compiled once — `.regularExpression` re-compiles per call, and chunks
-    // arrive many times per second during a download.
     private static let ansiEscapes = try? NSRegularExpression(
         pattern: "\u{001B}\\[[0-?]*[ -/]*[@-~]"
     )

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
@@ -103,7 +103,7 @@ extension CaskCatalogViewModel {
             analyticsPeriod: analyticsPeriod,
             recentlyAddedWindow: recentlyAddedWindow,
             selectedSidebar: selectedSidebar,
-            searchText: searchText,
+            searchText: appliedSearchText,
             sortOption: sortOption
         )
         return filteredCache.value(for: key) {
@@ -111,7 +111,7 @@ extension CaskCatalogViewModel {
                 casks: casks,
                 library: librarySnapshot,
                 selectedSidebar: selectedSidebar,
-                searchText: searchText,
+                searchText: appliedSearchText,
                 sortOption: sortOption,
                 downloadCounts: downloadCounts,
                 recentTokens: recentlyAdded.recentTokens(

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
@@ -105,15 +105,27 @@ extension CaskCatalogViewModel {
 
     /// One locale-aware sort per catalog load; projections then order name sorts
     /// by Int rank instead of running ICU collation per comparison.
+    /// Collation-equal names share a rank so ties stay ties — a strict order
+    /// would silently reverse them in descending sorts.
     private var nameRanks: [String: Int] {
         nameRankCache.value(for: catalogRevision) { [casks] in
             let sorted = casks.sorted {
                 $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
                     == .orderedAscending
             }
-            return Dictionary(
-                sorted.enumerated().map { ($0.element.token, $0.offset) }
-            ) { first, _ in first }
+            var ranks: [String: Int] = [:]
+            ranks.reserveCapacity(sorted.count)
+            var rank = 0
+            for (index, cask) in sorted.enumerated() {
+                if index > 0,
+                   sorted[index - 1].displayName.localizedCaseInsensitiveCompare(
+                       cask.displayName
+                   ) != .orderedSame {
+                    rank = index
+                }
+                if ranks[cask.token] == nil { ranks[cask.token] = rank }
+            }
+            return ranks
         }
     }
 

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
@@ -103,6 +103,27 @@ extension CaskCatalogViewModel {
         }
     }
 
+    /// One locale-aware sort per catalog load; projections then order name sorts
+    /// by Int rank instead of running ICU collation per comparison.
+    private var nameRanks: [String: Int] {
+        nameRankCache.value(for: catalogRevision) { [casks] in
+            let sorted = casks.sorted {
+                $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
+                    == .orderedAscending
+            }
+            return Dictionary(
+                sorted.enumerated().map { ($0.element.token, $0.offset) }
+            ) { first, _ in first }
+        }
+    }
+
+    private var sortUsesNameRanks: Bool {
+        switch sortOption {
+        case .nameAZ, .nameZA, .recentlyInstalled: return true
+        case .mostPopular, .newest, .oldest: return false
+        }
+    }
+
     var filteredCasks: [Cask] {
         let key = FilteredCatalogCacheKey(
             library: libraryCacheKey,
@@ -127,7 +148,8 @@ extension CaskCatalogViewModel {
                 addedDates: recentlyAdded.addedDates,
                 installedDates: localHomebrew.installationSnapshot.installedCasks
                     .compactMapValues(\.installedAt),
-                searchKeys: appliedSearchText.isEmpty ? [:] : searchKeys
+                searchKeys: appliedSearchText.isEmpty ? [:] : searchKeys,
+                nameRanks: sortUsesNameRanks ? nameRanks : [:]
             ))
         }
     }

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
@@ -38,8 +38,6 @@ extension CaskCatalogViewModel {
         librarySnapshot.localStates[cask.token] ?? localHomebrew.localState(for: cask)
     }
 
-    /// Built once per catalog/category revision — every visible cell asks for
-    /// this on every body pass, so the per-call projector allocations add up.
     private var categoryPresentations: [String: CaskCategoryPresentation] {
         let key = CategoryPresentationCacheKey(
             catalogRevision: catalogRevision,
@@ -116,17 +114,13 @@ extension CaskCatalogViewModel {
 
     // MARK: - Filtered Casks
 
-    /// One lowercase pass per catalog load instead of three per cask per search.
     private var searchKeys: [String: String] {
         searchKeysCache.value(for: catalogRevision) { [casks] in
             Dictionary(casks.map { ($0.token, $0.searchKey) }) { first, _ in first }
         }
     }
 
-    /// One locale-aware sort per catalog load; projections then order name sorts
-    /// by Int rank instead of running ICU collation per comparison.
-    /// Collation-equal names share a rank so ties stay ties — a strict order
-    /// would silently reverse them in descending sorts.
+    /// Collation-equal names share a rank so descending sorts keep ties stable.
     private var nameRanks: [String: Int] {
         nameRankCache.value(for: catalogRevision) { [casks] in
             let sorted = casks.sorted {
@@ -156,8 +150,7 @@ extension CaskCatalogViewModel {
         }
     }
 
-    /// What the grid/list actually render; `filteredCasks` stays the full result
-    /// for counts and the hero card.
+    /// Render slice; `filteredCasks` stays uncapped for counts and the hero.
     var displayedCasks: [Cask] {
         let filtered = filteredCasks
         guard filtered.count > revealedCount else { return filtered }

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
@@ -38,8 +38,28 @@ extension CaskCatalogViewModel {
         librarySnapshot.localStates[cask.token] ?? localHomebrew.localState(for: cask)
     }
 
+    /// Built once per catalog/category revision — every visible cell asks for
+    /// this on every body pass, so the per-call projector allocations add up.
+    private var categoryPresentations: [String: CaskCategoryPresentation] {
+        let key = CategoryPresentationCacheKey(
+            catalogRevision: catalogRevision,
+            categoryRevision: categoryService.catalogStateRevision
+        )
+        return categoryPresentationCache.value(for: key) { [casks, categoryService] in
+            var result = [String: CaskCategoryPresentation](minimumCapacity: casks.count)
+            for cask in casks {
+                result[cask.token] = CaskCategoryProjector.make(
+                    token: cask.token,
+                    mappings: categoryService.tokenMappings,
+                    definitions: categoryService.categoryDefinitions
+                )
+            }
+            return result
+        }
+    }
+
     func categoryPresentation(for cask: Cask) -> CaskCategoryPresentation? {
-        CaskCategoryProjector.make(
+        categoryPresentations[cask.token] ?? CaskCategoryProjector.make(
             token: cask.token,
             mappings: categoryService.tokenMappings,
             definitions: categoryService.categoryDefinitions

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
@@ -124,6 +124,18 @@ extension CaskCatalogViewModel {
         }
     }
 
+    /// What the grid/list actually render; `filteredCasks` stays the full result
+    /// for counts and the hero card.
+    var displayedCasks: [Cask] {
+        let filtered = filteredCasks
+        guard filtered.count > revealedCount else { return filtered }
+        return Array(filtered.prefix(revealedCount))
+    }
+
+    var hasMoreToReveal: Bool {
+        filteredCasks.count > revealedCount
+    }
+
     var filteredCasks: [Cask] {
         let key = FilteredCatalogCacheKey(
             library: libraryCacheKey,

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
@@ -96,6 +96,13 @@ extension CaskCatalogViewModel {
 
     // MARK: - Filtered Casks
 
+    /// One lowercase pass per catalog load instead of three per cask per search.
+    private var searchKeys: [String: String] {
+        searchKeysCache.value(for: catalogRevision) { [casks] in
+            Dictionary(casks.map { ($0.token, $0.searchKey) }) { first, _ in first }
+        }
+    }
+
     var filteredCasks: [Cask] {
         let key = FilteredCatalogCacheKey(
             library: libraryCacheKey,
@@ -119,7 +126,8 @@ extension CaskCatalogViewModel {
                 ),
                 addedDates: recentlyAdded.addedDates,
                 installedDates: localHomebrew.installationSnapshot.installedCasks
-                    .compactMapValues(\.installedAt)
+                    .compactMapValues(\.installedAt),
+                searchKeys: appliedSearchText.isEmpty ? [:] : searchKeys
             ))
         }
     }

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -53,7 +53,19 @@ final class CaskCatalogViewModel {
     }
     /// Projection reads this instead of `searchText` so each keystroke echoes in
     /// the field immediately without re-filtering the full catalog on the MainActor.
-    private(set) var appliedSearchText = ""
+    private(set) var appliedSearchText = "" {
+        didSet { if oldValue != appliedSearchText { resetReveal() } }
+    }
+    static let revealChunk = 200
+    private(set) var revealedCount = revealChunk
+
+    func revealMore() {
+        revealedCount += Self.revealChunk
+    }
+
+    private func resetReveal() {
+        revealedCount = Self.revealChunk
+    }
     @ObservationIgnored var searchDebounceInterval: Duration = .milliseconds(200)
     @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
 
@@ -77,10 +89,13 @@ final class CaskCatalogViewModel {
         return analyticsByPeriod[analyticsPeriod] ?? [:]
     }
 
-    var sortOption: SortOption = .mostPopular
+    var sortOption: SortOption = .mostPopular {
+        didSet { if oldValue != sortOption { resetReveal() } }
+    }
     var selectedSidebar: SidebarSelection = .discover(.browse) {
         didSet {
             guard oldValue != selectedSidebar else { return }
+            resetReveal()
             switch selectedSidebar {
             case .library(.installed):
                 sortOption = .recentlyInstalled

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -48,7 +48,14 @@ final class CaskCatalogViewModel {
     private(set) var analyticsPeriod: AnalyticsPeriod = .days365
     private var analyticsRequestID = UUID()
     private(set) var catalogRevision = 0
-    var searchText = ""
+    var searchText = "" {
+        didSet { scheduleSearchApply() }
+    }
+    /// Projection reads this instead of `searchText` so each keystroke echoes in
+    /// the field immediately without re-filtering the full catalog on the MainActor.
+    private(set) var appliedSearchText = ""
+    @ObservationIgnored var searchDebounceInterval: Duration = .milliseconds(200)
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
 
     @ObservationIgnored let libraryCache =
         MemoizedValue<CatalogLibraryCacheKey, CatalogLibrarySnapshot>()
@@ -205,6 +212,20 @@ final class CaskCatalogViewModel {
             analytics.items.map { ($0.cask, $0.downloadCount) },
             uniquingKeysWith: max
         )
+    }
+
+    private func scheduleSearchApply() {
+        searchDebounceTask?.cancel()
+        // Clearing applies instantly; only typing debounces.
+        guard !searchText.isEmpty, searchDebounceInterval > .zero else {
+            appliedSearchText = searchText
+            return
+        }
+        searchDebounceTask = Task { [interval = searchDebounceInterval] in
+            try? await Task.sleep(for: interval)
+            guard !Task.isCancelled else { return }
+            appliedSearchText = searchText
+        }
     }
 
     func formattedDownloads(for token: String) -> String? {

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -63,6 +63,7 @@ final class CaskCatalogViewModel {
         BoundedMemoizedValues<FilteredCatalogCacheKey, [Cask]>(capacity: 16)
     @ObservationIgnored let browseCache =
         MemoizedValue<BrowseCatalogCacheKey, [BrowseSection]>()
+    @ObservationIgnored let searchKeysCache = MemoizedValue<Int, [String: String]>()
 
     private static let periodKey = "analyticsPeriod"
     private static let windowKey = "recentlyAddedWindow"

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -77,6 +77,8 @@ final class CaskCatalogViewModel {
         MemoizedValue<BrowseCatalogCacheKey, [BrowseSection]>()
     @ObservationIgnored let searchKeysCache = MemoizedValue<Int, [String: String]>()
     @ObservationIgnored let nameRankCache = MemoizedValue<Int, [String: Int]>()
+    @ObservationIgnored let categoryPresentationCache =
+        MemoizedValue<CategoryPresentationCacheKey, [String: CaskCategoryPresentation]>()
 
     private static let periodKey = "analyticsPeriod"
     private static let windowKey = "recentlyAddedWindow"
@@ -245,9 +247,14 @@ final class CaskCatalogViewModel {
         }
     }
 
+    // ponytail: en_US pin keeps the K/M suffixes stable across locales.
+    // Static so the Locale + style build once, not per visible cell per pass.
+    private static let downloadsStyle = IntegerFormatStyle<Int>.number
+        .notation(.compactName)
+        .locale(Locale(identifier: "en_US"))
+
     func formattedDownloads(for token: String) -> String? {
         guard let count = downloadCounts[token], count > 0 else { return nil }
-        // ponytail: en_US pin keeps the K/M suffixes stable across locales
-        return count.formatted(.number.notation(.compactName).locale(Locale(identifier: "en_US")))
+        return count.formatted(Self.downloadsStyle)
     }
 }

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -64,6 +64,7 @@ final class CaskCatalogViewModel {
     @ObservationIgnored let browseCache =
         MemoizedValue<BrowseCatalogCacheKey, [BrowseSection]>()
     @ObservationIgnored let searchKeysCache = MemoizedValue<Int, [String: String]>()
+    @ObservationIgnored let nameRankCache = MemoizedValue<Int, [String: Int]>()
 
     private static let periodKey = "analyticsPeriod"
     private static let windowKey = "recentlyAddedWindow"

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -51,8 +51,7 @@ final class CaskCatalogViewModel {
     var searchText = "" {
         didSet { scheduleSearchApply() }
     }
-    /// Projection reads this instead of `searchText` so each keystroke echoes in
-    /// the field immediately without re-filtering the full catalog on the MainActor.
+    /// Projection reads this; `searchText` stays instant for the field echo.
     private(set) var appliedSearchText = "" {
         didSet { if oldValue != appliedSearchText { resetReveal() } }
     }
@@ -247,8 +246,7 @@ final class CaskCatalogViewModel {
         }
     }
 
-    // ponytail: en_US pin keeps the K/M suffixes stable across locales.
-    // Static so the Locale + style build once, not per visible cell per pass.
+    // ponytail: en_US pin keeps the K/M suffixes stable across locales
     private static let downloadsStyle = IntegerFormatStyle<Int>.number
         .notation(.compactName)
         .locale(Locale(identifier: "en_US"))

--- a/CaskHub/ViewModels/Catalog/Projection/CatalogProjectionCache.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CatalogProjectionCache.swift
@@ -71,6 +71,11 @@ struct FilteredCatalogCacheKey: Equatable {
     let sortOption: SortOption
 }
 
+struct CategoryPresentationCacheKey: Equatable {
+    let catalogRevision: Int
+    let categoryRevision: Int
+}
+
 struct BrowseCatalogCacheKey: Equatable {
     let catalogRevision: Int
     let categoryRevision: Int

--- a/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
@@ -198,8 +198,7 @@ enum CatalogProjector {
         }
     }
 
-    /// Ranks carry the localized order precomputed once per catalog; the ICU
-    /// comparator is the fallback for casks outside that catalog snapshot.
+    /// ICU comparator is the fallback for casks outside the rank snapshot.
     private static func nameAscending(
         _ lhs: Cask,
         _ rhs: Cask,
@@ -212,8 +211,6 @@ enum CatalogProjector {
             == .orderedAscending
     }
 
-    /// Same dedup a Set gave, without allocating one per cask per pass —
-    /// secondary is 0-2 curated entries, so the prefix scan is cheaper.
     private static func forEachUniqueCategory(
         in mapping: TokenCategoryMapping,
         _ body: (CategoryID) -> Void

--- a/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
@@ -57,7 +57,7 @@ enum CatalogProjector {
                 adoptableCasks.append(cask)
             }
             if let mapping = input.categoryMappings[cask.token] {
-                for categoryID in Set([mapping.primary] + mapping.secondary) {
+                forEachUniqueCategory(in: mapping) { categoryID in
                     casksByCategory[categoryID, default: []].append(cask)
                 }
             }
@@ -84,9 +84,10 @@ enum CatalogProjector {
         var casksByCategory: [String: [Cask]] = [:]
         for cask in popularityOrder {
             guard let mapping = input.categoryMappings[cask.token] else { continue }
-            for categoryID in Set([mapping.primary] + mapping.secondary)
-                where casksByCategory[categoryID, default: []].count < sectionSize {
-                casksByCategory[categoryID, default: []].append(cask)
+            forEachUniqueCategory(in: mapping) { categoryID in
+                if casksByCategory[categoryID, default: []].count < sectionSize {
+                    casksByCategory[categoryID, default: []].append(cask)
+                }
             }
         }
 
@@ -209,6 +210,20 @@ enum CatalogProjector {
         }
         return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
             == .orderedAscending
+    }
+
+    /// Same dedup a Set gave, without allocating one per cask per pass —
+    /// secondary is 0-2 curated entries, so the prefix scan is cheaper.
+    private static func forEachUniqueCategory(
+        in mapping: TokenCategoryMapping,
+        _ body: (CategoryID) -> Void
+    ) {
+        body(mapping.primary)
+        for (index, categoryID) in mapping.secondary.enumerated()
+            where categoryID != mapping.primary
+                && !mapping.secondary[..<index].contains(categoryID) {
+            body(categoryID)
+        }
     }
 
     private static func sortedByDownloads(

--- a/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
@@ -32,6 +32,7 @@ struct CatalogFilteredProjectionInput {
     let recentTokens: Set<String>
     let addedDates: [String: String]
     let installedDates: [String: Date]
+    var searchKeys: [String: String] = [:]
 }
 
 enum CatalogProjector {
@@ -119,7 +120,7 @@ enum CatalogProjector {
         from input: CatalogFilteredProjectionInput
     ) -> [Cask] {
         let filtered = applySidebarFilter(input)
-        let searched = applySearch(input.searchText, to: filtered)
+        let searched = applySearch(input.searchText, to: filtered, keys: input.searchKeys)
         return applySort(input.sortOption, to: searched, input: input)
     }
 
@@ -153,14 +154,13 @@ enum CatalogProjector {
 
     private static func applySearch(
         _ searchText: String,
-        to casks: [Cask]
+        to casks: [Cask],
+        keys: [String: String]
     ) -> [Cask] {
         guard !searchText.isEmpty else { return casks }
         let query = searchText.lowercased()
         return casks.filter { cask in
-            cask.displayName.lowercased().contains(query)
-                || cask.token.lowercased().contains(query)
-                || (cask.desc?.lowercased().contains(query) ?? false)
+            (keys[cask.token] ?? cask.searchKey).contains(query)
         }
     }
 

--- a/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
@@ -33,6 +33,7 @@ struct CatalogFilteredProjectionInput {
     let addedDates: [String: String]
     let installedDates: [String: Date]
     var searchKeys: [String: String] = [:]
+    var nameRanks: [String: Int] = [:]
 }
 
 enum CatalogProjector {
@@ -173,15 +174,9 @@ enum CatalogProjector {
         case .mostPopular:
             return sortedByDownloads(casks, using: input.downloadCounts)
         case .nameAZ:
-            return casks.sorted {
-                $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
-                    == .orderedAscending
-            }
+            return casks.sorted { nameAscending($0, $1, ranks: input.nameRanks) }
         case .nameZA:
-            return casks.sorted {
-                $0.displayName.localizedCaseInsensitiveCompare($1.displayName)
-                    == .orderedDescending
-            }
+            return casks.sorted { nameAscending($1, $0, ranks: input.nameRanks) }
         case .recentlyInstalled:
             return casks.sorted { lhs, rhs in
                 let lhsDate = input.installedDates[lhs.token]
@@ -190,8 +185,7 @@ enum CatalogProjector {
                     if let lhsDate, let rhsDate { return lhsDate > rhsDate }
                     return lhsDate != nil
                 }
-                return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
-                    == .orderedAscending
+                return nameAscending(lhs, rhs, ranks: input.nameRanks)
             }
         case .newest:
             return sortedByNewest(casks, addedDates: input.addedDates)
@@ -201,6 +195,20 @@ enum CatalogProjector {
                     < (input.addedDates[$1.token] ?? "9999")
             }
         }
+    }
+
+    /// Ranks carry the localized order precomputed once per catalog; the ICU
+    /// comparator is the fallback for casks outside that catalog snapshot.
+    private static func nameAscending(
+        _ lhs: Cask,
+        _ rhs: Cask,
+        ranks: [String: Int]
+    ) -> Bool {
+        if let lhsRank = ranks[lhs.token], let rhsRank = ranks[rhs.token] {
+            return lhsRank < rhsRank
+        }
+        return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+            == .orderedAscending
     }
 
     private static func sortedByDownloads(

--- a/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CatalogProjector.swift
@@ -32,8 +32,8 @@ struct CatalogFilteredProjectionInput {
     let recentTokens: Set<String>
     let addedDates: [String: String]
     let installedDates: [String: Date]
-    var searchKeys: [String: String] = [:]
-    var nameRanks: [String: Int] = [:]
+    let searchKeys: [String: String]
+    let nameRanks: [String: Int]
 }
 
 enum CatalogProjector {

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -342,42 +342,6 @@ private extension ContentView {
     }
 }
 
-/// Placed as the last item of a lazy container, so it only materializes — and
-/// reveals the next chunk — when the user scrolls to the bottom of the cap.
-private struct RevealSentinel: View {
-    let onReveal: () -> Void
-
-    var body: some View {
-        Color.clear
-            .frame(height: 1)
-            .onAppear(perform: onReveal)
-    }
-}
-
-private struct ResetScrollOnChange<Trigger: Equatable>: ViewModifier {
-    let trigger: Trigger
-    @State private var position = ScrollPosition(edge: .top)
-    @State private var isAtTop = true
-
-    func body(content: Content) -> some View {
-        content
-            .scrollPosition($position)
-            .onScrollGeometryChange(for: Bool.self) { geometry in
-                geometry.contentOffset.y <= geometry.contentInsets.top + 1
-            } action: { _, newValue in
-                isAtTop = newValue
-            }
-            .onChange(of: trigger) {
-                guard !isAtTop else { return }
-                var transaction = Transaction()
-                transaction.disablesAnimations = true
-                withTransaction(transaction) {
-                    position.scrollTo(edge: .top)
-                }
-            }
-    }
-}
-
 // MARK: - Outside-Click Focus Handling
 
 struct ResignFocusOnOutsideClick: ViewModifier {

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -194,9 +194,11 @@ struct ContentView: View {
         return viewModel.filteredCasks.first
     }
 
+    // Gates on the debounced value so the layout swaps in the same frame as the
+    // filtered results — raw searchText would flash an unfiltered grid first.
     private var showsBrowseSections: Bool {
         selectedSidebar == .discover(.browse)
-            && viewModel.searchText.isEmpty
+            && viewModel.appliedSearchText.isEmpty
             && viewMode == .grid
     }
 
@@ -253,7 +255,7 @@ private extension ContentView {
                     browseSectionView(section)
                 }
             } else {
-                caskGrid(viewModel.displayedCasks)
+                caskGrid(viewModel.displayedCasks, showsReveal: true)
             }
         }
         .frame(width: CHSize.contentWidth, alignment: .leading)
@@ -282,7 +284,9 @@ private extension ContentView {
         .frame(maxWidth: .infinity)
     }
 
-    func caskGrid(_ casks: [Cask]) -> some View {
+    // showsReveal must stay off for the bounded browse-section shelves — their
+    // sentinels would fire against the global reveal state, not their own casks.
+    func caskGrid(_ casks: [Cask], showsReveal: Bool = false) -> some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: CHSpace.gridGap) {
             ForEach(casks) { cask in
                 CaskCardView(
@@ -293,7 +297,7 @@ private extension ContentView {
                     localState: viewModel.localState(for: cask)
                 )
             }
-            if viewModel.hasMoreToReveal {
+            if showsReveal && viewModel.hasMoreToReveal {
                 RevealSentinel { viewModel.revealMore() }
             }
         }

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -253,7 +253,7 @@ private extension ContentView {
                     browseSectionView(section)
                 }
             } else {
-                caskGrid(viewModel.filteredCasks)
+                caskGrid(viewModel.displayedCasks)
             }
         }
         .frame(width: CHSize.contentWidth, alignment: .leading)
@@ -262,7 +262,7 @@ private extension ContentView {
 
     var listContent: some View {
         LazyVStack(spacing: 0) {
-            ForEach(viewModel.filteredCasks) { cask in
+            ForEach(viewModel.displayedCasks) { cask in
                 CaskRowView(
                     cask: cask,
                     downloads: viewModel.formattedDownloads(for: cask.token),
@@ -273,6 +273,9 @@ private extension ContentView {
 
                 Color.chHairline
                     .frame(height: 1)
+            }
+            if viewModel.hasMoreToReveal {
+                RevealSentinel { viewModel.revealMore() }
             }
         }
         .frame(width: CHSize.contentWidth)
@@ -289,6 +292,9 @@ private extension ContentView {
                     onSelectCategory: { viewModel.selectedSidebar = .category($0) },
                     localState: viewModel.localState(for: cask)
                 )
+            }
+            if viewModel.hasMoreToReveal {
+                RevealSentinel { viewModel.revealMore() }
             }
         }
     }
@@ -329,6 +335,18 @@ private extension ContentView {
                 Task { await viewModel.fetchCasks() }
             }
         }
+    }
+}
+
+/// Placed as the last item of a lazy container, so it only materializes — and
+/// reveals the next chunk — when the user scrolls to the bottom of the cap.
+private struct RevealSentinel: View {
+    let onReveal: () -> Void
+
+    var body: some View {
+        Color.clear
+            .frame(height: 1)
+            .onAppear(perform: onReveal)
     }
 }
 

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -194,8 +194,7 @@ struct ContentView: View {
         return viewModel.filteredCasks.first
     }
 
-    // Gates on the debounced value so the layout swaps in the same frame as the
-    // filtered results — raw searchText would flash an unfiltered grid first.
+    // Raw searchText would swap layout before results apply and flash a stale grid.
     private var showsBrowseSections: Bool {
         selectedSidebar == .discover(.browse)
             && viewModel.appliedSearchText.isEmpty
@@ -284,8 +283,7 @@ private extension ContentView {
         .frame(maxWidth: .infinity)
     }
 
-    // showsReveal must stay off for the bounded browse-section shelves — their
-    // sentinels would fire against the global reveal state, not their own casks.
+    // showsReveal stays off for browse shelves — global reveal state, not theirs.
     func caskGrid(_ casks: [Cask], showsReveal: Bool = false) -> some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: CHSpace.gridGap) {
             ForEach(casks) { cask in

--- a/CaskHub/Views/Shared/CatalogScrollSupport.swift
+++ b/CaskHub/Views/Shared/CatalogScrollSupport.swift
@@ -7,8 +7,7 @@
 
 import SwiftUI
 
-/// Placed as the last item of a lazy container, so it only materializes — and
-/// reveals the next chunk — when the user scrolls to the bottom of the cap.
+/// Last item of a lazy container: materializing means the user hit the cap.
 struct RevealSentinel: View {
     let onReveal: () -> Void
 

--- a/CaskHub/Views/Shared/CatalogScrollSupport.swift
+++ b/CaskHub/Views/Shared/CatalogScrollSupport.swift
@@ -1,0 +1,44 @@
+//
+//  CatalogScrollSupport.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 03/08/2026.
+//
+
+import SwiftUI
+
+/// Placed as the last item of a lazy container, so it only materializes — and
+/// reveals the next chunk — when the user scrolls to the bottom of the cap.
+struct RevealSentinel: View {
+    let onReveal: () -> Void
+
+    var body: some View {
+        Color.clear
+            .frame(height: 1)
+            .onAppear(perform: onReveal)
+    }
+}
+
+struct ResetScrollOnChange<Trigger: Equatable>: ViewModifier {
+    let trigger: Trigger
+    @State private var position = ScrollPosition(edge: .top)
+    @State private var isAtTop = true
+
+    func body(content: Content) -> some View {
+        content
+            .scrollPosition($position)
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.contentOffset.y <= geometry.contentInsets.top + 1
+            } action: { _, newValue in
+                isAtTop = newValue
+            }
+            .onChange(of: trigger) {
+                guard !isAtTop else { return }
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    position.scrollTo(edge: .top)
+                }
+            }
+    }
+}

--- a/CaskHubTests/Catalog/CaskCatalogSortTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogSortTests.swift
@@ -61,7 +61,9 @@ final class CaskCatalogSortTests: XCTestCase {
             downloadCounts: [:],
             recentTokens: [],
             addedDates: [:],
-            installedDates: [:]
+            installedDates: [:],
+            searchKeys: [:],
+            nameRanks: [:]
         ))
 
         XCTAssertEqual(library.installedCasks.map(\.token), ["installed", "adoptable"])

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -76,6 +76,27 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(vm.filteredCasks.count, 3)
     }
 
+    @MainActor
+    func test_search_projection_debounces_typing_and_clears_instantly() async throws {
+        let (vm, _) = await makeSUT(casks: [
+            makeCask("firefox", name: "Firefox", desc: "Web browser")
+        ])
+        vm.searchDebounceInterval = .milliseconds(50)
+
+        vm.searchText = "b"
+        vm.searchText = "br"
+        vm.searchText = "browser"
+        XCTAssertEqual(vm.appliedSearchText, "")
+
+        try await Task.sleep(for: .milliseconds(300))
+        XCTAssertEqual(vm.appliedSearchText, "browser")
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["firefox"])
+
+        vm.searchText = ""
+        XCTAssertEqual(vm.appliedSearchText, "")
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["firefox"])
+    }
+
     // MARK: Sidebar filters
 
     @MainActor

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -100,6 +100,21 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["firefox"])
     }
 
+    @MainActor
+    func test_name_sort_keeps_localized_diacritic_order() async {
+        let (vm, _) = await makeSUT(casks: [
+            makeCask("zoom", name: "zoom.us"),
+            makeCask("uebersicht", name: "Übersicht"),
+            makeCask("arc", name: "Arc")
+        ])
+
+        vm.sortOption = .nameAZ
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["arc", "uebersicht", "zoom"])
+
+        vm.sortOption = .nameZA
+        XCTAssertEqual(vm.filteredCasks.map(\.token), ["zoom", "uebersicht", "arc"])
+    }
+
     // MARK: Sidebar filters
 
     @MainActor

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -72,6 +72,9 @@ final class CaskCatalogViewModelTests: XCTestCase {
         vm.searchText = "SLACK"
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["slack"])
 
+        vm.searchText = "oxweb"
+        XCTAssertTrue(vm.filteredCasks.isEmpty, "query must not match across field boundaries")
+
         vm.searchText = ""
         XCTAssertEqual(vm.filteredCasks.count, 3)
     }

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -116,6 +116,22 @@ final class CaskCatalogViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_name_rank_path_preserves_descending_order_for_collation_ties() async {
+        let casks = [
+            makeCask("upper", name: "Foo"),
+            makeCask("lower", name: "foo"),
+            makeCask("bar", name: "Bar")
+        ]
+        let expected = casks.sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedDescending
+        }
+        let (vm, _) = await makeSUT(casks: casks)
+        vm.sortOption = .nameZA
+
+        XCTAssertEqual(vm.filteredCasks.map(\.token), expected.map(\.token))
+    }
+
+    @MainActor
     func test_displayed_casks_cap_at_reveal_chunk_and_reset_on_context_change() async {
         let chunk = CaskCatalogViewModel.revealChunk
         let (vm, _) = await makeSUT(casks: (0..<(chunk + 50)).map { makeCask("cask-\($0)") })

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -115,6 +115,31 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["zoom", "uebersicht", "arc"])
     }
 
+    @MainActor
+    func test_displayed_casks_cap_at_reveal_chunk_and_reset_on_context_change() async {
+        let chunk = CaskCatalogViewModel.revealChunk
+        let (vm, _) = await makeSUT(casks: (0..<(chunk + 50)).map { makeCask("cask-\($0)") })
+
+        XCTAssertEqual(vm.filteredCasks.count, chunk + 50)
+        XCTAssertEqual(vm.displayedCasks.count, chunk)
+        XCTAssertTrue(vm.hasMoreToReveal)
+
+        vm.revealMore()
+        XCTAssertEqual(vm.displayedCasks.count, chunk + 50)
+        XCTAssertFalse(vm.hasMoreToReveal)
+
+        vm.sortOption = .nameAZ
+        XCTAssertEqual(vm.displayedCasks.count, chunk)
+
+        vm.revealMore()
+        vm.searchText = "cask"
+        XCTAssertEqual(vm.displayedCasks.count, chunk)
+
+        vm.revealMore()
+        vm.selectedSidebar = .discover(.topCharts)
+        XCTAssertEqual(vm.displayedCasks.count, chunk)
+    }
+
     // MARK: Sidebar filters
 
     @MainActor

--- a/CaskHubTests/Homebrew/Domain/CaskOperationProgressTests.swift
+++ b/CaskHubTests/Homebrew/Domain/CaskOperationProgressTests.swift
@@ -28,7 +28,7 @@ final class CaskOperationProgressTests: XCTestCase {
     }
 
     @MainActor
-    func test_brew_output_updates_download_phase_then_install_phase() throws {
+    func test_brew_output_updates_download_phase_then_install_phase() async throws {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("operation-progress"))
         service.mutationCoordinator.beginOperation(
             .installing,
@@ -41,6 +41,7 @@ final class CaskOperationProgressTests: XCTestCase {
             "==> Downloading https://example.com/firefox.dmg",
             token: "firefox"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
         XCTAssertEqual(service.operationStore.state(for: "firefox")?.progress?.phase, .checkingDownload)
         XCTAssertEqual(
             service.operationStore.state(for: "firefox")?.progress?.inlineLabel,
@@ -51,6 +52,7 @@ final class CaskOperationProgressTests: XCTestCase {
             "Cask firefox    ########    Downloading    42.0MB/100.0MB",
             token: "firefox"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
         let downloading = try XCTUnwrap(service.operationStore.state(for: "firefox")?.progress)
         XCTAssertEqual(downloading.phase, .downloading)
         XCTAssertEqual(downloading.completedBytes, 42_000_000)
@@ -62,12 +64,13 @@ final class CaskOperationProgressTests: XCTestCase {
             "==> Installing Cask firefox",
             token: "firefox"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
         XCTAssertEqual(service.operationStore.state(for: "firefox")?.progress?.phase, .performing)
         XCTAssertFalse(service.operationStore.state(for: "firefox")?.canCancel == true)
     }
 
     @MainActor
-    func test_rapid_progress_redraws_are_throttled_but_markers_parse_immediately() {
+    func test_rapid_progress_redraws_are_throttled_but_markers_parse_immediately() async {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("throttled-progress"))
         service.mutationCoordinator.beginOperation(
             .installing,
@@ -79,6 +82,7 @@ final class CaskOperationProgressTests: XCTestCase {
             "Cask firefox    ####    Downloading    10.0MB/100.0MB",
             token: "firefox"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
         XCTAssertEqual(
             service.operationStore.state(for: "firefox")?.progress?.completedBytes,
             10_000_000
@@ -88,6 +92,7 @@ final class CaskOperationProgressTests: XCTestCase {
             "Cask firefox    ####    Downloading    20.0MB/100.0MB",
             token: "firefox"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
         XCTAssertEqual(
             service.operationStore.state(for: "firefox")?.progress?.completedBytes,
             10_000_000
@@ -97,6 +102,7 @@ final class CaskOperationProgressTests: XCTestCase {
             "==> Installing Cask firefox",
             token: "firefox"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
         XCTAssertEqual(
             service.operationStore.state(for: "firefox")?.progress?.phase,
             .performing
@@ -104,7 +110,7 @@ final class CaskOperationProgressTests: XCTestCase {
     }
 
     @MainActor
-    func test_brew_output_reports_cached_download_at_full_size() throws {
+    func test_brew_output_reports_cached_download_at_full_size() async throws {
         let cachedDownload = FileManager.default.temporaryDirectory
             .appendingPathComponent("cached download-\(UUID().uuidString).dmg")
         try Data(repeating: 0, count: 2_048).write(to: cachedDownload)
@@ -123,6 +129,7 @@ final class CaskOperationProgressTests: XCTestCase {
             """,
             token: "chatgpt-classic"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
 
         let progress = try XCTUnwrap(
             service.operationStore.state(for: "chatgpt-classic")?.progress
@@ -144,7 +151,7 @@ final class CaskOperationProgressTests: XCTestCase {
     }
 
     @MainActor
-    func test_brew_output_updates_download_phase_then_upgrade_phase() {
+    func test_brew_output_updates_download_phase_then_upgrade_phase() async {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("update-progress"))
         service.mutationCoordinator.beginOperation(
             .updating,
@@ -160,12 +167,14 @@ final class CaskOperationProgressTests: XCTestCase {
             """,
             token: "firefox"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
         XCTAssertEqual(service.operationStore.state(for: "firefox")?.progress?.phase, .downloading)
 
         service.mutationCoordinator.consumeBrewOutput(
             "==> Upgrading firefox",
             token: "firefox"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
         XCTAssertEqual(service.operationStore.state(for: "firefox")?.progress?.phase, .performing)
         XCTAssertFalse(service.operationStore.state(for: "firefox")?.canCancel == true)
     }
@@ -221,7 +230,7 @@ final class CaskOperationProgressTests: XCTestCase {
     }
 
     @MainActor
-    func test_progress_capsule_and_status_bar_render() {
+    func test_progress_capsule_and_status_bar_render() async {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("progress-render"))
         service.mutationCoordinator.beginOperation(
             .installing,
@@ -232,6 +241,7 @@ final class CaskOperationProgressTests: XCTestCase {
             "Cask plain    ########    Downloading    84.0MB/245.0MB",
             token: "plain"
         )
+        await service.mutationCoordinator.awaitPendingOutput()
 
         render(CaskActionsView(cask: makeCask("plain")).environment(service))
         render(CaskActionsView(cask: makeCask("plain"), fullWidth: false).environment(service))

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -215,13 +215,15 @@ func makeViewModel(
     localHomebrew: LocalHomebrewService? = nil,
     defaults: UserDefaults? = nil
 ) -> CaskCatalogViewModel {
-    CaskCatalogViewModel(
+    let vm = CaskCatalogViewModel(
         apiClient: api,
         categoryService: categories ?? CategoryService(),
         recentlyAdded: recentlyAdded ?? RecentlyAddedService(),
         localHomebrew: localHomebrew ?? LocalHomebrewService(),
         defaults: defaults ?? makeScratchDefaults("viewmodel-scratch")
     )
+    vm.searchDebounceInterval = .zero
+    return vm
 }
 
 func makeScratchDefaults(_ name: String = #function) -> UserDefaults {

--- a/CaskHubTests/Views/ContentViewTests.swift
+++ b/CaskHubTests/Views/ContentViewTests.swift
@@ -283,4 +283,54 @@ final class TopBarViewTests: XCTestCase {
         renderTopBar(isUpdatingAll: false, greedyUpdates: true)
         renderTopBar(isUpdatingAll: false, greedyUpdates: false)
     }
+
+    /// Production-boundary check for the reveal sentinel: the browse landing
+    /// page's bounded shelves share `caskGrid` with the capped flat grid and
+    /// must never fire the global `revealMore()`.
+    @MainActor
+    func test_browse_landing_page_does_not_consume_reveal_budget() async throws {
+        let chunk = CaskCatalogViewModel.revealChunk
+        let api = MockBrewAPIClient()
+        api.casks = (0 ..< (chunk + 50)).map { makeCask("cask-\($0)") }
+        let categories = CategoryService()
+        let local = LocalHomebrewService(defaults: makeScratchDefaults("reveal-probe"))
+        let vm = makeViewModel(api: api, categories: categories, localHomebrew: local)
+        await vm.fetchCasks()
+        XCTAssertTrue(vm.hasMoreToReveal)
+
+        let storedViewMode = UserDefaults.standard.string(forKey: "viewMode")
+        UserDefaults.standard.set(ViewMode.grid.rawValue, forKey: "viewMode")
+
+        // Tall enough that every browse shelf — and any sentinel wrongly attached
+        // to one — materializes inside the lazy containers.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 3000),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: ContentView(viewModel: vm)
+            .environment(categories)
+            .environment(local)
+            .environment(ImageCacheService()))
+        window.orderFrontRegardless()
+
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        addTeardownBlock { @MainActor in
+            UserDefaults.standard.set(storedViewMode, forKey: "viewMode")
+            window.contentView = NSView()
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+            window.close()
+        }
+
+        XCTAssertEqual(
+            vm.revealedCount, chunk,
+            "browse shelves must not trigger the flat grid's reveal sentinel"
+        )
+    }
 }


### PR DESCRIPTION
Steps 1-4 of the post-0.6.8 hang perf pass (CASKHUB-M layout hangs, CASKHUB-Z `_stringCompare`).

## Problem

Every keystroke re-filtered and re-sorted the full ~3.7k-cask catalog synchronously on the MainActor (`searchText` fed the cache key directly), `applySearch` lowercased three fields per cask per pass, name sorts ran `localizedCaseInsensitiveCompare` per comparison (~44k ICU walks), and browse-list/Top Charts handed the entire result array to SwiftUI to diff and lay out.

## Changes

**1 — debounce:** `appliedSearchText` drives the projection; TextField echo stays instant. 200ms trailing apply, instant clear. `searchDebounceInterval` injectable; test factory sets `.zero` (synchronous).

**2 — search keys:** `Cask.searchKey` (displayName/token/desc lowercased once, newline-separated so queries can't match across fields), memoized per `catalogRevision`, built lazily on first applied search. Filter = one `contains` per cask.

**3 — name sort ranks:** one `localizedCaseInsensitiveCompare` sort per catalog revision memoizes token→rank; nameAZ/nameZA/recentlyInstalled-tiebreak compare Int ranks. Ordering bit-identical, diacritics included ('Übersicht' stays under U — dedicated test). ICU comparator kept as fallback; built lazily on first name sort.

**4 — render cap:** grid/list render `displayedCasks` = `filteredCasks.prefix(200)`; an invisible `RevealSentinel` as the last lazy item reveals the next 200 when scrolled to (only materializes at the bottom, so reveal is seamless). `filteredCasks` stays uncapped for the top-bar count and hero card; cap resets on sidebar/sort/applied-search changes. Browse sections (8/section) and Featured (100) were already bounded.

Net: one projection per typing pause; search = dictionary lookup per cask; name sorts = Int compares; SwiftUI diffs at most 200 items per update instead of 3.7k.

## Tests

- debounce coalescing + instant clear
- cross-field boundary (`oxweb` matches nothing)
- localized diacritic order through the rank path (AZ + ZA)
- cap at 200 / reveal / reset on sort, search, and sidebar changes
- Full suite: **TEST SUCCEEDED**