### PR TITLE
fix: Refresh local state when brew rejects an action as not installed

### DIFF
--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -306,7 +306,19 @@ final class HomebrewMutationCoordinator {
             error: error,
             strandedCopyExists: callbacks.strandedCopyExists()
         )
+        if Self.indicatesStateDesync(error) {
+            await callbacks.refresh()
+        }
         throw error
+    }
+
+    /// Brew rejecting the action over install state means our snapshot is stale
+    /// — without a refresh the UI keeps offering an action brew will keep failing.
+    private static func indicatesStateDesync(_ error: Error) -> Bool {
+        guard case let LocalHomebrewError.brewCommandFailed(_, _, stderr) = error else {
+            return false
+        }
+        return LocalHomebrewError.failureClass(stderr: stderr) == "not-installed"
     }
 
 }

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
@@ -308,10 +308,10 @@ extension HomebrewInstallationScanner {
         )
     }
 
-    /// Brew's own installed check (`Cask#installed?`) is the presence of a
-    /// timestamped caskfile under `.metadata/<version>/<timestamp>/Casks/`.
-    /// Entries without one must not offer brew actions — brew rejects them
-    /// with "is not installed" (CASKHUB-14).
+    /// Mirrors brew's `Caskroom.cask_installed_caskfile`: the single newest
+    /// timestamp directory across all versions must contain `Casks/<token>.rb`
+    /// or `.json`. Entries failing that must not offer brew actions — brew
+    /// rejects them with "is not installed" (CASKHUB-14).
     private static func timestampedCaskfileExists(
         in entry: URL,
         fileManager: FileManager
@@ -319,27 +319,26 @@ extension HomebrewInstallationScanner {
         let metadata = entry.appendingPathComponent(".metadata", isDirectory: true)
         guard let versionDirectories = try? fileManager.contentsOfDirectory(
             at: metadata,
-            includingPropertiesForKeys: [.isDirectoryKey],
+            includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]
         ) else { return false }
-        for versionDirectory in versionDirectories {
-            guard let timestamps = try? fileManager.contentsOfDirectory(
-                at: versionDirectory,
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            ) else { continue }
-            for timestamp in timestamps {
-                let casks = timestamp.appendingPathComponent("Casks")
-                if let files = try? fileManager.contentsOfDirectory(
-                    at: casks,
+        let newestTimestamp = versionDirectories
+            .flatMap { versionDirectory in
+                (try? fileManager.contentsOfDirectory(
+                    at: versionDirectory,
                     includingPropertiesForKeys: nil,
                     options: [.skipsHiddenFiles]
-                ), !files.isEmpty {
-                    return true
-                }
+                )) ?? []
             }
+            .max { $0.lastPathComponent < $1.lastPathComponent }
+        guard let newestTimestamp else { return false }
+        let token = entry.lastPathComponent
+        return ["rb", "json"].contains { fileExtension in
+            fileManager.fileExists(
+                atPath: newestTimestamp
+                    .appendingPathComponent("Casks/\(token).\(fileExtension)").path
+            )
         }
-        return false
     }
 
     private static func latestVersionDirectory(

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
@@ -283,12 +283,14 @@ extension HomebrewInstallationScanner {
                 try? InstallReceipt(jsonData: $0)
             }
             : nil
-        let isZombie = !receiptExists || appsGoneEverywhere(
-            appNames: receipt?.appBundleNames ?? [],
-            versionDirectory: versionDirectory,
-            fileManager: fileManager,
-            applicationDirectories: applicationDirectories
-        )
+        let isZombie = !receiptExists
+            || !timestampedCaskfileExists(in: entry, fileManager: fileManager)
+            || appsGoneEverywhere(
+                appNames: receipt?.appBundleNames ?? [],
+                versionDirectory: versionDirectory,
+                fileManager: fileManager,
+                applicationDirectories: applicationDirectories
+            )
         let versionModifiedAt = try? versionDirectory.resourceValues(
             forKeys: [.contentModificationDateKey]
         ).contentModificationDate
@@ -304,6 +306,40 @@ extension HomebrewInstallationScanner {
             appBundleNames: receipt?.appBundleNames ?? [],
             isZombie: isZombie
         )
+    }
+
+    /// Brew's own installed check (`Cask#installed?`) is the presence of a
+    /// timestamped caskfile under `.metadata/<version>/<timestamp>/Casks/`.
+    /// Entries without one must not offer brew actions — brew rejects them
+    /// with "is not installed" (CASKHUB-14).
+    private static func timestampedCaskfileExists(
+        in entry: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        let metadata = entry.appendingPathComponent(".metadata", isDirectory: true)
+        guard let versionDirectories = try? fileManager.contentsOfDirectory(
+            at: metadata,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return false }
+        for versionDirectory in versionDirectories {
+            guard let timestamps = try? fileManager.contentsOfDirectory(
+                at: versionDirectory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+            for timestamp in timestamps {
+                let casks = timestamp.appendingPathComponent("Casks")
+                if let files = try? fileManager.contentsOfDirectory(
+                    at: casks,
+                    includingPropertiesForKeys: nil,
+                    options: [.skipsHiddenFiles]
+                ), !files.isEmpty {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private static func latestVersionDirectory(

--- a/CaskHubTests/Homebrew/Coordination/MutationRecoveryTests.swift
+++ b/CaskHubTests/Homebrew/Coordination/MutationRecoveryTests.swift
@@ -86,6 +86,28 @@ final class MutationRecoveryTests: XCTestCase {
         }
     }
 
+    func test_failed_upgrade_for_uninstalled_cask_refreshes_stale_local_state() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "Error: Cask 'thorium' is not installed."
+        )]
+        let service = makeService(runner: runner)
+        updateInstalledCask(installation("thorium", version: "1.0"), in: service)
+        let thorium = makeCask("thorium")
+        XCTAssertTrue(service.localState(for: thorium).isPresent)
+
+        do {
+            try await service.upgrade(token: "thorium")
+            XCTFail("expected failure")
+        } catch {}
+
+        XCTAssertFalse(
+            service.localState(for: thorium).isPresent,
+            "brew disagreeing about install state must trigger a snapshot refresh"
+        )
+    }
+
     func test_brew_error_diagnostics_keep_error_before_long_cleanup_tail() async {
         let runner = StubBrewProcessRunner()
         let cleanupTail = (1...30).map { "formula-\($0)" }.joined(separator: "\n")

--- a/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
@@ -104,6 +104,23 @@ final class ZombieDetectionTests: XCTestCase {
         XCTAssertEqual(scan()["thorium"]?.isZombie, true)
     }
 
+    /// Brew only consults the single newest timestamp directory
+    /// (`Caskroom.cask_installed_caskfile`) — a valid caskfile in an older
+    /// timestamp does not make the cask installed.
+    func test_latest_timestamp_must_contain_the_matching_caskfile() throws {
+        try makeEntry("thorium", receiptApps: ["Thorium.app"])
+        let newestCasks = caskroom
+            .appendingPathComponent("thorium/.metadata/1.0/20270101000000.000/Casks")
+        try fm.createDirectory(at: newestCasks, withIntermediateDirectories: true)
+        try Data("cask \"another-token\"\n".utf8)
+            .write(to: newestCasks.appendingPathComponent("another-token.rb"))
+        try fm.createDirectory(
+            at: appsDir.appendingPathComponent("Thorium.app"), withIntermediateDirectories: true
+        )
+
+        XCTAssertEqual(scan()["thorium"]?.isZombie, true)
+    }
+
     func test_cli_cask_with_appless_receipt_is_not_zombie() throws {
         try makeEntry("some-cli", receiptApps: [])
         XCTAssertEqual(scan()["some-cli"]?.isZombie, false)

--- a/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
@@ -35,7 +35,11 @@ final class ZombieDetectionTests: XCTestCase {
 
     /// receiptApps nil = no INSTALL_RECEIPT.json at all.
     @discardableResult
-    private func makeEntry(_ token: String, receiptApps: [String]?) throws -> URL {
+    private func makeEntry(
+        _ token: String,
+        receiptApps: [String]?,
+        caskfile: Bool = true
+    ) throws -> URL {
         let versionDir = caskroom.appendingPathComponent("\(token)/1.0")
         try fm.createDirectory(at: versionDir, withIntermediateDirectories: true)
         if let receiptApps {
@@ -44,6 +48,12 @@ final class ZombieDetectionTests: XCTestCase {
             let receipt: [String: Any] = ["uninstall_artifacts": [["app": receiptApps]]]
             let data = try JSONSerialization.data(withJSONObject: receipt)
             try data.write(to: metadata.appendingPathComponent("INSTALL_RECEIPT.json"))
+            if caskfile {
+                let casks = metadata.appendingPathComponent("1.0/20260101000000.000/Casks")
+                try fm.createDirectory(at: casks, withIntermediateDirectories: true)
+                try Data("cask \"\(token)\"\n".utf8)
+                    .write(to: casks.appendingPathComponent("\(token).rb"))
+            }
         }
         return versionDir
     }
@@ -82,6 +92,16 @@ final class ZombieDetectionTests: XCTestCase {
     func test_missing_receipt_is_zombie() throws {
         try makeEntry("sequel-ace", receiptApps: nil)
         XCTAssertEqual(scan()["sequel-ace"]?.isZombie, true)
+    }
+
+    /// Brew's installed check is the timestamped caskfile, not the receipt —
+    /// offering brew actions for such entries earns "Cask 'x' is not installed".
+    func test_missing_timestamped_caskfile_is_zombie_even_with_receipt() throws {
+        try makeEntry("thorium", receiptApps: ["Thorium.app"], caskfile: false)
+        try fm.createDirectory(
+            at: appsDir.appendingPathComponent("Thorium.app"), withIntermediateDirectories: true
+        )
+        XCTAssertEqual(scan()["thorium"]?.isZombie, true)
     }
 
     func test_cli_cask_with_appless_receipt_is_not_zombie() throws {


### PR DESCRIPTION
Targets CASKHUB-14 / CASKHUB-1H (`Error: Cask 'x' is not installed` on upgrade/uninstall — state desync, both shapes).

## Diagnosis (from Sentry breadcrumbs + brew source)

Two shapes of the same desync, confirmed same-prefix via event tags (`brew.path` and `brew.caskroom` both `/opt/homebrew`):

1. **Entry fully removed externally** (e.g. `brew uninstall` in a terminal mid-session) — snapshot stale until next refresh, Update button invites retries (lulu user: two events 62s apart).
2. **Caskfile-less leftover**: brew's `Cask#installed?` is the presence of a timestamped caskfile (`.metadata/<version>/<timestamp>/Casks/<token>.rb` — `cask.rb:244`), while our scanner accepted any version dir + `INSTALL_RECEIPT.json`. Interrupted uninstalls leave exactly that shape: CaskHub says installed+updatable, brew says not installed, forever.

## Changes

**Commit 1 — self-heal (shape 1):** terminal mutation failures classed `not-installed` trigger `callbacks.refresh()`, so the UI reconciles and the retry loop dies.

**Commit 2 — aligned detection (shape 2):** `HomebrewInstallationScanner` now requires the timestamped caskfile brew requires; entries without one are zombies, which `CaskLocalStateResolver.isOutdated` already excludes from update offers. The two commits compose: a not-installed failure refreshes, the rescan classifies the leftover as zombie, the button is gone.

Reporting unchanged — first occurrences still reach Sentry so we can verify the class dies after release.

## Tests

- `test_failed_upgrade_for_uninstalled_cask_refreshes_stale_local_state` (shape 1)
- `test_missing_timestamped_caskfile_is_zombie_even_with_receipt` (shape 2, app present on disk)
- Zombie fixture now seeds the real brew `.metadata` layout; existing zombie semantics unchanged
- Full suite: **TEST SUCCEEDED**