### PR TITLE
feat: Enhance settings experience

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		A29100000000000000000002 /* CaskMetadataProjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000001 /* CaskMetadataProjector.swift */; };
 		41DFD4A830028F7D00608C7A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47830028F7D00608C7A /* SettingsView.swift */; };
 		41DFD4E230028F7D00608C7A /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4E130028F7D00608C7A /* AppearanceSettingsView.swift */; };
+		A26000000000000000000002 /* UpdateSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26000000000000000000001 /* UpdateSettingsView.swift */; };
 		41DFD4A930028F7D00608C7A /* CaskActionAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47A30028F7D00608C7A /* CaskActionAlerts.swift */; };
 		41DFD4AA30028F7D00608C7A /* CaskCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47B30028F7D00608C7A /* CaskCardView.swift */; };
 		41DFD4AB30028F7D00608C7A /* CaskIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD47C30028F7D00608C7A /* CaskIconView.swift */; };
@@ -104,6 +105,7 @@
 		F25000000000000000000001 /* CaskCatalogSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25000000000000000000001 /* CaskCatalogSortTests.swift */; };
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
 		ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */; };
+		A26000000000000000000004 /* UpdateSettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26000000000000000000003 /* UpdateSettingsViewTests.swift */; };
 		FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */; };
 		F26000000000000000000001 /* CaskListActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26000000000000000000001 /* CaskListActionTests.swift */; };
 		F24000000000000000000003 /* CaskOperationProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24000000000000000000003 /* CaskOperationProgressTests.swift */; };
@@ -211,6 +213,7 @@
 		A29100000000000000000001 /* CaskMetadataProjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskMetadataProjector.swift; sourceTree = "<group>"; };
 		41DFD47830028F7D00608C7A /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		41DFD4E130028F7D00608C7A /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
+		A26000000000000000000001 /* UpdateSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSettingsView.swift; sourceTree = "<group>"; };
 		41DFD47A30028F7D00608C7A /* CaskActionAlerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskActionAlerts.swift; sourceTree = "<group>"; };
 		41DFD47B30028F7D00608C7A /* CaskCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCardView.swift; sourceTree = "<group>"; };
 		41DFD47C30028F7D00608C7A /* CaskIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskIconView.swift; sourceTree = "<group>"; };
@@ -231,6 +234,7 @@
 		41EBDCE12F37FD8B00BEABB8 /* CaskHub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaskHub.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		41EBDCEE2F37FD8C00BEABB8 /* CaskHubTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaskHubTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewTests.swift; sourceTree = "<group>"; };
+		A26000000000000000000003 /* UpdateSettingsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSettingsViewTests.swift; sourceTree = "<group>"; };
 		8BB79639B5E04DEBBDB54898 /* AdoptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdoptionTests.swift; sourceTree = "<group>"; };
 		E26000000000000000000001 /* CaskListActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskListActionTests.swift; sourceTree = "<group>"; };
 		E24000000000000000000003 /* CaskOperationProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskOperationProgressTests.swift; sourceTree = "<group>"; };
@@ -526,6 +530,7 @@
 			children = (
 				41DFD4E130028F7D00608C7A /* AppearanceSettingsView.swift */,
 				41DFD47830028F7D00608C7A /* SettingsView.swift */,
+				A26000000000000000000001 /* UpdateSettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -638,6 +643,7 @@
 			children = (
 				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
 				ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */,
+				A26000000000000000000003 /* UpdateSettingsViewTests.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -958,6 +964,7 @@
 				A29100000000000000000002 /* CaskMetadataProjector.swift in Sources */,
 				41DFD4A830028F7D00608C7A /* SettingsView.swift in Sources */,
 				41DFD4E230028F7D00608C7A /* AppearanceSettingsView.swift in Sources */,
+				A26000000000000000000002 /* UpdateSettingsView.swift in Sources */,
 				41DFD4A930028F7D00608C7A /* CaskActionAlerts.swift in Sources */,
 				41DFD4AA30028F7D00608C7A /* CaskCardView.swift in Sources */,
 				41DFD4AB30028F7D00608C7A /* CaskIconView.swift in Sources */,
@@ -984,6 +991,7 @@
 				41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */,
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,
+				A26000000000000000000004 /* UpdateSettingsViewTests.swift in Sources */,
 				FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */,
 				F26000000000000000000001 /* CaskListActionTests.swift in Sources */,
 				F24000000000000000000003 /* CaskOperationProgressTests.swift in Sources */,

--- a/CaskHub/Services/Updates/UpdaterService.swift
+++ b/CaskHub/Services/Updates/UpdaterService.swift
@@ -23,8 +23,8 @@ struct StagedUpdateGate {
     private(set) var pending = false
 
     // Called when a background check staged an update for install-on-quit.
-    mutating func updateStaged(showPromptEnabled: Bool) {
-        if showPromptEnabled { pending = true }
+    mutating func updateStaged(automaticChecksEnabled: Bool) {
+        if automaticChecksEnabled { pending = true }
     }
 
     // checkForUpdates() is a no-op mid-session, so we wait for canCheck to flip
@@ -38,16 +38,15 @@ struct StagedUpdateGate {
 
 @Observable
 final class UpdaterService: NSObject, SPUUpdaterDelegate {
-    static let showUpdatePromptKey = "showUpdatePromptAtLaunch"
-
     private var controller: SPUStandardUpdaterController!
     private(set) var canCheckForUpdates = false
-    @ObservationIgnored private var cancellable: AnyCancellable?
+    private(set) var isCheckingForUpdates = false
+    private(set) var lastUpdateCheckDate: Date?
+    @ObservationIgnored private var cancellables = Set<AnyCancellable>()
     @ObservationIgnored private var stagedUpdate = StagedUpdateGate()
 
     override init() {
         super.init()
-        UserDefaults.standard.register(defaults: [Self.showUpdatePromptKey: true])
         controller = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: self,
@@ -55,16 +54,23 @@ final class UpdaterService: NSObject, SPUUpdaterDelegate {
         )
         // Sparkle allows a forced launch check here, before its scheduled cycle starts.
         Self.checkForUpdatesOnLaunch(using: controller.updater)
-        cancellable = controller.updater.publisher(for: \.canCheckForUpdates)
+        controller.updater.publisher(for: \.canCheckForUpdates)
             .sink { [weak self] canCheck in
                 guard let self else { return }
                 canCheckForUpdates = canCheck
+                if canCheck { isCheckingForUpdates = false }
                 // Resume the staged update as a user-facing check: shows the
                 // ready-to-install prompt with release notes, no re-download.
                 if stagedUpdate.consumeResume(canCheck: canCheck) {
                     controller.updater.checkForUpdates()
                 }
             }
+            .store(in: &cancellables)
+        controller.updater.publisher(for: \.lastUpdateCheckDate)
+            .sink { [weak self] date in
+                self?.lastUpdateCheckDate = date
+            }
+            .store(in: &cancellables)
     }
 
     static func checkForUpdatesOnLaunch(using updater: some BackgroundUpdateChecking) {
@@ -73,6 +79,8 @@ final class UpdaterService: NSObject, SPUUpdaterDelegate {
     }
 
     func checkForUpdates() {
+        guard canCheckForUpdates else { return }
+        isCheckingForUpdates = !controller.updater.sessionInProgress
         controller.updater.checkForUpdates()
     }
 
@@ -94,7 +102,7 @@ final class UpdaterService: NSObject, SPUUpdaterDelegate {
         // Sparkle calls delegate methods on the main thread.
         MainActor.assumeIsolated {
             stagedUpdate.updateStaged(
-                showPromptEnabled: UserDefaults.standard.bool(forKey: Self.showUpdatePromptKey)
+                automaticChecksEnabled: updater.automaticallyChecksForUpdates
             )
         }
         return false
@@ -108,6 +116,5 @@ struct CheckForUpdatesView: View {
         Button("Check for Updates…") {
             updater.checkForUpdates()
         }
-        .disabled(!updater.canCheckForUpdates)
     }
 }

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -27,6 +27,10 @@ struct SettingsView: View {
                 .tabItem {
                     Label("Privacy", systemImage: "hand.raised")
                 }
+            UpdateSettingsView()
+                .tabItem {
+                    Label("Updates", systemImage: "arrow.triangle.2.circlepath")
+                }
             AboutSettingsView()
                 .tabItem {
                     Label("About", systemImage: "info.circle")
@@ -37,6 +41,8 @@ struct SettingsView: View {
 }
 
 struct AboutSettingsView: View {
+    static let issuesURL = URL(string: "https://github.com/alielsokary/CaskHub/issues/new/choose")!
+
     private var version: String {
         let info = Bundle.main.infoDictionary
         let short = info?["CFBundleShortVersionString"] as? String ?? "—"
@@ -68,6 +74,29 @@ struct AboutSettingsView: View {
 
             Spacer()
 
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Support")
+                    .font(.headline)
+
+                GroupBox {
+                    HStack(spacing: 12) {
+                        Image(systemName: "ladybug")
+                            .accessibilityHidden(true)
+
+                        Text("Submit a bug or feature request")
+
+                        Spacer()
+
+                        Link("View", destination: Self.issuesURL)
+                            .buttonStyle(.bordered)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 4)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 12)
+
             Text("© 2026 Ali Elsokary. All rights reserved.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -78,18 +107,15 @@ struct AboutSettingsView: View {
 }
 
 struct GeneralSettingsView: View {
-    @Environment(UpdaterService.self) private var updater
     @Environment(ImageCacheService.self) private var imageCache
     @State private var settingsModel: GeneralSettingsModel
     @AppStorage(SidebarView.showAdoptKey) private var showAdoptApps = true
-    @AppStorage(UpdaterService.showUpdatePromptKey) private var showUpdatePrompt = true
 
     init(settingsModel: GeneralSettingsModel? = nil) {
         _settingsModel = State(initialValue: settingsModel ?? GeneralSettingsModel())
     }
 
     var body: some View {
-        @Bindable var updater = updater
         Form {
             Section("Startup") {
                 Toggle(
@@ -99,17 +125,6 @@ struct GeneralSettingsView: View {
                         set: { settingsModel.setLaunchAtLogin($0) }
                     )
                 )
-            }
-            Section("Updates") {
-                Toggle("Automatically check for updates", isOn: $updater.automaticallyChecksForUpdates)
-                Toggle("Show update notification at launch", isOn: $showUpdatePrompt)
-                Text("""
-                Updates always download in the background. When this is off, they \
-                install silently the next time you quit CaskHub instead of showing \
-                what's new first.
-                """)
-                .font(.callout)
-                .foregroundStyle(.secondary)
             }
             Section("Sidebar") {
                 Toggle("Show Adopt Apps", isOn: $showAdoptApps)
@@ -237,24 +252,38 @@ private struct HomebrewSettingsContent: View {
                 )
             }
             Section("Custom Location") {
-                LabeledContent("Custom Path") {
-                    HStack(spacing: 10) {
-                        TextField("", text: $locationModel.customPathField, prompt: Text(""))
-                            .textFieldStyle(.roundedBorder)
-                            .frame(minWidth: 220)
-                            .onSubmit {
-                                Task { await locationModel.applyTypedPath() }
-                            }
-                        Button("Choose…") { chooseCustomPrefix() }
+                HStack(alignment: .center, spacing: 10) {
+                    TextField(
+                        "",
+                        text: $locationModel.customPathField,
+                        prompt: Text("Homebrew path")
+                    )
+                    .labelsHidden()
+                    .accessibilityLabel("Homebrew path")
+                    .font(.body.monospaced())
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+                    .layoutPriority(1)
+                    .onSubmit {
+                        Task { await locationModel.applyTypedPath() }
+                    }
+
+                    Button("Choose…") { chooseCustomPrefix() }
+                        .fixedSize()
+                }
+                .frame(maxWidth: .infinity)
+                .controlSize(.regular)
+
+                if localHomebrew.customBrewPrefix != nil {
+                    Button("Use Automatic Location") {
+                        locationModel.customPathField = ""
+                        Task { await locationModel.applyTypedPath() }
                     }
                 }
-                Text("""
-                Point CaskHub at a Homebrew installed outside the standard locations \
-                (/opt/homebrew and /usr/local). Select the brew binary or its \
-                installation folder.
-                """)
-                .font(.callout)
-                .foregroundStyle(.secondary)
+
+                Text("Only needed when Homebrew is installed outside /opt/homebrew or /usr/local.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)
@@ -305,32 +334,36 @@ struct PrivacySettingsView: View {
 
     var body: some View {
         Form {
-            LabeledContent("Analytics:") {
-                checkboxRow(
+            Section("Usage Analytics") {
+                Toggle(
                     "Share anonymous usage analytics",
-                    isOn: $analyticsEnabled,
-                    description: """
-                    Helps improve CaskHub by sending anonymized usage signals \
-                    via TelemetryDeck. No personal data is collected and it \
-                    cannot be used to identify you.
-                    """
+                    isOn: $analyticsEnabled
                 )
+
+                Text("""
+                Sends anonymized usage signals through TelemetryDeck. No personal \
+                information is collected.
+                """)
+                .font(.callout)
+                .foregroundStyle(.secondary)
             }
-            LabeledContent("Crash Report:") {
-                checkboxRow(
+
+            Section("Crash Reports") {
+                Toggle(
                     "Share crash reports",
-                    isOn: $crashReportingEnabled,
-                    description: """
-                    Helps improve CaskHub's stability by sending crash reports \
-                    and error diagnostics to Sentry so bugs get found and \
-                    fixed faster.
-                    """
+                    isOn: $crashReportingEnabled
                 )
+
+                Text("""
+                Sends crash reports and technical diagnostics through Sentry to help \
+                identify and fix problems.
+                """)
+                .font(.callout)
+                .foregroundStyle(.secondary)
             }
         }
-        .formStyle(.columns)
-        .padding(24)
-        .frame(maxHeight: .infinity, alignment: .top)
+        .formStyle(.grouped)
+        .padding()
         .onChange(of: analyticsEnabled) { _, isOn in
             Analytics.refresh()
             if isOn { Analytics.analyticsReEnabled() }
@@ -338,23 +371,6 @@ struct PrivacySettingsView: View {
         .onChange(of: crashReportingEnabled) { _, _ in
             CrashReporter.refresh()
         }
-    }
-
-    private func checkboxRow(
-        _ title: String,
-        isOn: Binding<Bool>,
-        description: String
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Toggle(title, isOn: isOn)
-                .toggleStyle(.checkbox)
-            Text(description)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.leading, 20)
-        }
-        .padding(.bottom, 12)
     }
 }
 

--- a/CaskHub/Views/Settings/UpdateSettingsView.swift
+++ b/CaskHub/Views/Settings/UpdateSettingsView.swift
@@ -1,0 +1,68 @@
+//
+//  UpdateSettingsView.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 02/08/2026.
+//
+
+import SwiftUI
+
+struct UpdateSettingsView: View {
+    @Environment(UpdaterService.self) private var updater
+
+    var body: some View {
+        @Bindable var updater = updater
+        Form {
+            Section("Automatic Updates") {
+                Toggle(
+                    "Automatically check for updates",
+                    isOn: $updater.automaticallyChecksForUpdates
+                )
+
+                Text("""
+                When automatic checks are enabled, CaskHub downloads updates in the \
+                background and always shows the update prompt before installation.
+                """)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            }
+
+            Section {
+                HStack {
+                    Text(lastCheckDescription)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    if updater.isCheckingForUpdates {
+                        HStack(spacing: 6) {
+                            ProgressView()
+                                .controlSize(.small)
+                                .accessibilityHidden(true)
+
+                            Text("Checking…")
+                                .foregroundStyle(.secondary)
+                        }
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("Checking for updates")
+                    } else {
+                        Button("Check Now") {
+                            updater.checkForUpdates()
+                        }
+                        .disabled(!updater.canCheckForUpdates)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+
+    private var lastCheckDescription: String {
+        guard let date = updater.lastUpdateCheckDate else {
+            return "Last checked: Never"
+        }
+        return "Last checked: \(date.formatted(date: .abbreviated, time: .shortened))"
+    }
+}

--- a/CaskHubTests/Views/SettingsViewTests.swift
+++ b/CaskHubTests/Views/SettingsViewTests.swift
@@ -85,9 +85,9 @@ final class SettingsViewTests: XCTestCase {
     }
 
     @MainActor
-    func test_staged_update_not_pending_when_prompt_disabled() {
+    func test_staged_update_not_pending_when_automatic_checks_disabled() {
         var gate = StagedUpdateGate()
-        gate.updateStaged(showPromptEnabled: false)
+        gate.updateStaged(automaticChecksEnabled: false)
 
         XCTAssertFalse(gate.pending)
         XCTAssertFalse(gate.consumeResume(canCheck: true))
@@ -96,7 +96,7 @@ final class SettingsViewTests: XCTestCase {
     @MainActor
     func test_staged_update_resumes_once_after_session_ends() {
         var gate = StagedUpdateGate()
-        gate.updateStaged(showPromptEnabled: true)
+        gate.updateStaged(automaticChecksEnabled: true)
 
         XCTAssertTrue(gate.pending)
         // Session still in progress: checkForUpdates() would be a no-op, so hold.
@@ -125,10 +125,8 @@ final class SettingsViewTests: XCTestCase {
     func test_settings_tabs_render() {
         render(AppearanceSettingsView())
         render(PrivacySettingsView())
-        render(AboutSettingsView())
         render(
             GeneralSettingsView()
-                .environment(UpdaterService())
                 .environment(ImageCacheService())
         )
         render(

--- a/CaskHubTests/Views/UpdateSettingsViewTests.swift
+++ b/CaskHubTests/Views/UpdateSettingsViewTests.swift
@@ -1,0 +1,36 @@
+//
+//  UpdateSettingsViewTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 02/08/2026.
+//
+
+@testable import CaskHub
+import SwiftUI
+import XCTest
+
+final class UpdateSettingsViewTests: XCTestCase {
+    @MainActor
+    func test_update_settings_and_about_support_render() {
+        render(
+            UpdateSettingsView()
+                .environment(UpdaterService())
+        )
+        render(AboutSettingsView())
+    }
+
+    @MainActor
+    func test_about_support_uses_caskhub_issue_chooser() {
+        XCTAssertEqual(
+            AboutSettingsView.issuesURL.absoluteString,
+            "https://github.com/alielsokary/CaskHub/issues/new/choose"
+        )
+    }
+
+    @MainActor
+    private func render(_ view: some View) {
+        let hosting = NSHostingView(rootView: AnyView(view))
+        hosting.frame = NSRect(x: 0, y: 0, width: 460, height: 480)
+        hosting.layoutSubtreeIfNeeded()
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated Updates tab between Privacy and About
- add manual update checking with progress and last-check status
- always show staged update prompts when automatic checks are enabled
- stabilize the main-menu update command to avoid AppKit menu-update crashes
- modernize Privacy and custom Homebrew location layouts
- add an About support card linking to the CaskHub issue chooser

## Validation

- full macOS test suite passes
- signed Debug build succeeds
- SwiftLint build phase passes
- no resource JSON or changelog changes

## Checklist

- [x] Base branch is develop
- [x] Title uses a conventional prefix and sentence-case subject
- [x] Tests added or updated
- [x] SwiftLint build phase passes locally
- [x] No changes to CaskHub/Resources/*.json or CHANGELOG.md