### PR TITLE
docs: add acknowledgements section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Interested in contributing to CaskHub? We welcome contributions of all kinds!
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request — note that all PRs target the `develop` branch.
 
+## Acknowledgements
+
+- [CaskFlow](https://github.com/alielsokary/CaskFlow) — the data pipeline behind CaskHub's categories, Recently Added dates, and app icons
+- [Homebrew](https://brew.sh) — the package manager CaskHub is built on
+
 ## License
 
 CaskHub is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- Adds an **Acknowledgements** section to the README crediting [CaskFlow](https://github.com/alielsokary/CaskFlow) (categories, Recently Added dates, and app icons) and [Homebrew](https://brew.sh).

## Notes

Counterpart to CaskFlow PR [alielsokary/CaskFlow#71](https://github.com/alielsokary/CaskFlow/pull/71), which adds a *Projects using CaskFlow* table and an attribution note on the upstream side.