### PR TITLE
fix: Sentry 0.6.9 follow-ups — hang mechanisms, sudo-declined class, state routing

### DIFF
--- a/CaskHub/App/Askpass.swift
+++ b/CaskHub/App/Askpass.swift
@@ -24,6 +24,10 @@ enum Askpass {
         alert.accessoryView = passwordField
         alert.window.initialFirstResponder = passwordField
 
+        // Accessory process under cooperative activation: without the floating
+        // level + forced activation the prompt can open behind other windows.
+        alert.window.level = .floating
+        NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
         app.activate()
         guard alert.runModal() == .alertFirstButtonReturn else { exit(1) }
         print(passwordField.stringValue)

--- a/CaskHub/App/Askpass.swift
+++ b/CaskHub/App/Askpass.swift
@@ -24,11 +24,11 @@ enum Askpass {
         alert.accessoryView = passwordField
         alert.window.initialFirstResponder = passwordField
 
-        // Accessory process under cooperative activation: without the floating
-        // level + forced activation the prompt can open behind other windows.
+        // Activation is cooperative; the floating level keeps the prompt on top.
         alert.window.level = .floating
         NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
         app.activate()
+        app.requestUserAttention(.criticalRequest)
         guard alert.runModal() == .alertFirstButtonReturn else { exit(1) }
         print(passwordField.stringValue)
         exit(0)

--- a/CaskHub/App/Askpass.swift
+++ b/CaskHub/App/Askpass.swift
@@ -26,7 +26,6 @@ enum Askpass {
 
         // Activation is cooperative; the floating level keeps the prompt on top.
         alert.window.level = .floating
-        NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
         app.activate()
         app.requestUserAttention(.criticalRequest)
         guard alert.runModal() == .alertFirstButtonReturn else { exit(1) }

--- a/CaskHub/Services/Catalog/RecentlyAddedService.swift
+++ b/CaskHub/Services/Catalog/RecentlyAddedService.swift
@@ -74,24 +74,13 @@ final class RecentlyAddedService {
         apply(remote)
     }
 
-    private struct RecentTokensKey: Equatable {
-        let revision: Int
-        let days: Int
-        let cutoff: String
-    }
-
     // Full-dictionary filter per projection recompute hangs slow machines.
     @ObservationIgnored
-    private let recentTokensCache = MemoizedValue<RecentTokensKey, Set<String>>()
+    private let recentTokensCache = MemoizedValue<String, Set<String>>()
 
     func recentTokens(within days: Int) -> Set<String> {
         let cutoff = Self.dateString(daysAgo: days)
-        let key = RecentTokensKey(
-            revision: catalogStateRevision,
-            days: days,
-            cutoff: cutoff
-        )
-        return recentTokensCache.value(for: key) { [addedDates] in
+        return recentTokensCache.value(for: "\(catalogStateRevision)|\(cutoff)") { [addedDates] in
             Set(addedDates.filter { $0.value >= cutoff }.keys)
         }
     }

--- a/CaskHub/Services/Catalog/RecentlyAddedService.swift
+++ b/CaskHub/Services/Catalog/RecentlyAddedService.swift
@@ -74,9 +74,27 @@ final class RecentlyAddedService {
         apply(remote)
     }
 
+    private struct RecentTokensKey: Equatable {
+        let revision: Int
+        let days: Int
+        let cutoff: String
+    }
+
+    // Called from projection recomputes on the main thread; the full-dictionary
+    // filter is hang material on slow machines (CASKHUB-2H).
+    @ObservationIgnored
+    private let recentTokensCache = MemoizedValue<RecentTokensKey, Set<String>>()
+
     func recentTokens(within days: Int) -> Set<String> {
         let cutoff = Self.dateString(daysAgo: days)
-        return Set(addedDates.filter { $0.value >= cutoff }.keys)
+        let key = RecentTokensKey(
+            revision: catalogStateRevision,
+            days: days,
+            cutoff: cutoff
+        )
+        return recentTokensCache.value(for: key) { [addedDates] in
+            Set(addedDates.filter { $0.value >= cutoff }.keys)
+        }
     }
 
     private static func dateString(daysAgo: Int) -> String {

--- a/CaskHub/Services/Catalog/RecentlyAddedService.swift
+++ b/CaskHub/Services/Catalog/RecentlyAddedService.swift
@@ -80,8 +80,7 @@ final class RecentlyAddedService {
         let cutoff: String
     }
 
-    // Called from projection recomputes on the main thread; the full-dictionary
-    // filter is hang material on slow machines (CASKHUB-2H).
+    // Full-dictionary filter per projection recompute hangs slow machines.
     @ObservationIgnored
     private let recentTokensCache = MemoizedValue<RecentTokensKey, Set<String>>()
 

--- a/CaskHub/Services/Homebrew/Coordination/CaskLocalStateResolver.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskLocalStateResolver.swift
@@ -160,9 +160,8 @@ struct CaskLocalStateResolver {
                     cask.token
                 )
             }
-            let bundleNames = Set(launchableBundleNames(for: cask))
-            return snapshot.detectedApplications.contains {
-                bundleNames.contains($0.bundleName)
+            return launchableBundleNames(for: cask).contains {
+                snapshot.detectedApplicationsByBundleName[$0] != nil
             }
         }
         let hasStoreApp = snapshot.installationIndex.catalogTokens.contains(cask.token)
@@ -198,14 +197,14 @@ struct CaskLocalStateResolver {
     }
 
     func existingBundleURL(named names: [String]) -> URL? {
-        let nameSet = Set(names)
-        if let detected = snapshot.detectedApplications.first(where: {
-            nameSet.contains($0.bundleName)
-                && applicationDiscovery.metadata(
+        if let detected = names.lazy
+            .flatMap({ snapshot.detectedApplicationsByBundleName[$0] ?? [] })
+            .first(where: {
+                applicationDiscovery.metadata(
                     at: $0.url,
                     fileManager: fileManager
                 ) != nil
-        }) {
+            }) {
             return detected.url
         }
 
@@ -239,19 +238,16 @@ struct CaskLocalStateResolver {
         if snapshot.installationIndex.catalogTokens.contains(cask.token) {
             return snapshot.installationIndex.macAppStoreApplications[cask.token]
         }
-        let matchingNames = Set(
-            cask.appArtifactNames + cask.packageAppNameCandidates
-        )
-        return snapshot.detectedApplications.first { application in
-            guard application.isMacAppStore,
-                  matchingNames.contains(application.bundleName)
-            else { return false }
-            guard cask.hasPackageArtifact else { return true }
-            guard let bundleIdentifier = application.bundleIdentifier else {
-                return false
+        return (cask.appArtifactNames + cask.packageAppNameCandidates).lazy
+            .flatMap { snapshot.detectedApplicationsByBundleName[$0] ?? [] }
+            .first { application in
+                guard application.isMacAppStore else { return false }
+                guard cask.hasPackageArtifact else { return true }
+                guard let bundleIdentifier = application.bundleIdentifier else {
+                    return false
+                }
+                return storeBundleIdentifier(bundleIdentifier, matches: cask)
             }
-            return storeBundleIdentifier(bundleIdentifier, matches: cask)
-        }
     }
 
     private func storeBundleIdentifier(

--- a/CaskHub/Services/Homebrew/Domain/InstallationSnapshot.swift
+++ b/CaskHub/Services/Homebrew/Domain/InstallationSnapshot.swift
@@ -13,6 +13,10 @@ nonisolated struct ApplicationInstallationSnapshot: Sendable {
     let macAppStoreAppNames: Set<String>
     let macAppStoreBundleIdentifiers: [String: Set<String>]
     let detectedApplications: [DetectedApplication]
+    /// Built once per scan so per-cask resolver lookups stay O(1); linear
+    /// scans over detectedApplications inside view bodies were hang material
+    /// (CASKHUB-Z / CASKHUB-23).
+    let detectedApplicationsByBundleName: [String: [DetectedApplication]]
 
     init(
         externalAppNames: Set<String> = [],
@@ -26,6 +30,9 @@ nonisolated struct ApplicationInstallationSnapshot: Sendable {
         self.macAppStoreAppNames = macAppStoreAppNames
         self.macAppStoreBundleIdentifiers = macAppStoreBundleIdentifiers
         self.detectedApplications = detectedApplications
+        detectedApplicationsByBundleName = Dictionary(
+            grouping: detectedApplications, by: \.bundleName
+        )
     }
 
     static let empty = ApplicationInstallationSnapshot()
@@ -58,6 +65,10 @@ nonisolated struct InstallationSnapshot: Sendable {
 
     var detectedApplications: [DetectedApplication] {
         applications.detectedApplications
+    }
+
+    var detectedApplicationsByBundleName: [String: [DetectedApplication]] {
+        applications.detectedApplicationsByBundleName
     }
 
     init(

--- a/CaskHub/Services/Homebrew/Domain/InstallationSnapshot.swift
+++ b/CaskHub/Services/Homebrew/Domain/InstallationSnapshot.swift
@@ -13,9 +13,7 @@ nonisolated struct ApplicationInstallationSnapshot: Sendable {
     let macAppStoreAppNames: Set<String>
     let macAppStoreBundleIdentifiers: [String: Set<String>]
     let detectedApplications: [DetectedApplication]
-    /// Built once per scan so per-cask resolver lookups stay O(1); linear
-    /// scans over detectedApplications inside view bodies were hang material
-    /// (CASKHUB-Z / CASKHUB-23).
+    /// Built once per scan so per-cask resolver lookups stay O(1).
     let detectedApplicationsByBundleName: [String: [DetectedApplication]]
 
     init(

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -308,9 +308,7 @@ enum LocalHomebrewError: LocalizedError {
     }
 
     private static let failurePatterns: [(fragment: String, classification: String)] = [
-        // First: a declined askpass prompt is the terminal cause even when the
-        // stderr also carries fragments of later patterns (e.g. brew's
-        // incidental "already a Binary at" warnings).
+        // First: a declined prompt outranks incidental fragments below it.
         ("sudo: no password was provided", "sudo-declined"),
         ("sudo: a password is required", "sudo-declined"),
         ("is not there", "missing-artifact-source"),

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -308,6 +308,11 @@ enum LocalHomebrewError: LocalizedError {
     }
 
     private static let failurePatterns: [(fragment: String, classification: String)] = [
+        // First: a declined askpass prompt is the terminal cause even when the
+        // stderr also carries fragments of later patterns (e.g. brew's
+        // incidental "already a Binary at" warnings).
+        ("sudo: no password was provided", "sudo-declined"),
+        ("sudo: a password is required", "sudo-declined"),
         ("is not there", "missing-artifact-source"),
         ("different from the one being installed", "adopt-version-mismatch"),
         ("No Cask with this name exists", "unknown-cask"),
@@ -328,7 +333,8 @@ enum LocalHomebrewError: LocalizedError {
         "checksum-mismatch",
         "network-failure",
         "permission-denied",
-        "stranded-caskroom-app"
+        "stranded-caskroom-app",
+        "sudo-declined"
     ]
 
     /// A previous interrupted operation parked the real .app inside the Caskroom
@@ -361,6 +367,10 @@ enum LocalHomebrewError: LocalizedError {
                 return "Your installed copy doesn't match the version Homebrew has on record, "
                     + "so it can't be adopted as-is. You can replace it with Homebrew's copy "
                     + "instead — your settings and data are kept."
+            }
+            if Self.failureClass(stderr: trimmed) == "sudo-declined" {
+                return "This step needs your administrator password. "
+                    + "Try again and enter your password when CaskHub asks for it."
             }
             if trimmed.contains("reports different checksum") || trimmed.contains("SHA256 mismatch") {
                 return "The download doesn't match the checksum Homebrew has on record — "

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
@@ -18,10 +18,13 @@ extension LocalHomebrewService {
     }
 
     func uninstall(token: String) async throws {
+        // Zombie entries lack brew's timestamped caskfile, so plain uninstall
+        // is rejected with "Cask 'x' is not installed"; --force still works.
+        let force = installedCasks[token]?.isZombie == true
         try await runMutation(
             .uninstalling,
             token: token,
-            args: ["uninstall", "--cask", token],
+            args: ["uninstall", "--cask", token] + (force ? ["--force"] : []),
             origin: .individual
         )
     }

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
@@ -18,8 +18,7 @@ extension LocalHomebrewService {
     }
 
     func uninstall(token: String) async throws {
-        // Zombie entries lack brew's timestamped caskfile, so plain uninstall
-        // is rejected with "Cask 'x' is not installed"; --force still works.
+        // Brew rejects plain uninstall for caskfile-less zombies; --force works.
         let force = installedCasks[token]?.isZombie == true
         try await runMutation(
             .uninstalling,

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
@@ -256,6 +256,12 @@ extension HomebrewInstallationScanner {
                     let fileSize = values.fileSize,
                     fileSize > 0
                 else { continue }
+                // A symlink into an app bundle belongs to that app, not to a
+                // standalone CLI — OrbStack's docker shims otherwise mark
+                // docker-desktop as installed. App ownership is attributed
+                // by the application scan with real bundle matching.
+                guard !entry.resolvingSymlinksInPath().path.contains(".app/")
+                else { continue }
                 if paths[entry.lastPathComponent] == nil {
                     paths[entry.lastPathComponent] = entry
                 }

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
@@ -256,10 +256,7 @@ extension HomebrewInstallationScanner {
                     let fileSize = values.fileSize,
                     fileSize > 0
                 else { continue }
-                // A symlink into an app bundle belongs to that app, not to a
-                // standalone CLI — OrbStack's docker shims otherwise mark
-                // docker-desktop as installed. App ownership is attributed
-                // by the application scan with real bundle matching.
+                // Shims into app bundles belong to that app (OrbStack docker).
                 guard !entry.resolvingSymlinksInPath().path.contains(".app/")
                 else { continue }
                 if paths[entry.lastPathComponent] == nil {

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -71,8 +71,7 @@ enum CrashReporter {
         if nsError.domain == NSURLErrorDomain, ignoredURLErrorCodes.contains(nsError.code) {
             return
         }
-        // Disk full is user state, not a defect — every write path (icon
-        // cache, settings) degrades gracefully.
+        // Disk full is user state — write paths degrade gracefully.
         if nsError.domain == NSCocoaErrorDomain,
            nsError.code == CocoaError.fileWriteOutOfSpace.rawValue {
             return
@@ -80,12 +79,13 @@ enum CrashReporter {
         if nsError.domain == NSPOSIXErrorDomain, nsError.code == Int(ENOSPC) {
             return
         }
-        // Truncated HTTP body (CDN hiccup) self-heals on the next refresh;
-        // real schema breaks throw keyNotFound/typeMismatch and still report.
+        // Truncated CDN body only; garbage-but-complete payloads still report.
         if case let DecodingError.dataCorrupted(context) = error,
            let underlying = context.underlyingError as NSError?,
            underlying.domain == NSCocoaErrorDomain,
-           underlying.code == NSPropertyListReadCorruptError {
+           underlying.code == NSPropertyListReadCorruptError,
+           (underlying.userInfo[NSDebugDescriptionErrorKey] as? String)?
+               .contains("Unexpected end of file") == true {
             return
         }
         let signature = "\(type(of: error)):\(nsError.domain):\(nsError.code)"

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -71,6 +71,23 @@ enum CrashReporter {
         if nsError.domain == NSURLErrorDomain, ignoredURLErrorCodes.contains(nsError.code) {
             return
         }
+        // Disk full is user state, not a defect — every write path (icon
+        // cache, settings) degrades gracefully.
+        if nsError.domain == NSCocoaErrorDomain,
+           nsError.code == CocoaError.fileWriteOutOfSpace.rawValue {
+            return
+        }
+        if nsError.domain == NSPOSIXErrorDomain, nsError.code == Int(ENOSPC) {
+            return
+        }
+        // Truncated HTTP body (CDN hiccup) self-heals on the next refresh;
+        // real schema breaks throw keyNotFound/typeMismatch and still report.
+        if case let DecodingError.dataCorrupted(context) = error,
+           let underlying = context.underlyingError as NSError?,
+           underlying.domain == NSCocoaErrorDomain,
+           underlying.code == NSPropertyListReadCorruptError {
+            return
+        }
         let signature = "\(type(of: error)):\(nsError.domain):\(nsError.code)"
         let count = captureCounts[signature, default: 0]
         guard count < captureLimit else { return }

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -76,9 +76,6 @@ enum CrashReporter {
            nsError.code == CocoaError.fileWriteOutOfSpace.rawValue {
             return
         }
-        if nsError.domain == NSPOSIXErrorDomain, nsError.code == Int(ENOSPC) {
-            return
-        }
         // Truncated CDN body only; garbage-but-complete payloads still report.
         if case let DecodingError.dataCorrupted(context) = error,
            let underlying = context.underlyingError as NSError?,

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -480,4 +480,22 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(garbled.analyticsPeriod, .days365)
         XCTAssertEqual(garbled.recentlyAddedWindow, .days30)
     }
+
+    @MainActor
+    func test_recent_tokens_memoize_and_invalidate_on_data_change() {
+        let service = RecentlyAddedService()
+        service.addedDates = [
+            "new-cask": dateString(daysAgo: 1),
+            "old-cask": dateString(daysAgo: 400)
+        ]
+        XCTAssertEqual(service.recentTokens(within: 30), ["new-cask"])
+        XCTAssertEqual(service.recentTokens(within: 30), ["new-cask"])
+
+        service.addedDates["another"] = dateString(daysAgo: 2)
+        XCTAssertEqual(
+            service.recentTokens(within: 30),
+            ["new-cask", "another"]
+        )
+        XCTAssertEqual(service.recentTokens(within: 90), ["new-cask", "another"])
+    }
 }

--- a/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
@@ -324,8 +324,6 @@ final class ZombieDetectionTests: XCTestCase {
         XCTAssertEqual(launcher.lastOpenedURL?.lastPathComponent, "ChatGPT.app")
     }
 
-    /// Plain `brew uninstall` rejects caskfile-less entries with
-    /// "Cask 'x' is not installed" — zombies must route through --force.
     @MainActor
     func test_zombie_uninstall_appends_force() async {
         let executor = RecordingHomebrewCommandExecutor()

--- a/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
@@ -324,6 +324,40 @@ final class ZombieDetectionTests: XCTestCase {
         XCTAssertEqual(launcher.lastOpenedURL?.lastPathComponent, "ChatGPT.app")
     }
 
+    /// Plain `brew uninstall` rejects caskfile-less entries with
+    /// "Cask 'x' is not installed" — zombies must route through --force.
+    @MainActor
+    func test_zombie_uninstall_appends_force() async {
+        let executor = RecordingHomebrewCommandExecutor()
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("zombie-uninstall-force")
+        ) {
+            $0.commandExecutor = executor
+            $0.softwareScanner = EmptyInstalledSoftwareScanner()
+            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
+            $0.brewVersionProvider = { "test" }
+        }
+        updateInstalledCask(LocalCaskInstallation(
+            token: "mole-app", installedVersion: "1.0", installedAt: nil,
+            appBundleNames: ["Mole.app"], isZombie: true
+        ), in: service)
+        try? await service.uninstall(token: "mole-app")
+        XCTAssertEqual(
+            executor.requests.last?.arguments,
+            ["uninstall", "--cask", "mole-app", "--force"]
+        )
+
+        updateInstalledCask(LocalCaskInstallation(
+            token: "chrome", installedVersion: "1.0", installedAt: nil,
+            appBundleNames: ["Chrome.app"], isZombie: false
+        ), in: service)
+        try? await service.uninstall(token: "chrome")
+        XCTAssertEqual(
+            executor.requests.last?.arguments,
+            ["uninstall", "--cask", "chrome"]
+        )
+    }
+
     @MainActor
     func test_zombies_never_offer_updates() {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("zombie-updates"))

--- a/CaskHubTests/Homebrew/Infrastructure/HomebrewCommandExecutorTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/HomebrewCommandExecutorTests.swift
@@ -72,15 +72,3 @@ private final class SuspendingHomebrewCommandExecutor: HomebrewCommandExecuting 
     }
 }
 
-private nonisolated struct EmptyInstalledSoftwareScanner: InstalledSoftwareScanning {
-    func scan(_ request: InstalledSoftwareScanRequest) async -> InstallationSnapshot {
-        .empty
-    }
-
-    func reconcileCatalog(
-        _ request: InstalledSoftwareScanRequest,
-        with current: InstallationSnapshot
-    ) async -> InstallationSnapshot {
-        current
-    }
-}

--- a/CaskHubTests/Homebrew/Infrastructure/HomebrewCommandExecutorTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/HomebrewCommandExecutorTests.swift
@@ -71,4 +71,3 @@ private final class SuspendingHomebrewCommandExecutor: HomebrewCommandExecuting 
         continuation = nil
     }
 }
-

--- a/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
+++ b/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
@@ -182,6 +182,16 @@ final class CaskHubTests: XCTestCase {
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
         }
 
+        let appBinary = root.appendingPathComponent("OrbStack.app/Contents/MacOS/xbin/docker")
+        try FileManager.default.createDirectory(
+            at: appBinary.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: appBinary.path, contents: Data("#!/bin/sh\n".utf8))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: appBinary.path)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("docker"), withDestinationURL: appBinary
+        )
+
         let scan = HomebrewInstallationScanner.scanBinaryDirectories(
             fileManager: FileManager.default,
             directories: [root]
@@ -189,6 +199,10 @@ final class CaskHubTests: XCTestCase {
         XCTAssertEqual(Set(scan.keys), ["copilot"])
         XCTAssertEqual(scan["copilot"]?.lastPathComponent, executable.lastPathComponent)
         XCTAssertNil(scan["stale-tool"], "zero-byte executable artifacts must be ignored")
+        XCTAssertNil(
+            scan["docker"],
+            "a shim into an app bundle belongs to that app, not a standalone CLI"
+        )
     }
 
     func test_apple_silicon_detection_matches_native_build_arch() {

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -284,6 +284,37 @@ final class RecordingApplicationLauncher: ApplicationLaunching {
     }
 }
 
+nonisolated struct EmptyInstalledSoftwareScanner: InstalledSoftwareScanning {
+    func scan(_ request: InstalledSoftwareScanRequest) async -> InstallationSnapshot {
+        .empty
+    }
+
+    func reconcileCatalog(
+        _ request: InstalledSoftwareScanRequest,
+        with current: InstallationSnapshot
+    ) async -> InstallationSnapshot {
+        current
+    }
+}
+
+@MainActor
+final class RecordingHomebrewCommandExecutor: HomebrewCommandExecuting {
+    private(set) var requests: [HomebrewCommandRequest] = []
+    var result = BrewProcessResult(exitCode: 0, output: "")
+
+    func execute(
+        _ request: HomebrewCommandRequest,
+        onStart: @escaping @MainActor @Sendable () -> Void,
+        onChunk _: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> BrewProcessResult {
+        requests.append(request)
+        onStart()
+        return result
+    }
+
+    func cancel(token _: String) -> Bool { false }
+}
+
 // MARK: - Crash-reporting spies
 
 final class SpyCrashSpan: CrashSpan {

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -300,7 +300,6 @@ nonisolated struct EmptyInstalledSoftwareScanner: InstalledSoftwareScanning {
 @MainActor
 final class RecordingHomebrewCommandExecutor: HomebrewCommandExecuting {
     private(set) var requests: [HomebrewCommandRequest] = []
-    var result = BrewProcessResult(exitCode: 0, output: "")
 
     func execute(
         _ request: HomebrewCommandRequest,
@@ -309,7 +308,7 @@ final class RecordingHomebrewCommandExecutor: HomebrewCommandExecuting {
     ) async throws -> BrewProcessResult {
         requests.append(request)
         onStart()
-        return result
+        return BrewProcessResult(exitCode: 0, output: "")
     }
 
     func cancel(token _: String) -> Bool { false }

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -132,22 +132,23 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_disk_full_and_truncated_payloads_are_never_captured() {
+        func corrupt(_ debug: String) -> DecodingError {
+            .dataCorrupted(DecodingError.Context(
+                codingPath: [],
+                debugDescription: "The given data was not valid JSON.",
+                underlyingError: NSError(
+                    domain: NSCocoaErrorDomain,
+                    code: NSPropertyListReadCorruptError,
+                    userInfo: [NSDebugDescriptionErrorKey: debug]
+                )
+            ))
+        }
+
         CrashReporter.capture(NSError(
             domain: NSCocoaErrorDomain,
             code: CocoaError.fileWriteOutOfSpace.rawValue
         ))
-        CrashReporter.capture(NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC)))
-        CrashReporter.capture(DecodingError.dataCorrupted(DecodingError.Context(
-            codingPath: [],
-            debugDescription: "The given data was not valid JSON.",
-            underlyingError: NSError(
-                domain: NSCocoaErrorDomain,
-                code: NSPropertyListReadCorruptError,
-                userInfo: [
-                    NSDebugDescriptionErrorKey: "Unexpected end of file during JSON parse."
-                ]
-            )
-        )))
+        CrashReporter.capture(corrupt("Unexpected end of file during JSON parse."))
         XCTAssertTrue(spy.capturedErrors.isEmpty)
 
         CrashReporter.capture(DecodingError.typeMismatch(
@@ -156,17 +157,7 @@ final class CrashReporterTests: XCTestCase {
         ))
         XCTAssertEqual(spy.capturedErrors.count, 1, "real schema breaks still report")
 
-        CrashReporter.capture(DecodingError.dataCorrupted(DecodingError.Context(
-            codingPath: [],
-            debugDescription: "The given data was not valid JSON.",
-            underlyingError: NSError(
-                domain: NSCocoaErrorDomain,
-                code: NSPropertyListReadCorruptError,
-                userInfo: [
-                    NSDebugDescriptionErrorKey: "Invalid value around line 1, column 0."
-                ]
-            )
-        )))
+        CrashReporter.capture(corrupt("Invalid value around line 1, column 0."))
         XCTAssertEqual(
             spy.capturedErrors.count, 2,
             "garbage-but-complete payloads are not truncation and still report"

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -198,7 +198,24 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertEqual(cls("curl: (6) Could not resolve host: example.com"), "network-failure")
         XCTAssertEqual(cls("It seems there is already a Binary at '/opt/homebrew/bin/x'."), "binary-conflict")
         XCTAssertEqual(cls("It seems there is already an App at '/Applications/X.app'."), "app-conflict")
+        XCTAssertEqual(cls("sudo: no password was provided"), "sudo-declined")
+        XCTAssertEqual(cls("sudo: a password is required"), "sudo-declined")
+        XCTAssertEqual(
+            cls("Warning: It seems there is already a Binary at '/usr/local/bin/docker'.\n"
+                + "sudo: a password is required"),
+            "sudo-declined",
+            "a declined prompt is the terminal cause even with incidental conflict warnings"
+        )
         XCTAssertEqual(cls("something novel"), "uncategorized")
+    }
+
+    func test_declined_sudo_prompt_is_not_reported() {
+        CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
+            args: ["uninstall", "--cask", "wetype"],
+            exitCode: 1,
+            stderr: "sudo: no password was provided\nsudo: a password is required"
+        ))
+        XCTAssertTrue(spy.capturedErrors.isEmpty)
     }
 
     func test_other_errors_keep_default_grouping() {

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -142,7 +142,10 @@ final class CrashReporterTests: XCTestCase {
             debugDescription: "The given data was not valid JSON.",
             underlyingError: NSError(
                 domain: NSCocoaErrorDomain,
-                code: NSPropertyListReadCorruptError
+                code: NSPropertyListReadCorruptError,
+                userInfo: [
+                    NSDebugDescriptionErrorKey: "Unexpected end of file during JSON parse."
+                ]
             )
         )))
         XCTAssertTrue(spy.capturedErrors.isEmpty)
@@ -152,6 +155,22 @@ final class CrashReporterTests: XCTestCase {
             DecodingError.Context(codingPath: [], debugDescription: "schema break")
         ))
         XCTAssertEqual(spy.capturedErrors.count, 1, "real schema breaks still report")
+
+        CrashReporter.capture(DecodingError.dataCorrupted(DecodingError.Context(
+            codingPath: [],
+            debugDescription: "The given data was not valid JSON.",
+            underlyingError: NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSPropertyListReadCorruptError,
+                userInfo: [
+                    NSDebugDescriptionErrorKey: "Invalid value around line 1, column 0."
+                ]
+            )
+        )))
+        XCTAssertEqual(
+            spy.capturedErrors.count, 2,
+            "garbage-but-complete payloads are not truncation and still report"
+        )
     }
 
     func test_recoverable_brew_failures_are_never_captured() {

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -131,6 +131,29 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertTrue(spy.capturedErrors.isEmpty)
     }
 
+    func test_disk_full_and_truncated_payloads_are_never_captured() {
+        CrashReporter.capture(NSError(
+            domain: NSCocoaErrorDomain,
+            code: CocoaError.fileWriteOutOfSpace.rawValue
+        ))
+        CrashReporter.capture(NSError(domain: NSPOSIXErrorDomain, code: Int(ENOSPC)))
+        CrashReporter.capture(DecodingError.dataCorrupted(DecodingError.Context(
+            codingPath: [],
+            debugDescription: "The given data was not valid JSON.",
+            underlyingError: NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSPropertyListReadCorruptError
+            )
+        )))
+        XCTAssertTrue(spy.capturedErrors.isEmpty)
+
+        CrashReporter.capture(DecodingError.typeMismatch(
+            String.self,
+            DecodingError.Context(codingPath: [], debugDescription: "schema break")
+        ))
+        XCTAssertEqual(spy.capturedErrors.count, 1, "real schema breaks still report")
+    }
+
     func test_recoverable_brew_failures_are_never_captured() {
         let failures = [
             "It seems the existing App is different from the one being installed.",


### PR DESCRIPTION
## Summary

Five fixes from the 0.6.9(466) Sentry audit (05/08 + 08/08 new-issue review), each traced to a verified mechanism before touching code.

| Commit | Sentry | Fix |
|---|---|---|
| 7221977 | CASKHUB-1H | Zombie Caskroom entries (missing timestamped caskfile) route through `brew uninstall --force` at the shared workflow — plain uninstall is guaranteed to fail with "Cask 'x' is not installed" |
| 4e429e1 | CASKHUB-K, CASKHUB-N | New `sudo-declined` failure class: a declined askpass prompt is the terminal cause even when stderr carries incidental conflict fragments; recoverable (stops reaching Sentry), friendly message. Askpass dialog gets floating window level + forced activation so it can't open behind other windows |
| 4038c70 | Reddit report | External CLI detection skips binaries whose symlink target lives inside an `.app` bundle — OrbStack's docker shims no longer mark `docker-desktop` as Installed |
| cf1c2f8 | CASKHUB-Z, CASKHUB-23 | `detectedApplicationsByBundleName` built once per scan; the three resolver fallbacks (`macAppStoreApplication`, `canOpen`, `existingBundleURL`) drop from linear scans over detected apps (~3 × catalog × O(apps) on the main thread inside SwiftUI bodies) to O(1) lookups |
| a53c48e | CASKHUB-2H, CASKHUB-2J, CASKHUB-2D | `recentTokens` memoized per (revision, window, day) instead of full-dictionary filter per projection recompute; disk-full writes (ENOSPC) and truncated CDN payloads filtered at the `CrashReporter.capture` choke point — schema breaks still report |

Deliberately skipped: moving the library projection off-main (the index removes the hang's actual cost; revisit only if 0.7.0 telemetry still shows the reduce hanging).

## Test plan

- [x] Full suite green (`xcodebuild test`, macOS destination)
- [x] New regression tests: zombie uninstall args, sudo-declined classification + suppression + precedence, app-bundle shim exclusion, recentTokens memoization/invalidation, disk-full + truncated-payload filtering (positive case: `typeMismatch` still reports)