### PR TITLE
fix: classify field-mined brew failures, repair stderr capture fidelity

### DIFF
--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -334,6 +334,13 @@ enum LocalHomebrewError: LocalizedError {
         // failures in download-failed phrasing.
         ("reports different checksum", "checksum-mismatch"),
         ("SHA256 mismatch", "checksum-mismatch"),
+        // Installer/dmg failures outrank the download family: vendor pkg
+        // scripts run curl themselves, and a stray curl error must not
+        // reclassify (and suppress) a real installer failure.
+        ("attach failed - Resource busy", "dmg-mount-busy"),
+        ("installer: The install failed", "pkg-installer-failed"),
+        ("installer: The upgrade failed", "pkg-installer-failed"),
+        ("/usr/sbin/installer -pkg", "pkg-installer-failed"),
         // HTTP errors (curl 22) split out: persistent 404s flag dead casks.
         ("The requested URL returned error:", "download-broken"),
         ("curl: (5)", "network-failure"),
@@ -358,10 +365,6 @@ enum LocalHomebrewError: LocalizedError {
         ("is already running", "brew-busy"),
         ("Please wait for it to finish", "brew-busy"),
         ("not writable by your user", "homebrew-not-writable"),
-        ("attach failed - Resource busy", "dmg-mount-busy"),
-        ("installer: The install failed", "pkg-installer-failed"),
-        ("installer: The upgrade failed", "pkg-installer-failed"),
-        ("/usr/sbin/installer -pkg", "pkg-installer-failed"),
         ("Error: Not upgrading", "upgrade-refused"),
         // Last: success text must never outrank a real error line above.
         ("successfully upgraded!", "exit-nonzero-after-success")

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -308,16 +308,13 @@ enum LocalHomebrewError: LocalizedError {
         if stderr.contains("uninstall script"), stderr.contains("does not exist") {
             return "missing-uninstall-script"
         }
-        if let exitCode, killedExitCodes.contains(exitCode),
+        if let exitCode, [9, 15, 130].contains(exitCode),  // SIGKILL/SIGTERM/SIGINT
            stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return "process-killed"
         }
         return failurePatterns.first { stderr.contains($0.fragment) }?.classification
             ?? "uncategorized"
     }
-
-    /// SIGKILL, SIGTERM, SIGINT — brew died without writing a word.
-    private static let killedExitCodes: Set<Int32> = [9, 15, 130]
 
     private static let failurePatterns: [(fragment: String, classification: String)] = [
         // First: a failed prompt outranks incidental fragments below it.
@@ -330,13 +327,10 @@ enum LocalHomebrewError: LocalizedError {
         ("No Cask with this name exists", "unknown-cask"),
         ("No casks found", "unknown-cask"),
         ("is not installed", "not-installed"),
-        // Checksum outranks the download fragments — brew wraps some checksum
-        // failures in download-failed phrasing.
+        // Checksum above the download family: brew wraps some in download phrasing.
         ("reports different checksum", "checksum-mismatch"),
         ("SHA256 mismatch", "checksum-mismatch"),
-        // Installer/dmg failures outrank the download family: vendor pkg
-        // scripts run curl themselves, and a stray curl error must not
-        // reclassify (and suppress) a real installer failure.
+        // Installer/dmg above the download family: vendor pkg scripts run curl too.
         ("attach failed - Resource busy", "dmg-mount-busy"),
         ("installer: The install failed", "pkg-installer-failed"),
         ("installer: The upgrade failed", "pkg-installer-failed"),
@@ -353,8 +347,6 @@ enum LocalHomebrewError: LocalizedError {
         ("curl: (92)", "network-failure"),
         ("Cannot download non-corrupt", "brew-api-unavailable"),
         ("Download failed on Cask", "download-failed"),
-        // brew's --force overwrite *warning* reuses these sentences with a
-        // "; overwriting." suffix — HomebrewOutputDiagnostics strips those lines.
         ("already a Binary at", "binary-conflict"),
         ("already an App at", "app-conflict"),
         ("conflicts with", "cask-conflict"),

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -294,36 +294,77 @@ enum LocalHomebrewError: LocalizedError {
             return false
         case .appBundleNotFound:
             return true
-        case let .brewCommandFailed(_, _, stderr):
-            return !Self.recoverableFailureClasses.contains(Self.failureClass(stderr: stderr))
+        case let .brewCommandFailed(_, code, stderr):
+            return !Self.recoverableFailureClasses.contains(
+                Self.failureClass(stderr: stderr, exitCode: code)
+            )
         }
     }
 
     /// Coarse classes for Sentry grouping — one issue per way brew fails, not per cask.
-    static func failureClass(stderr: String) -> String {
+    static func failureClass(stderr: String, exitCode: Int32? = nil) -> String {
         if isStrandedApp(stderr: stderr) { return "stranded-caskroom-app" }
         if isAppManagementDenial(stderr: stderr) { return "permission-denied" }
+        if stderr.contains("uninstall script"), stderr.contains("does not exist") {
+            return "missing-uninstall-script"
+        }
+        if let exitCode, killedExitCodes.contains(exitCode),
+           stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "process-killed"
+        }
         return failurePatterns.first { stderr.contains($0.fragment) }?.classification
             ?? "uncategorized"
     }
 
+    /// SIGKILL, SIGTERM, SIGINT — brew died without writing a word.
+    private static let killedExitCodes: Set<Int32> = [9, 15, 130]
+
     private static let failurePatterns: [(fragment: String, classification: String)] = [
-        // First: a declined prompt outranks incidental fragments below it.
+        // First: a failed prompt outranks incidental fragments below it.
         ("sudo: no password was provided", "sudo-declined"),
         ("sudo: a password is required", "sudo-declined"),
+        ("incorrect password attempt", "sudo-wrong-password"),
+        ("is not in the sudoers file", "sudo-not-admin"),
         ("is not there", "missing-artifact-source"),
         ("different from the one being installed", "adopt-version-mismatch"),
         ("No Cask with this name exists", "unknown-cask"),
         ("No casks found", "unknown-cask"),
         ("is not installed", "not-installed"),
+        // Checksum outranks the download fragments — brew wraps some checksum
+        // failures in download-failed phrasing.
         ("reports different checksum", "checksum-mismatch"),
         ("SHA256 mismatch", "checksum-mismatch"),
+        // HTTP errors (curl 22) split out: persistent 404s flag dead casks.
+        ("The requested URL returned error:", "download-broken"),
         ("curl: (5)", "network-failure"),
         ("curl: (6)", "network-failure"),
         ("curl: (7)", "network-failure"),
+        ("curl: (18)", "network-failure"),
         ("curl: (28)", "network-failure"),
+        ("curl: (35)", "network-failure"),
+        ("curl: (56)", "network-failure"),
+        ("curl: (92)", "network-failure"),
+        ("Cannot download non-corrupt", "brew-api-unavailable"),
+        ("Download failed on Cask", "download-failed"),
+        // brew's --force overwrite *warning* reuses these sentences with a
+        // "; overwriting." suffix — HomebrewOutputDiagnostics strips those lines.
         ("already a Binary at", "binary-conflict"),
-        ("already an App at", "app-conflict")
+        ("already an App at", "app-conflict"),
+        ("conflicts with", "cask-conflict"),
+        ("Refusing to uninstall", "cask-dependency"),
+        ("This cask does not run on macOS versions", "platform-unsupported"),
+        ("depends on hardware architecture", "platform-unsupported"),
+        ("requires Linux", "platform-unsupported"),
+        ("is already running", "brew-busy"),
+        ("Please wait for it to finish", "brew-busy"),
+        ("not writable by your user", "homebrew-not-writable"),
+        ("attach failed - Resource busy", "dmg-mount-busy"),
+        ("installer: The install failed", "pkg-installer-failed"),
+        ("installer: The upgrade failed", "pkg-installer-failed"),
+        ("/usr/sbin/installer -pkg", "pkg-installer-failed"),
+        ("Error: Not upgrading", "upgrade-refused"),
+        // Last: success text must never outrank a real error line above.
+        ("successfully upgraded!", "exit-nonzero-after-success")
     ]
 
     private static let recoverableFailureClasses: Set<String> = [
@@ -332,7 +373,8 @@ enum LocalHomebrewError: LocalizedError {
         "network-failure",
         "permission-denied",
         "stranded-caskroom-app",
-        "sudo-declined"
+        "sudo-declined",
+        "sudo-wrong-password"
     ]
 
     /// A previous interrupted operation parked the real .app inside the Caskroom
@@ -366,9 +408,21 @@ enum LocalHomebrewError: LocalizedError {
                     + "so it can't be adopted as-is. You can replace it with Homebrew's copy "
                     + "instead — your settings and data are kept."
             }
-            if Self.failureClass(stderr: trimmed) == "sudo-declined" {
+            switch Self.failureClass(stderr: trimmed, exitCode: code) {
+            case "sudo-declined":
                 return "This step needs your administrator password. "
                     + "Try again and enter your password when CaskHub asks for it."
+            case "sudo-wrong-password":
+                return "The password wasn't accepted. "
+                    + "Try again and re-enter your administrator password."
+            case "sudo-not-admin":
+                return "This step needs an administrator account. "
+                    + "Your macOS user doesn't have administrator rights, so Homebrew "
+                    + "can't complete it."
+            case "process-killed":
+                return "The operation was interrupted before it finished. Try again."
+            default:
+                break
             }
             if trimmed.contains("reports different checksum") || trimmed.contains("SHA256 mismatch") {
                 return "The download doesn't match the checksum Homebrew has on record — "
@@ -384,7 +438,8 @@ enum LocalHomebrewError: LocalizedError {
 
     /// The App Management (TCC) permission gating modification of other apps' bundles.
     static func isAppManagementDenial(stderr: String) -> Bool {
-        stderr.components(separatedBy: .newlines).contains { line in
+        if stderr.contains("does not have App Management permissions") { return true }
+        return stderr.components(separatedBy: .newlines).contains { line in
             line.contains("Operation not permitted")
                 && line.contains("/Applications/")
                 && line.contains(".app")

--- a/CaskHub/Services/Homebrew/Infrastructure/BrewOutputCollector.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/BrewOutputCollector.swift
@@ -96,8 +96,7 @@ nonisolated final class BrewOutputCollector: @unchecked Sendable {
         } else {
             stripped = text
         }
-        // The pty's ONLCR already turned \n into \r\n; fold that back first or
-        // every line doubles and halves the useful tail.
+        // The pty's ONLCR emits \r\n; fold it first or every line doubles.
         return stripped
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")

--- a/CaskHub/Services/Homebrew/Infrastructure/BrewOutputCollector.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/BrewOutputCollector.swift
@@ -85,7 +85,7 @@ nonisolated final class BrewOutputCollector: @unchecked Sendable {
         pattern: "\u{001B}\\[[0-?]*[ -/]*[@-~]"
     )
 
-    private static func plainText(_ text: String) -> String {
+    static func plainText(_ text: String) -> String {
         let stripped: String
         if let ansiEscapes {
             stripped = ansiEscapes.stringByReplacingMatches(
@@ -96,6 +96,10 @@ nonisolated final class BrewOutputCollector: @unchecked Sendable {
         } else {
             stripped = text
         }
-        return stripped.replacingOccurrences(of: "\r", with: "\n")
+        // The pty's ONLCR already turned \n into \r\n; fold that back first or
+        // every line doubles and halves the useful tail.
+        return stripped
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
     }
 }

--- a/CaskHub/Services/Homebrew/Infrastructure/BrewProcessRunner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/BrewProcessRunner.swift
@@ -45,8 +45,7 @@ final class SystemBrewProcessRunner: BrewProcessRunning {
         if let terminal {
             var terminalEnvironment = environment
             terminalEnvironment["TERM"] = "xterm-256color"
-            // brew sizes output via `stty size` (fails: stdin is nulled) then
-            // `tput cols`, which honors COLUMNS — without it every line clips at 80.
+            // stty can't size the pty (stdin nulled); tput honors COLUMNS, else 80-col clipping.
             terminalEnvironment["COLUMNS"] = "180"
             process.environment = terminalEnvironment
             process.standardOutput = terminal.childHandle

--- a/CaskHub/Services/Homebrew/Infrastructure/BrewProcessRunner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/BrewProcessRunner.swift
@@ -45,6 +45,9 @@ final class SystemBrewProcessRunner: BrewProcessRunning {
         if let terminal {
             var terminalEnvironment = environment
             terminalEnvironment["TERM"] = "xterm-256color"
+            // brew sizes output via `stty size` (fails: stdin is nulled) then
+            // `tput cols`, which honors COLUMNS — without it every line clips at 80.
+            terminalEnvironment["COLUMNS"] = "180"
             process.environment = terminalEnvironment
             process.standardOutput = terminal.childHandle
             process.standardError = terminal.childHandle

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewOutputDiagnostics.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewOutputDiagnostics.swift
@@ -11,13 +11,42 @@ nonisolated enum HomebrewOutputDiagnostics {
     static func make(from output: String) -> String {
         let trimmed = stripProgressNoise(from: output)
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Sentry keeps the head of long messages while we keep the tail — slice
+        // long payloads to the last Error: line so preambles can't push it past
+        // Sentry's cap.
+        if trimmed.count > 1_200,
+           let range = trimmed.range(of: "\nError:", options: .backwards) {
+            return String(trimmed[trimmed.index(after: range.lowerBound)...].suffix(4_000))
+        }
         return String(trimmed.suffix(4_000))
     }
 
-    /// Drops brew's \r progress frames so the error line stays classifiable.
+    /// Drops brew's \r progress frames and the multi-KB tap-trust advisory so
+    /// the error line stays classifiable.
     static func stripProgressNoise(from output: String) -> String {
-        output.components(separatedBy: .newlines)
-            .filter { !isProgressFrame($0) }
+        var insideTapTrustAdvisory = false
+        return output.components(separatedBy: .newlines)
+            .filter { line in
+                if line.contains("The following taps are not trusted") {
+                    insideTapTrustAdvisory = true
+                }
+                if insideTapTrustAdvisory {
+                    if line.contains("docs.brew.sh/Tap-Trust") {
+                        insideTapTrustAdvisory = false
+                        return false
+                    }
+                    // Escape hatch: a truncated advisory must not swallow the error.
+                    if line.hasPrefix("Error:") || line.hasPrefix("==>") {
+                        insideTapTrustAdvisory = false
+                    } else {
+                        return false
+                    }
+                }
+                // --force overwrite warnings reuse the conflict-error sentence;
+                // keeping them misclassifies unrelated --force failures.
+                if line.contains("; overwriting.") { return false }
+                return !isProgressFrame(line)
+            }
             .joined(separator: "\n")
     }
 

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewOutputDiagnostics.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewOutputDiagnostics.swift
@@ -12,14 +12,31 @@ nonisolated enum HomebrewOutputDiagnostics {
         let trimmed = stripProgressNoise(from: output)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         // Sentry keeps the head of long messages while we keep the tail — slice
-        // long payloads to the last Error: line so preambles can't push it past
-        // Sentry's cap.
+        // long payloads near the last Error: line so preambles can't push it past
+        // Sentry's cap. Keep some context above it: the root cause (sudo:,
+        // hdiutil:, installer:) prints BEFORE brew's final "Failure while
+        // executing" wrapper, and classification runs on this sliced text.
         if trimmed.count > 1_200,
-           let range = trimmed.range(of: "\nError:", options: .backwards) {
-            return String(trimmed[trimmed.index(after: range.lowerBound)...].suffix(4_000))
+           let range = trimmed.range(of: "\nError:", options: .backwards),
+           let contextStart = trimmed.index(
+               range.lowerBound, offsetBy: -600, limitedBy: trimmed.startIndex
+           ) {
+            let sliced = trimmed[contextStart...].drop { $0 != "\n" }.dropFirst()
+            return String(sliced.suffix(4_000))
         }
         return String(trimmed.suffix(4_000))
     }
+
+    /// Advisory body lines matched individually as well: the collector strips
+    /// per pty chunk, so block state alone leaks lines whose trigger line
+    /// arrived in an earlier chunk.
+    private static let tapTrustNoiseMarkers = [
+        "taps are not trusted",
+        "tap trust is required",
+        "To trust these taps",
+        "brew trust ",
+        "docs.brew.sh/Tap-Trust"
+    ]
 
     /// Drops brew's \r progress frames and the multi-KB tap-trust advisory so
     /// the error line stays classifiable.
@@ -42,6 +59,8 @@ nonisolated enum HomebrewOutputDiagnostics {
                         return false
                     }
                 }
+                if !line.hasPrefix("Error:"),
+                   tapTrustNoiseMarkers.contains(where: line.contains) { return false }
                 // --force overwrite warnings reuse the conflict-error sentence;
                 // keeping them misclassifies unrelated --force failures.
                 if line.contains("; overwriting.") { return false }

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewOutputDiagnostics.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewOutputDiagnostics.swift
@@ -11,11 +11,8 @@ nonisolated enum HomebrewOutputDiagnostics {
     static func make(from output: String) -> String {
         let trimmed = stripProgressNoise(from: output)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        // Sentry keeps the head of long messages while we keep the tail — slice
-        // long payloads near the last Error: line so preambles can't push it past
-        // Sentry's cap. Keep some context above it: the root cause (sudo:,
-        // hdiutil:, installer:) prints BEFORE brew's final "Failure while
-        // executing" wrapper, and classification runs on this sliced text.
+        // Sentry caps long messages from the head; keep the root-cause lines
+        // that print just above brew's final Error: wrapper.
         if trimmed.count > 1_200,
            let range = trimmed.range(of: "\nError:", options: .backwards),
            let contextStart = trimmed.index(
@@ -27,42 +24,34 @@ nonisolated enum HomebrewOutputDiagnostics {
         return String(trimmed.suffix(4_000))
     }
 
-    /// Advisory body lines matched individually as well: the collector strips
-    /// per pty chunk, so block state alone leaks lines whose trigger line
-    /// arrived in an earlier chunk.
+    /// Matched per line — the collector strips per pty chunk, so a block
+    /// trigger can arrive in a different chunk than its body.
     private static let tapTrustNoiseMarkers = [
         "taps are not trusted",
         "tap trust is required",
+        "Prefer trusting only",
+        "these taps with:",
         "To trust these taps",
         "brew trust ",
+        "Whole-tap trust",
+        "Trust whole taps",
+        "Untap them with:",
+        "brew untap ",
+        "To disable trust checks",
+        "HOMEBREW_NO_REQUIRE_TAP_TRUST",
+        "not recommended and will be removed",
+        "For more information, see:",
         "docs.brew.sh/Tap-Trust"
     ]
 
     /// Drops brew's \r progress frames and the multi-KB tap-trust advisory so
     /// the error line stays classifiable.
     static func stripProgressNoise(from output: String) -> String {
-        var insideTapTrustAdvisory = false
-        return output.components(separatedBy: .newlines)
+        output.components(separatedBy: .newlines)
             .filter { line in
-                if line.contains("The following taps are not trusted") {
-                    insideTapTrustAdvisory = true
-                }
-                if insideTapTrustAdvisory {
-                    if line.contains("docs.brew.sh/Tap-Trust") {
-                        insideTapTrustAdvisory = false
-                        return false
-                    }
-                    // Escape hatch: a truncated advisory must not swallow the error.
-                    if line.hasPrefix("Error:") || line.hasPrefix("==>") {
-                        insideTapTrustAdvisory = false
-                    } else {
-                        return false
-                    }
-                }
                 if !line.hasPrefix("Error:"),
                    tapTrustNoiseMarkers.contains(where: line.contains) { return false }
-                // --force overwrite warnings reuse the conflict-error sentence;
-                // keeping them misclassifies unrelated --force failures.
+                // brew's --force overwrite warning reuses the conflict-error sentence.
                 if line.contains("; overwriting.") { return false }
                 return !isProgressFrame(line)
             }

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -156,9 +156,13 @@ final class SentryProvider: CrashReporterProvider {
     /// domain+code — one issue per way brew fails, so a rare destructive failure
     /// can't hide inside a busy catch-all group.
     static func fingerprint(for error: Error) -> [String]? {
-        guard case let LocalHomebrewError.brewCommandFailed(args, _, stderr) = error,
+        guard case let LocalHomebrewError.brewCommandFailed(args, exitCode, stderr) = error,
               let subcommand = args.first else { return nil }
-        return ["brewCommandFailed", subcommand, LocalHomebrewError.failureClass(stderr: stderr)]
+        return [
+            "brewCommandFailed",
+            subcommand,
+            LocalHomebrewError.failureClass(stderr: stderr, exitCode: exitCode)
+        ]
     }
 
     func setTag(_ key: String, value: String) {

--- a/CaskHubTests/Homebrew/Infrastructure/HomebrewOutputDiagnosticsTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/HomebrewOutputDiagnosticsTests.swift
@@ -64,6 +64,55 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
         XCTAssertLessThanOrEqual(result.count, 4_000)
     }
 
+    func test_tap_trust_advisory_block_is_stripped() {
+        let output = """
+        Warning: The following taps are not trusted:
+          lihaoyun6/tap
+        Homebrew is currently ignoring formulae, casks and commands from these taps \
+        because tap trust is required.
+        To trust these taps, run:
+          brew trust lihaoyun6/tap
+          https://docs.brew.sh/Tap-Trust
+        Error: quickrecorder: Download failed on Cask 'quickrecorder'
+        """
+        let result = HomebrewOutputDiagnostics.make(from: output)
+        XCTAssertEqual(result, "Error: quickrecorder: Download failed on Cask 'quickrecorder'")
+    }
+
+    func test_truncated_tap_trust_advisory_does_not_swallow_the_error() {
+        let output = """
+        Warning: The following taps are not trusted:
+          lihaoyun6/tap
+        Error: something real broke
+        """
+        let result = HomebrewOutputDiagnostics.make(from: output)
+        XCTAssertEqual(result, "Error: something real broke")
+    }
+
+    func test_force_overwrite_warnings_are_stripped() {
+        let output = """
+        Warning: It seems there is already an App at '/Applications/MacDown.app'; overwriting.
+        Error: Failure while executing; `/usr/bin/sudo -A -E -- /bin/rm -f -- x` exited with 1.
+        """
+        let result = HomebrewOutputDiagnostics.make(from: output)
+        XCTAssertFalse(result.contains("already an App at"))
+        XCTAssertNotEqual(LocalHomebrewError.failureClass(stderr: result), "app-conflict")
+    }
+
+    func test_long_payload_slices_from_the_last_error_line() {
+        let preamble = (0..<60).map { "==> Installing dependency step \($0)" }
+            .joined(separator: "\n")
+        let output = preamble + "\nError: the decisive line\nfollow-up detail"
+        let result = HomebrewOutputDiagnostics.make(from: output)
+        XCTAssertTrue(result.hasPrefix("Error: the decisive line"))
+        XCTAssertTrue(result.hasSuffix("follow-up detail"))
+    }
+
+    func test_short_payload_keeps_context_above_the_error_line() {
+        let output = "==> Installing Cask foo\nError: the decisive line"
+        XCTAssertEqual(HomebrewOutputDiagnostics.make(from: output), output)
+    }
+
     func test_error_line_survives_a_trailing_progress_flood() {
         let frames = (0 ..< 100).map { _ in
             "Extracting  205.4MB/205.4MB⠴ Cask parallels (26.4.0-57513)"

--- a/CaskHubTests/Homebrew/Infrastructure/HomebrewOutputDiagnosticsTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/HomebrewOutputDiagnosticsTests.swift
@@ -99,13 +99,46 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
         XCTAssertNotEqual(LocalHomebrewError.failureClass(stderr: result), "app-conflict")
     }
 
-    func test_long_payload_slices_from_the_last_error_line() {
+    func test_long_payload_slices_near_the_last_error_line_keeping_context() {
         let preamble = (0..<60).map { "==> Installing dependency step \($0)" }
             .joined(separator: "\n")
         let output = preamble + "\nError: the decisive line\nfollow-up detail"
         let result = HomebrewOutputDiagnostics.make(from: output)
-        XCTAssertTrue(result.hasPrefix("Error: the decisive line"))
+        XCTAssertTrue(result.contains("Error: the decisive line"))
         XCTAssertTrue(result.hasSuffix("follow-up detail"))
+        XCTAssertFalse(result.contains("step 0"), "distant preamble is dropped")
+        XCTAssertLessThan(result.count, 700, "decisive line stays within Sentry's head cap")
+    }
+
+    func test_slice_keeps_subprocess_root_cause_above_the_wrapper_error() {
+        let preamble = (0..<50).map { "==> Running installer step \($0)" }
+            .joined(separator: "\n")
+        let output = preamble + "\nSorry, try again.\nSorry, try again.\n"
+            + "sudo: 3 incorrect password attempts\n"
+            + "Error: Failure while executing; `/usr/bin/sudo -A -E -- "
+            + "/usr/sbin/installer -pkg /private/tmp/x.pkg -target /` exited with 1."
+        let result = HomebrewOutputDiagnostics.make(from: output)
+        XCTAssertTrue(result.contains("sudo: 3 incorrect password attempts"))
+        XCTAssertEqual(
+            LocalHomebrewError.failureClass(stderr: result),
+            "sudo-wrong-password",
+            "slicing must not strip the lines classification depends on"
+        )
+    }
+
+    func test_tap_trust_lines_are_stripped_even_without_their_trigger_line() {
+        // The collector strips per pty chunk — advisory body lines can arrive
+        // in a chunk whose trigger line was already consumed.
+        let orphanedAdvisory = """
+        Homebrew is currently ignoring formulae, casks and commands from these \
+        taps because tap trust is required.
+        To trust these taps, run:
+          brew trust lihaoyun6/tap
+          https://docs.brew.sh/Tap-Trust
+        Error: something real broke
+        """
+        let result = HomebrewOutputDiagnostics.make(from: orphanedAdvisory)
+        XCTAssertEqual(result, "Error: something real broke")
     }
 
     func test_short_payload_keeps_context_above_the_error_line() {

--- a/CaskHubTests/Homebrew/Infrastructure/HomebrewOutputDiagnosticsTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/HomebrewOutputDiagnosticsTests.swift
@@ -64,7 +64,7 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
         XCTAssertLessThanOrEqual(result.count, 4_000)
     }
 
-    func test_tap_trust_advisory_block_is_stripped() {
+    func test_tap_trust_advisory_is_stripped_keeping_the_error() {
         let output = """
         Warning: The following taps are not trusted:
           lihaoyun6/tap
@@ -72,21 +72,20 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
         because tap trust is required.
         To trust these taps, run:
           brew trust lihaoyun6/tap
+        Untap them with:
+          brew untap lihaoyun6/tap
+        To disable trust checks:
+        export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+        This is not recommended and will be removed in a later release.
+        For more information, see:
           https://docs.brew.sh/Tap-Trust
         Error: quickrecorder: Download failed on Cask 'quickrecorder'
         """
         let result = HomebrewOutputDiagnostics.make(from: output)
-        XCTAssertEqual(result, "Error: quickrecorder: Download failed on Cask 'quickrecorder'")
-    }
-
-    func test_truncated_tap_trust_advisory_does_not_swallow_the_error() {
-        let output = """
-        Warning: The following taps are not trusted:
-          lihaoyun6/tap
-        Error: something real broke
-        """
-        let result = HomebrewOutputDiagnostics.make(from: output)
-        XCTAssertEqual(result, "Error: something real broke")
+        XCTAssertTrue(result.contains("Error: quickrecorder"))
+        XCTAssertFalse(result.contains("brew trust"))
+        XCTAssertFalse(result.contains("taps are not trusted"))
+        XCTAssertFalse(result.contains("HOMEBREW_NO_REQUIRE_TAP_TRUST"))
     }
 
     func test_force_overwrite_warnings_are_stripped() {
@@ -127,8 +126,6 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
     }
 
     func test_tap_trust_lines_are_stripped_even_without_their_trigger_line() {
-        // The collector strips per pty chunk — advisory body lines can arrive
-        // in a chunk whose trigger line was already consumed.
         let orphanedAdvisory = """
         Homebrew is currently ignoring formulae, casks and commands from these \
         taps because tap trust is required.

--- a/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
+++ b/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
@@ -301,6 +301,11 @@ final class CaskHubTests: XCTestCase {
         XCTAssertFalse(LocalHomebrewError.isAppManagementDenial(stderr: "curl: (6) Could not resolve host"))
     }
 
+    func test_output_collector_folds_pty_crlf_instead_of_doubling() {
+        XCTAssertEqual(BrewOutputCollector.plainText("line one\r\nline two\r\n"), "line one\nline two\n")
+        XCTAssertEqual(BrewOutputCollector.plainText("frame\rframe\r"), "frame\nframe\n")
+    }
+
     func test_output_collector_finishes_when_grandchild_keeps_pipe_open() async throws {
         // Reproduces the stuck adopt spinner: sh exits but its backgrounded child
         // inherits the pipe's write end, so EOF never arrives.

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -242,6 +242,121 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertEqual(cls("something novel"), "uncategorized")
     }
 
+    func test_failure_classes_cover_field_mined_brew_errors() {
+        func cls(_ stderr: String) -> String {
+            LocalHomebrewError.failureClass(stderr: stderr)
+        }
+        XCTAssertEqual(
+            cls("Sorry, try again.\nSorry, try again.\nsudo: 3 incorrect password attempts"),
+            "sudo-wrong-password"
+        )
+        XCTAssertEqual(
+            cls("user is not in the sudoers file.  This incident will be reported."),
+            "sudo-not-admin"
+        )
+        XCTAssertEqual(
+            cls("Error: tinymediamanager: Download failed on Cask 'tinymediamanager' "
+                + "with message: Download failed: https://example.com/tmm.dmg\n"
+                + "curl: (22) The requested URL returned error: 404"),
+            "download-broken"
+        )
+        XCTAssertEqual(
+            cls("Error: linearmouse: Download failed on Cask 'linearmouse' with message: "
+                + "Download failed: https://dl.linearmouse.org/v0.11.4/LinearMouse.dmg\n"
+                + "curl: (56) Recv failure: Connection reset by peer"),
+            "network-failure"
+        )
+        XCTAssertEqual(
+            cls("Error: Cannot download non-corrupt "
+                + "https://formulae.brew.sh/api/internal/packages.arm64_tahoe.jws.json!"),
+            "brew-api-unavailable"
+        )
+        XCTAssertEqual(
+            cls("Error: foo: Download failed on Cask 'foo' with message: mystery"),
+            "download-failed"
+        )
+        XCTAssertEqual(
+            cls("Error: microsoft-office: Cask 'microsoft-office' conflicts with 'microsoft-excel'."),
+            "cask-conflict"
+        )
+        XCTAssertEqual(
+            cls("Error: Refusing to uninstall pieces-os\n"
+                + "because it is required by pieces, which is currently installed."),
+            "cask-dependency"
+        )
+        XCTAssertEqual(
+            cls("Error: onyx: This cask does not run on macOS versions other than "
+                + "Catalina, Big Sur, Monterey, Ventura, Sonoma, Sequoia and Tahoe."),
+            "platform-unsupported"
+        )
+        XCTAssertEqual(cls("Error: Another `brew update` process is already running."), "brew-busy")
+        XCTAssertEqual(
+            cls("Error: A `brew uninstall --cask cursor --force` process has already locked "
+                + "/opt/homebrew/Cellar/llvm@21.\nPlease wait for it to finish or terminate it."),
+            "brew-busy"
+        )
+        XCTAssertEqual(
+            cls("Error: The following directories are not writable by your user:\n"
+                + "/opt/homebrew/share/man/man5"),
+            "homebrew-not-writable"
+        )
+    }
+
+    func test_failure_classes_cover_field_mined_installer_and_env_errors() {
+        func cls(_ stderr: String) -> String {
+            LocalHomebrewError.failureClass(stderr: stderr)
+        }
+        XCTAssertEqual(cls("hdiutil: attach failed - Resource busy"), "dmg-mount-busy")
+        XCTAssertEqual(
+            cls("installer: The upgrade failed. (The Installer encountered an error.)\n"
+                + "Error: Failure while executing; `/usr/bin/sudo -A -E -- "
+                + "/usr/sbin/installer -pkg /private/tmp/x.pkg -target /` exited with 1."),
+            "pkg-installer-failed"
+        )
+        XCTAssertEqual(cls("Error: Not upgrading 1 pinned package:\nmarkedit 1.33.0"), "upgrade-refused")
+        XCTAssertEqual(
+            cls("🍺  proton-mail was successfully upgraded!\n==> Upgraded 1 outdated package"),
+            "exit-nonzero-after-success"
+        )
+        XCTAssertEqual(
+            cls("Error: uninstall script /Applications/gpt4all/maintenancetool.app"
+                + "/Contents/MacOS/maintenancetool does not exist."),
+            "missing-uninstall-script"
+        )
+        XCTAssertEqual(
+            cls("Error: Cannot change the ownership of '/Applications/Tunnelblick.app' "
+                + "because your terminal does not have App Management permissions."),
+            "permission-denied"
+        )
+    }
+
+    func test_killed_process_with_silent_stderr_gets_its_own_class() {
+        XCTAssertEqual(LocalHomebrewError.failureClass(stderr: "", exitCode: 9), "process-killed")
+        XCTAssertEqual(LocalHomebrewError.failureClass(stderr: "", exitCode: 1), "uncategorized")
+        XCTAssertEqual(
+            LocalHomebrewError.failureClass(stderr: "Error: real failure", exitCode: 9),
+            "uncategorized",
+            "a kill with actual output classifies on the output"
+        )
+        let killed = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "stash"], exitCode: 9, stderr: ""
+        )
+        XCTAssertEqual(
+            SentryProvider.fingerprint(for: killed),
+            ["brewCommandFailed", "install", "process-killed"]
+        )
+        XCTAssertTrue(killed.shouldReport, "watch volume before deciding to suppress")
+    }
+
+    func test_wrong_sudo_password_is_not_reported() {
+        CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "arq"],
+            exitCode: 1,
+            stderr: "Sorry, try again.\nsudo: 3 incorrect password attempts"
+        ))
+        XCTAssertTrue(spy.capturedErrors.isEmpty)
+    }
+
     func test_declined_sudo_prompt_is_not_reported() {
         CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
             args: ["uninstall", "--cask", "wetype"],

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -216,10 +216,11 @@ final class CrashReporterTests: XCTestCase {
         )
     }
 
+    private func cls(_ stderr: String) -> String {
+        LocalHomebrewError.failureClass(stderr: stderr)
+    }
+
     func test_failure_classes_cover_observed_brew_errors() {
-        func cls(_ stderr: String) -> String {
-            LocalHomebrewError.failureClass(stderr: stderr)
-        }
         XCTAssertEqual(cls("Warning: Cask 'x' is unavailable: No Cask with this name exists."), "unknown-cask")
         XCTAssertEqual(cls("Error: Cask 'sequel-ace' is not installed."), "not-installed")
         XCTAssertEqual(
@@ -243,9 +244,6 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_failure_classes_cover_field_mined_brew_errors() {
-        func cls(_ stderr: String) -> String {
-            LocalHomebrewError.failureClass(stderr: stderr)
-        }
         XCTAssertEqual(
             cls("Sorry, try again.\nSorry, try again.\nsudo: 3 incorrect password attempts"),
             "sudo-wrong-password"
@@ -292,9 +290,6 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_failure_classes_cover_field_mined_brew_env_errors() {
-        func cls(_ stderr: String) -> String {
-            LocalHomebrewError.failureClass(stderr: stderr)
-        }
         XCTAssertEqual(cls("Error: Another `brew update` process is already running."), "brew-busy")
         XCTAssertEqual(
             cls("Error: A `brew uninstall --cask cursor --force` process has already locked "
@@ -309,9 +304,6 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_failure_classes_cover_field_mined_installer_and_env_errors() {
-        func cls(_ stderr: String) -> String {
-            LocalHomebrewError.failureClass(stderr: stderr)
-        }
         XCTAssertEqual(cls("hdiutil: attach failed - Resource busy"), "dmg-mount-busy")
         XCTAssertEqual(
             cls("installer: The upgrade failed. (The Installer encountered an error.)\n"

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -289,6 +289,12 @@ final class CrashReporterTests: XCTestCase {
                 + "Catalina, Big Sur, Monterey, Ventura, Sonoma, Sequoia and Tahoe."),
             "platform-unsupported"
         )
+    }
+
+    func test_failure_classes_cover_field_mined_brew_env_errors() {
+        func cls(_ stderr: String) -> String {
+            LocalHomebrewError.failureClass(stderr: stderr)
+        }
         XCTAssertEqual(cls("Error: Another `brew update` process is already running."), "brew-busy")
         XCTAssertEqual(
             cls("Error: A `brew uninstall --cask cursor --force` process has already locked "

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -319,6 +319,14 @@ final class CrashReporterTests: XCTestCase {
                 + "/usr/sbin/installer -pkg /private/tmp/x.pkg -target /` exited with 1."),
             "pkg-installer-failed"
         )
+        XCTAssertEqual(
+            cls("curl: (7) Failed to connect to updates.vendor.com port 443\n"
+                + "installer: The install failed. (The Installer encountered an error.)\n"
+                + "Error: Failure while executing; `/usr/bin/sudo -A -E -- "
+                + "/usr/sbin/installer -pkg /private/tmp/vendor.pkg -target /` exited with 1."),
+            "pkg-installer-failed",
+            "a vendor installer's own curl chatter must not reclassify the failure"
+        )
         XCTAssertEqual(cls("Error: Not upgrading 1 pinned package:\nmarkedit 1.33.0"), "upgrade-refused")
         XCTAssertEqual(
             cls("🍺  proton-mail was successfully upgraded!\n==> Upgraded 1 outdated package"),


### PR DESCRIPTION
## Summary

Pattern-mined all 8 unresolved `CaskHub.LocalHomebrewError` Sentry issues (~1,050 events over 14d) and translated the findings into fragment classes plus stderr-capture fixes.

### New failure classes (fingerprint splitting — nothing new is silenced except where noted)

| Class | Decisive stderr | Reported? |
|---|---|---|
| `download-broken` | `The requested URL returned error:` (HTTP 404s = dead casks) | yes |
| `network-failure` (extended) | `curl: (18/35/56/92)` | no — same transient family as existing 5/6/7/28 |
| `brew-api-unavailable` | `Cannot download non-corrupt …jws.json` | yes |
| `download-failed` | `Download failed on Cask` catch-all | yes |
| `cask-conflict` | `conflicts with` | yes |
| `cask-dependency` | `Refusing to uninstall` | yes |
| `platform-unsupported` | macOS/arch/Linux gate messages | yes |
| `brew-busy` | lock contention / `already running` | yes |
| `homebrew-not-writable` | prefix permission breakage | yes |
| `dmg-mount-busy` | `hdiutil: attach failed - Resource busy` | yes |
| `pkg-installer-failed` | vendor pkg exits non-zero | yes |
| `upgrade-refused` | pinned / `installer manual` casks | yes |
| `missing-uninstall-script` | uninstall script gone from disk | yes |
| `sudo-wrong-password` | `incorrect password attempt` | **no** — askpass re-prompts per attempt (audited), pure user typo |
| `sudo-not-admin` | `is not in the sudoers file` | yes |
| `process-killed` | empty stderr + exit 9/15/130 | yes — watch volume first |
| `exit-nonzero-after-success` | `successfully upgraded!` with no error line | yes — capture-loss sentinel |

Also: `isAppManagementDenial` now matches brew's newer `does not have App Management permissions` phrasing (existing recoverable class + settings-button recovery).

### Capture fidelity fixes
- **CRLF doubling**: the pty's ONLCR already emits `\r\n`; converting `\r`→`\n` afterwards doubled every line and halved the useful 2000-char tail. Fold `\r\n` first.
- **80-column clipping**: brew sizes output via `stty size` (fails — stdin is nulled) then `tput cols` → 80. Pass `COLUMNS=180`.
- **Tap-trust advisory flood**: multi-KB advisory blocks pushed the decisive `Error:` line past Sentry's head-kept cap; stripped before classification (with an escape hatch so truncated blocks can't swallow real errors).
- **`--force` overwrite warnings** reuse the conflict-error sentence (`…; overwriting.`) and misclassified unrelated failures as app/binary-conflict; stripped.
- **Long payloads** now slice from the last `Error:` line so the decisive line survives Sentry-side truncation.

### Expected Sentry impact
CASKHUB-C shrinks ~85–90% into named per-class fingerprints; CASKHUB-10 ~70%; CASKHUB-K ~55%. Conflict/artifact classes (N, D, W, 12) split cleanly and get recovery UX in a follow-up before any of them flip recoverable.

## Test plan
- Verbatim field-mined stderr classification tests for every new class
- Capture tests: CRLF folding, tap-trust strip + truncated-advisory escape hatch, overwrite-warning strip, Error-line slicing, short-payload passthrough
- Full suite: 283 passed; the single failure is `test_application_menu_contract` from unrelated in-progress Help-menu work in the local tree (not part of this PR)