### PR TITLE
feat: recovery buttons for conflict failures, flip conflicts recoverable

### DIFF
--- a/CaskHub/Services/Homebrew/Coordination/CaskOperationFailureFactory.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskOperationFailureFactory.swift
@@ -24,7 +24,7 @@ enum CaskOperationFailureFactory {
         case LocalHomebrewError.appBundleNotFound:
             kind = .applicationUnavailable
 
-        case let LocalHomebrewError.brewCommandFailed(arguments, _, stderr):
+        case let LocalHomebrewError.brewCommandFailed(arguments, exitCode, stderr):
             if LocalHomebrewError.isAppManagementDenial(stderr: stderr) {
                 kind = .appManagementDenied
                 recoveries.insert(.openAppManagementSettings)
@@ -39,6 +39,11 @@ enum CaskOperationFailureFactory {
                 || (arguments.first == "upgrade" && strandedCopyExists) {
                 recoveries.insert(.repairAndReinstall)
             }
+            recoveries.formUnion(classRecoveries(
+                failureClass: LocalHomebrewError.failureClass(stderr: stderr, exitCode: exitCode),
+                arguments: arguments,
+                stderr: stderr
+            ))
 
         default:
             break
@@ -49,5 +54,36 @@ enum CaskOperationFailureFactory {
             message: message,
             recoveries: recoveries
         )
+    }
+
+    private static func classRecoveries(
+        failureClass: String,
+        arguments: [String],
+        stderr: String
+    ) -> Set<CaskRecoveryAction> {
+        switch failureClass {
+        case "binary-conflict":
+            return [.replaceWithHomebrew]
+        case "app-conflict":
+            // Adopt keeps the user's copy; pointless retry after a failed --adopt.
+            let canAdopt = arguments.first == "install" && !arguments.contains("--adopt")
+            return canAdopt ? [.adoptExisting, .replaceWithHomebrew] : [.replaceWithHomebrew]
+        case "missing-uninstall-script":
+            // brew upgrade uninstalls the old version internally, so this fires
+            // on updates too — a bare force-uninstall there strands the user
+            // with no app; repair-and-reinstall completes what they asked for.
+            switch arguments.first {
+            case "uninstall": return [.forceUninstall]
+            case "upgrade": return [.repairAndReinstall]
+            default: return []
+            }
+        case "missing-artifact-source"
+            where arguments.first == "upgrade" && !stderr.contains("Caskroom"):
+            // The user moved the app; a Caskroom staging path missing means the
+            // download itself is broken and reinstalling can't help.
+            return [.repairAndReinstall]
+        default:
+            return []
+        }
     }
 }

--- a/CaskHub/Services/Homebrew/Coordination/CaskOperationFailureFactory.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskOperationFailureFactory.swift
@@ -65,13 +65,11 @@ enum CaskOperationFailureFactory {
         case "binary-conflict":
             return [.replaceWithHomebrew]
         case "app-conflict":
-            // Adopt keeps the user's copy; pointless retry after a failed --adopt.
+            // No adopt retry after a failed --adopt.
             let canAdopt = arguments.first == "install" && !arguments.contains("--adopt")
             return canAdopt ? [.adoptExisting, .replaceWithHomebrew] : [.replaceWithHomebrew]
         case "missing-uninstall-script":
-            // brew upgrade uninstalls the old version internally, so this fires
-            // on updates too — a bare force-uninstall there strands the user
-            // with no app; repair-and-reinstall completes what they asked for.
+            // Fires on upgrades too — a bare force-uninstall there strands the user.
             switch arguments.first {
             case "uninstall": return [.forceUninstall]
             case "upgrade": return [.repairAndReinstall]
@@ -79,8 +77,7 @@ enum CaskOperationFailureFactory {
             }
         case "missing-artifact-source"
             where arguments.first == "upgrade" && !stderr.contains("Caskroom"):
-            // The user moved the app; a Caskroom staging path missing means the
-            // download itself is broken and reinstalling can't help.
+            // A missing Caskroom staging path is a broken download; reinstall can't help.
             return [.repairAndReinstall]
         default:
             return []

--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -107,9 +107,7 @@ final class HomebrewMutationCoordinator {
 
         var environment = ProcessInfo.processInfo.environment
         environment.merge(environmentOverrides) { _, override in override }
-        // brew 6 defaults to ask mode on install/upgrade/reinstall: it prints a
-        // "Would install…" plan and, when dependencies are involved, prompts on
-        // our pty — stdin is nulled, so the prompt EOFs and brew aborts.
+        // brew 6 ask-mode default prompts on our pty; stdin is nulled, so it EOF-aborts.
         environment["HOMEBREW_NO_ASK"] = "1"
         if let askpass {
             environment["SUDO_ASKPASS"] = askpass.path

--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -107,6 +107,10 @@ final class HomebrewMutationCoordinator {
 
         var environment = ProcessInfo.processInfo.environment
         environment.merge(environmentOverrides) { _, override in override }
+        // brew 6 defaults to ask mode on install/upgrade/reinstall: it prints a
+        // "Would install…" plan and, when dependencies are involved, prompts on
+        // our pty — stdin is nulled, so the prompt EOFs and brew aborts.
+        environment["HOMEBREW_NO_ASK"] = "1"
         if let askpass {
             environment["SUDO_ASKPASS"] = askpass.path
         }

--- a/CaskHub/Services/Homebrew/Domain/CaskOperationState.swift
+++ b/CaskHub/Services/Homebrew/Domain/CaskOperationState.swift
@@ -9,7 +9,9 @@ import Foundation
 
 nonisolated enum CaskRecoveryAction: Hashable, Sendable {
     case replaceWithHomebrew
+    case adoptExisting
     case repairAndReinstall
+    case forceUninstall
     case openAppManagementSettings
 }
 

--- a/CaskHub/Services/Homebrew/Domain/CaskOperationState.swift
+++ b/CaskHub/Services/Homebrew/Domain/CaskOperationState.swift
@@ -7,9 +7,10 @@
 
 import Foundation
 
-nonisolated enum CaskRecoveryAction: Hashable, Sendable {
-    case replaceWithHomebrew
+/// Declaration order is the alert button order.
+nonisolated enum CaskRecoveryAction: CaseIterable, Hashable, Sendable {
     case adoptExisting
+    case replaceWithHomebrew
     case repairAndReinstall
     case forceUninstall
     case openAppManagementSettings

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -362,8 +362,7 @@ enum LocalHomebrewError: LocalizedError {
         ("successfully upgraded!", "exit-nonzero-after-success")
     ]
 
-    /// binary/app-conflict joined once their recovery buttons shipped — a class
-    /// only moves here when the app offers a complete path out.
+    /// A class moves here only once the app offers a complete recovery path.
     private static let recoverableFailureClasses: Set<String> = [
         "adopt-version-mismatch",
         "app-conflict",

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -362,8 +362,12 @@ enum LocalHomebrewError: LocalizedError {
         ("successfully upgraded!", "exit-nonzero-after-success")
     ]
 
+    /// binary/app-conflict joined once their recovery buttons shipped — a class
+    /// only moves here when the app offers a complete path out.
     private static let recoverableFailureClasses: Set<String> = [
         "adopt-version-mismatch",
+        "app-conflict",
+        "binary-conflict",
         "checksum-mismatch",
         "network-failure",
         "permission-denied",
@@ -371,6 +375,15 @@ enum LocalHomebrewError: LocalizedError {
         "sudo-declined",
         "sudo-wrong-password"
     ]
+
+    /// "…because it is required by <token>, which is currently installed."
+    static func dependentCask(stderr: String) -> String? {
+        guard let range = stderr.range(
+            of: #"required by ([A-Za-z0-9@._+-]+)"#,
+            options: .regularExpression
+        ) else { return nil }
+        return String(stderr[range].dropFirst("required by ".count))
+    }
 
     /// A previous interrupted operation parked the real .app inside the Caskroom
     /// version directory; every upgrade then fails until the copy is cleared.
@@ -404,6 +417,28 @@ enum LocalHomebrewError: LocalizedError {
                     + "instead — your settings and data are kept."
             }
             switch Self.failureClass(stderr: trimmed, exitCode: code) {
+            case "binary-conflict":
+                return "A leftover command-line tool from a previous installation "
+                    + "is in the way. Replacing with Homebrew's version overwrites it — "
+                    + "your settings and data are kept."
+            case "app-conflict":
+                return "This app is already on your Mac, but Homebrew doesn't manage "
+                    + "it yet. Adopt keeps your current copy and hands management to "
+                    + "Homebrew; Replace installs Homebrew's copy fresh. Settings and "
+                    + "data are kept either way."
+            case "cask-dependency":
+                let dependent = Self.dependentCask(stderr: trimmed)
+                return "This can't be uninstalled because "
+                    + (dependent.map { "“\($0)” needs it" } ?? "another installed app needs it")
+                    + ". Uninstall \(dependent.map { "“\($0)”" } ?? "that app") first, "
+                    + "then try again."
+            case "missing-uninstall-script" where args.first == "upgrade":
+                return "The app's uninstall helper is missing, which blocks the "
+                    + "update. Repair & Reinstall clears it and installs the new "
+                    + "version fresh — your settings and data are kept."
+            case "missing-uninstall-script":
+                return "The app's uninstall helper is missing, so Homebrew can't run "
+                    + "its normal cleanup. Force Uninstall removes the app anyway."
             case "sudo-declined":
                 return "This step needs your administrator password. "
                     + "Try again and enter your password when CaskHub asks for it."

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -140,18 +140,7 @@ private extension View {
                 isPresented.wrappedValue = false
                 return
             }
-            let alert = NSAlert()
-            alert.messageText = "Uninstall \(cask.displayName)?"
-            alert.informativeText = "This will run:"
-            let command = NSHostingView(
-                rootView: CommandBlock(command: "brew uninstall --cask \(cask.token)")
-            )
-            command.setFrameSize(command.fittingSize)
-            alert.accessoryView = command
-            let uninstall = alert.addButton(withTitle: "Uninstall")
-            uninstall.hasDestructiveAction = true
-            uninstall.keyEquivalent = ""
-            alert.addButton(withTitle: "Cancel")
+            let alert = CaskActionAlertFactory.uninstallAlert(for: cask)
             alert.beginSheetModal(for: window) { response in
                 if response == .alertFirstButtonReturn {
                     service.send(.uninstall(token: cask.token))
@@ -188,31 +177,9 @@ private extension View {
                 isPresented.wrappedValue = false
                 return
             }
-            let alert = NSAlert()
-            alert.messageText = "\(cask.displayName) Failed"
-            // Long output scrolls in an accessory so buttons stay reachable (#144).
-            if failure.message.count <= 500 {
-                alert.informativeText = failure.message
-            } else {
-                let scroll = NSTextView.scrollableTextView()
-                if let textView = scroll.documentView as? NSTextView {
-                    textView.string = failure.message
-                    textView.isEditable = false
-                    textView.font = .monospacedSystemFont(
-                        ofSize: NSFont.smallSystemFontSize, weight: .regular
-                    )
-                    textView.textContainerInset = NSSize(width: 6, height: 6)
-                }
-                scroll.frame = NSRect(x: 0, y: 0, width: 440, height: 200)
-                alert.accessoryView = scroll
-            }
-            var actions: [() -> Void] = []
-            for recovery in CaskRecoveryAction.allCases where failure.recoveries.contains(recovery) {
-                alert.addButton(withTitle: recovery.buttonTitle).keyEquivalent = ""
-                actions.append { recovery.perform(cask: cask, service: service) }
-            }
-            alert.addButton(withTitle: "OK")
-            actions.append {}
+            let (alert, actions) = CaskActionAlertFactory.errorAlert(
+                for: cask, failure: failure, service: service
+            )
             alert.beginSheetModal(for: window) { response in
                 let index = response.rawValue - NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
                 if actions.indices.contains(index) { actions[index]() }
@@ -239,6 +206,57 @@ private extension View {
             return nil
         }
         return failure
+    }
+}
+
+@MainActor
+enum CaskActionAlertFactory {
+    static func uninstallAlert(for cask: Cask) -> NSAlert {
+        let alert = NSAlert()
+        alert.messageText = "Uninstall \(cask.displayName)?"
+        alert.informativeText = "This will run:"
+        let command = NSHostingView(
+            rootView: CommandBlock(command: "brew uninstall --cask \(cask.token)")
+        )
+        command.setFrameSize(command.fittingSize)
+        alert.accessoryView = command
+        let uninstall = alert.addButton(withTitle: "Uninstall")
+        uninstall.hasDestructiveAction = true
+        uninstall.keyEquivalent = ""
+        alert.addButton(withTitle: "Cancel")
+        return alert
+    }
+
+    static func errorAlert(
+        for cask: Cask,
+        failure: CaskOperationFailure,
+        service: LocalHomebrewService
+    ) -> (alert: NSAlert, actions: [() -> Void]) {
+        let alert = NSAlert()
+        alert.messageText = "\(cask.displayName) Failed"
+        if failure.message.count <= 500 {
+            alert.informativeText = failure.message
+        } else {
+            let scroll = NSTextView.scrollableTextView()
+            if let textView = scroll.documentView as? NSTextView {
+                textView.string = failure.message
+                textView.isEditable = false
+                textView.font = .monospacedSystemFont(
+                    ofSize: NSFont.smallSystemFontSize, weight: .regular
+                )
+                textView.textContainerInset = NSSize(width: 6, height: 6)
+            }
+            scroll.frame = NSRect(x: 0, y: 0, width: 440, height: 200)
+            alert.accessoryView = scroll
+        }
+        var actions: [() -> Void] = []
+        for recovery in CaskRecoveryAction.allCases where failure.recoveries.contains(recovery) {
+            alert.addButton(withTitle: recovery.buttonTitle).keyEquivalent = ""
+            actions.append { recovery.perform(cask: cask, service: service) }
+        }
+        alert.addButton(withTitle: "OK")
+        actions.append {}
+        return (alert, actions)
     }
 }
 

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -166,6 +166,12 @@ private extension View {
     ) -> some View {
         alert("Error", isPresented: isPresented) {
             if failure(for: cask, service: service)?
+                .recoveries.contains(.adoptExisting) == true {
+                Button("Adopt Existing App") {
+                    service.send(.adopt(cask))
+                }
+            }
+            if failure(for: cask, service: service)?
                 .recoveries.contains(.replaceWithHomebrew) == true {
                 Button("Replace with Homebrew Version") {
                     service.send(.replaceWithHomebrew(token: cask.token))
@@ -175,6 +181,12 @@ private extension View {
                 .recoveries.contains(.repairAndReinstall) == true {
                 Button("Repair & Reinstall") {
                     service.send(.repairAndReinstall(token: cask.token))
+                }
+            }
+            if failure(for: cask, service: service)?
+                .recoveries.contains(.forceUninstall) == true {
+                Button("Force Uninstall") {
+                    service.send(.repair(token: cask.token))
                 }
             }
             if failure(for: cask, service: service)?

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -134,13 +134,30 @@ private extension View {
         service: LocalHomebrewService,
         isPresented: Binding<Bool>
     ) -> some View {
-        alert("Uninstall \(cask.displayName)?", isPresented: isPresented) {
-            Button("Cancel", role: .cancel) {}
-            Button("Uninstall", role: .destructive) {
-                service.send(.uninstall(token: cask.token))
+        onChange(of: isPresented.wrappedValue) { _, show in
+            guard show else { return }
+            guard let window = NSApp.keyWindow else {
+                isPresented.wrappedValue = false
+                return
             }
-        } message: {
-            Text("This will run `brew uninstall --cask \(cask.token)`.")
+            let alert = NSAlert()
+            alert.messageText = "Uninstall \(cask.displayName)?"
+            alert.informativeText = "This will run:"
+            let command = NSHostingView(
+                rootView: CommandBlock(command: "brew uninstall --cask \(cask.token)")
+            )
+            command.setFrameSize(command.fittingSize)
+            alert.accessoryView = command
+            let uninstall = alert.addButton(withTitle: "Uninstall")
+            uninstall.hasDestructiveAction = true
+            uninstall.keyEquivalent = ""
+            alert.addButton(withTitle: "Cancel")
+            alert.beginSheetModal(for: window) { response in
+                if response == .alertFirstButtonReturn {
+                    service.send(.uninstall(token: cask.token))
+                }
+                isPresented.wrappedValue = false
+            }
         }
     }
 
@@ -164,41 +181,56 @@ private extension View {
         service: LocalHomebrewService,
         isPresented: Binding<Bool>
     ) -> some View {
-        alert("Error", isPresented: isPresented) {
-            if failure(for: cask, service: service)?
-                .recoveries.contains(.adoptExisting) == true {
-                Button("Adopt Existing App") {
-                    service.send(.adopt(cask))
-                }
+        onChange(of: isPresented.wrappedValue) { _, show in
+            guard show else { return }
+            guard let window = NSApp.keyWindow,
+                  let failure = failure(for: cask, service: service) else {
+                isPresented.wrappedValue = false
+                return
             }
-            if failure(for: cask, service: service)?
-                .recoveries.contains(.replaceWithHomebrew) == true {
-                Button("Replace with Homebrew Version") {
-                    service.send(.replaceWithHomebrew(token: cask.token))
+            let alert = NSAlert()
+            alert.messageText = "\(cask.displayName) Failed"
+            // Long brew output overflows a fixed alert off-screen (issue #144):
+            // short messages ride natively, long ones scroll in an accessory.
+            if failure.message.count <= 500 {
+                alert.informativeText = failure.message
+            } else {
+                let scroll = NSTextView.scrollableTextView()
+                if let textView = scroll.documentView as? NSTextView {
+                    textView.string = failure.message
+                    textView.isEditable = false
+                    textView.font = .monospacedSystemFont(
+                        ofSize: NSFont.smallSystemFontSize, weight: .regular
+                    )
+                    textView.textContainerInset = NSSize(width: 6, height: 6)
                 }
+                scroll.frame = NSRect(x: 0, y: 0, width: 440, height: 200)
+                alert.accessoryView = scroll
             }
-            if failure(for: cask, service: service)?
-                .recoveries.contains(.repairAndReinstall) == true {
-                Button("Repair & Reinstall") {
-                    service.send(.repairAndReinstall(token: cask.token))
-                }
+            var actions: [() -> Void] = []
+            for recovery in orderedRecoveries(in: failure) {
+                alert.addButton(withTitle: recovery.buttonTitle).keyEquivalent = ""
+                actions.append { recovery.perform(cask: cask, service: service) }
             }
-            if failure(for: cask, service: service)?
-                .recoveries.contains(.forceUninstall) == true {
-                Button("Force Uninstall") {
-                    service.send(.repair(token: cask.token))
-                }
+            alert.addButton(withTitle: "OK")
+            actions.append {}
+            alert.beginSheetModal(for: window) { response in
+                let index = response.rawValue - NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
+                if actions.indices.contains(index) { actions[index]() }
+                isPresented.wrappedValue = false
             }
-            if failure(for: cask, service: service)?
-                .recoveries.contains(.openAppManagementSettings) == true {
-                Button("Open System Settings") {
-                    AppManagementPermission.openSystemSettings()
-                }
-            }
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(failure(for: cask, service: service)?.message ?? "")
         }
+    }
+
+    private func orderedRecoveries(in failure: CaskOperationFailure) -> [CaskRecoveryAction] {
+        let order: [CaskRecoveryAction] = [
+            .adoptExisting,
+            .replaceWithHomebrew,
+            .repairAndReinstall,
+            .forceUninstall,
+            .openAppManagementSettings
+        ]
+        return order.filter(failure.recoveries.contains)
     }
 
     private func permissionForce(
@@ -219,6 +251,66 @@ private extension View {
             return nil
         }
         return failure
+    }
+}
+
+private extension CaskRecoveryAction {
+    var buttonTitle: String {
+        switch self {
+        case .adoptExisting: "Adopt Existing App"
+        case .replaceWithHomebrew: "Replace with Homebrew Version"
+        case .repairAndReinstall: "Repair & Reinstall"
+        case .forceUninstall: "Force Uninstall"
+        case .openAppManagementSettings: "Open System Settings"
+        }
+    }
+
+    @MainActor
+    func perform(cask: Cask, service: LocalHomebrewService) {
+        switch self {
+        case .adoptExisting:
+            service.send(.adopt(cask))
+        case .replaceWithHomebrew:
+            service.send(.replaceWithHomebrew(token: cask.token))
+        case .repairAndReinstall:
+            service.send(.repairAndReinstall(token: cask.token))
+        case .forceUninstall:
+            service.send(.repair(token: cask.token))
+        case .openAppManagementSettings:
+            AppManagementPermission.openSystemSettings()
+        }
+    }
+}
+
+private struct CommandBlock: View {
+    let command: String
+    @State private var copied = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(verbatim: command)
+                .font(.callout.monospaced())
+                .textSelection(.enabled)
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(command, forType: .string)
+                copied = true
+                Task {
+                    try? await Task.sleep(for: .seconds(1.5))
+                    copied = false
+                }
+            } label: {
+                Image(systemName: copied ? "checkmark.circle.fill" : "document.on.document")
+                    .foregroundStyle(copied ? Color.green : Color.secondary)
+                    .contentTransition(.symbolEffect(.replace))
+                    .frame(width: 16, height: 16)
+            }
+            .buttonStyle(.borderless)
+            .help("Copy Command")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
     }
 }
 

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -190,8 +190,7 @@ private extension View {
             }
             let alert = NSAlert()
             alert.messageText = "\(cask.displayName) Failed"
-            // Long brew output overflows a fixed alert off-screen (issue #144):
-            // short messages ride natively, long ones scroll in an accessory.
+            // Long output scrolls in an accessory so buttons stay reachable (#144).
             if failure.message.count <= 500 {
                 alert.informativeText = failure.message
             } else {
@@ -208,7 +207,7 @@ private extension View {
                 alert.accessoryView = scroll
             }
             var actions: [() -> Void] = []
-            for recovery in orderedRecoveries(in: failure) {
+            for recovery in CaskRecoveryAction.allCases where failure.recoveries.contains(recovery) {
                 alert.addButton(withTitle: recovery.buttonTitle).keyEquivalent = ""
                 actions.append { recovery.perform(cask: cask, service: service) }
             }
@@ -220,17 +219,6 @@ private extension View {
                 isPresented.wrappedValue = false
             }
         }
-    }
-
-    private func orderedRecoveries(in failure: CaskOperationFailure) -> [CaskRecoveryAction] {
-        let order: [CaskRecoveryAction] = [
-            .adoptExisting,
-            .replaceWithHomebrew,
-            .repairAndReinstall,
-            .forceUninstall,
-            .openAppManagementSettings
-        ]
-        return order.filter(failure.recoveries.contains)
     }
 
     private func permissionForce(

--- a/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ZombieDetectionTests.swift
@@ -160,6 +160,108 @@ final class ZombieDetectionTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func test_binary_conflict_offers_replace() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("bin-conflict"))
+        let error = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "iina"], exitCode: 1,
+            stderr: "Error: iina: It seems there is already a Binary at '/opt/homebrew/bin/iina'."
+        )
+        service.noteFailure(token: "iina", error: error)
+        let recoveries = service.operationStore.state(for: "iina")?.failure?.recoveries
+        XCTAssertEqual(recoveries, [.replaceWithHomebrew])
+        XCTAssertTrue(error.errorDescription?.contains("Replacing") == true)
+    }
+
+    @MainActor
+    func test_app_conflict_on_install_offers_adopt_and_replace() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("app-conflict"))
+        let error = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "wireshark-app"], exitCode: 1,
+            stderr: "Error: It seems there is already an App at '/Applications/Wireshark.app'."
+        )
+        service.noteFailure(token: "wireshark-app", error: error)
+        let recoveries = service.operationStore.state(for: "wireshark-app")?.failure?.recoveries
+        XCTAssertEqual(recoveries, [.adoptExisting, .replaceWithHomebrew])
+        XCTAssertTrue(error.errorDescription?.contains("Adopt") == true)
+    }
+
+    @MainActor
+    func test_app_conflict_after_failed_adopt_does_not_reoffer_adopt() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("adopt-fail"))
+        let error = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "canva", "--adopt"], exitCode: 1,
+            stderr: "Error: It seems there is already an App at '/Applications/Canva.app'."
+        )
+        service.noteFailure(token: "canva", error: error)
+        let recoveries = service.operationStore.state(for: "canva")?.failure?.recoveries
+        XCTAssertEqual(recoveries, [.replaceWithHomebrew])
+    }
+
+    @MainActor
+    func test_missing_uninstall_script_offers_force_uninstall() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("no-script"))
+        let error = LocalHomebrewError.brewCommandFailed(
+            args: ["uninstall", "--cask", "gpt4all"], exitCode: 1,
+            stderr: "Error: uninstall script /Applications/gpt4all/maintenancetool.app"
+                + "/Contents/MacOS/maintenancetool does not exist."
+        )
+        service.noteFailure(token: "gpt4all", error: error)
+        let recoveries = service.operationStore.state(for: "gpt4all")?.failure?.recoveries
+        XCTAssertEqual(recoveries, [.forceUninstall])
+        XCTAssertTrue(error.errorDescription?.contains("Force Uninstall") == true)
+    }
+
+    @MainActor
+    func test_missing_uninstall_script_during_update_repairs_instead_of_uninstalling() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("no-script-upgrade"))
+        let error = LocalHomebrewError.brewCommandFailed(
+            args: ["upgrade", "--cask", "lulu"], exitCode: 1,
+            stderr: "Error: uninstall script /Applications/LuLu.app"
+                + "/Contents/Resources/uninstall.sh does not exist."
+        )
+        service.noteFailure(token: "lulu", error: error)
+        let recoveries = service.operationStore.state(for: "lulu")?.failure?.recoveries
+        XCTAssertEqual(recoveries, [.repairAndReinstall])
+        XCTAssertTrue(error.errorDescription?.contains("Repair") == true)
+    }
+
+    @MainActor
+    func test_moved_app_on_upgrade_offers_repair_but_broken_staging_does_not() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("moved-app"))
+        let movedApp = LocalHomebrewError.brewCommandFailed(
+            args: ["upgrade", "--cask", "proton-mail"], exitCode: 1,
+            stderr: "Error: proton-mail: It seems the App source "
+                + "'/Applications/Proton Mail.app' is not there."
+        )
+        service.noteFailure(token: "proton-mail", error: movedApp)
+        XCTAssertTrue(
+            service.operationStore.state(for: "proton-mail")?.failure?
+                .recoveries.contains(.repairAndReinstall) == true
+        )
+
+        let brokenStaging = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "macpar-deluxe", "--adopt"], exitCode: 1,
+            stderr: "Error: It seems the App source '/opt/homebrew/Caskroom/"
+                + "macpar-deluxe/5.1.1/MacPAR deLuxe.app' is not there."
+        )
+        service.noteFailure(token: "macpar-deluxe", error: brokenStaging)
+        XCTAssertFalse(
+            service.operationStore.state(for: "macpar-deluxe")?.failure?
+                .recoveries.contains(.repairAndReinstall) == true
+        )
+    }
+
+    func test_dependency_refusal_names_the_dependent_cask() {
+        let stderr = "Error: Refusing to uninstall pieces-os\n"
+            + "because it is required by pieces, which is currently installed."
+        XCTAssertEqual(LocalHomebrewError.dependentCask(stderr: stderr), "pieces")
+        let error = LocalHomebrewError.brewCommandFailed(
+            args: ["uninstall", "--cask", "pieces-os", "--force"], exitCode: 1, stderr: stderr
+        )
+        XCTAssertTrue(error.errorDescription?.contains("“pieces”") == true)
+    }
+
     func test_stranded_app_error_message_explains_repair() {
         let error = LocalHomebrewError.brewCommandFailed(
             args: ["upgrade", "--cask", "tabby"], exitCode: 1,

--- a/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
@@ -150,4 +150,98 @@ final class AdoptionViewRenderTests: XCTestCase {
         ), in: service)
         render(CaskInfoPopover(cask: makeCask("known"), category: nil).environment(service))
     }
+
+    @MainActor
+    func test_uninstall_alert_shows_copyable_command_with_destructive_button() {
+        let alert = CaskActionAlertFactory.uninstallAlert(for: makeCask("iina", name: "IINA"))
+
+        XCTAssertEqual(alert.messageText, "Uninstall IINA?")
+        XCTAssertEqual(alert.informativeText, "This will run:")
+        XCTAssertNotNil(alert.accessoryView)
+        XCTAssertEqual(alert.buttons.map(\.title), ["Uninstall", "Cancel"])
+        XCTAssertTrue(alert.buttons[0].hasDestructiveAction)
+    }
+
+    @MainActor
+    func test_error_alert_orders_recovery_buttons_before_ok() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("alert-buttons"))
+        let failure = CaskOperationFailure(
+            kind: .brewCommand,
+            message: "short message",
+            recoveries: [.replaceWithHomebrew, .adoptExisting]
+        )
+
+        let (alert, actions) = CaskActionAlertFactory.errorAlert(
+            for: makeCask("wireshark-app", name: "Wireshark"), failure: failure, service: service
+        )
+
+        XCTAssertEqual(alert.messageText, "Wireshark Failed")
+        XCTAssertEqual(alert.informativeText, "short message")
+        XCTAssertNil(alert.accessoryView)
+        XCTAssertEqual(
+            alert.buttons.map(\.title),
+            ["Adopt Existing App", "Replace with Homebrew Version", "OK"]
+        )
+        XCTAssertEqual(actions.count, alert.buttons.count)
+    }
+
+    @MainActor
+    func test_error_alert_scrolls_long_output_instead_of_growing() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("alert-scroll"))
+        let message = String(repeating: "brew output line\n", count: 60)
+        let failure = CaskOperationFailure(kind: .brewCommand, message: message)
+
+        let (alert, _) = CaskActionAlertFactory.errorAlert(
+            for: makeCask("kdrive"), failure: failure, service: service
+        )
+
+        XCTAssertEqual(alert.informativeText, "")
+        let scroll = try? XCTUnwrap(alert.accessoryView as? NSScrollView)
+        let textView = scroll?.documentView as? NSTextView
+        XCTAssertEqual(textView?.string, message)
+        XCTAssertEqual(textView?.isEditable, false)
+        XCTAssertLessThanOrEqual(scroll?.frame.height ?? .infinity, 200)
+    }
+
+    @MainActor
+    func test_error_alert_covers_every_recovery_button_title_and_action() async {
+        let runner = StubBrewProcessRunner()
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("alert-titles")) {
+            $0.fileManager = NoFilesFileManager()
+            $0.processRunner = runner
+            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
+            $0.brewVersionProvider = { "test" }
+        }
+        service.permissionProbe = { .denied }
+        let failure = CaskOperationFailure(
+            kind: .brewCommand,
+            message: "short",
+            recoveries: Set(CaskRecoveryAction.allCases)
+        )
+
+        let (alert, actions) = CaskActionAlertFactory.errorAlert(
+            for: makeCask("firefox"), failure: failure, service: service
+        )
+
+        XCTAssertEqual(alert.buttons.map(\.title), [
+            "Adopt Existing App",
+            "Replace with Homebrew Version",
+            "Repair & Reinstall",
+            "Force Uninstall",
+            "Open System Settings",
+            "OK"
+        ])
+        XCTAssertEqual(actions.count, 6)
+
+        // Every action except Open System Settings (launches the real app) and OK.
+        for action in actions[0...3] {
+            action()
+            try? await Task.sleep(for: .milliseconds(150))
+        }
+        XCTAssertTrue(
+            runner.requests.contains { $0.arguments.contains("--force") },
+            "force uninstall reached the runner"
+        )
+        actions.last?()
+    }
 }

--- a/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
@@ -202,6 +202,12 @@ final class AdoptionSurfaceTests: XCTestCase {
         )
         XCTAssertNil(runner.requests[0].environment["HOMEBREW_NO_AUTOREMOVE"])
         XCTAssertNil(runner.requests[2].environment["HOMEBREW_NO_AUTOREMOVE"])
+        XCTAssertTrue(
+            runner.requests.dropFirst().allSatisfy {
+                $0.environment["HOMEBREW_NO_ASK"] == "1"
+            },
+            "ask-mode prompts EOF on the nulled stdin and abort the run"
+        )
     }
 
     func test_askpass_scripts_are_unique_shell_safe_and_removable() throws {

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -183,13 +183,26 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertTrue(spy.capturedErrors.isEmpty)
     }
 
-    func test_unexpected_brew_conflicts_remain_reportable() {
+    func test_conflicts_with_recovery_buttons_are_no_longer_captured() {
         CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
             args: ["install", "--cask", "x"],
             exitCode: 1,
             stderr: "It seems there is already a Binary at '/opt/homebrew/bin/x'."
         ))
-        XCTAssertEqual(spy.capturedErrors.count, 1)
+        CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "x"],
+            exitCode: 1,
+            stderr: "Error: It seems there is already an App at '/Applications/X.app'."
+        ))
+        XCTAssertTrue(spy.capturedErrors.isEmpty)
+
+        CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "x"],
+            exitCode: 1,
+            stderr: "Error: x: Download failed on Cask 'x' with message: "
+                + "curl: (22) The requested URL returned error: 404"
+        ))
+        XCTAssertEqual(spy.capturedErrors.count, 1, "classes without a recovery path still report")
     }
 
     // MARK: - Fingerprinting


### PR DESCRIPTION
## Summary

Phase 2 of the LocalHomebrewError work (stacked on #148 — merge that first; this retargets to `develop` automatically after).

Recovery UX for the conflict classes mined from Sentry, reusing existing flows end to end:

| Failure | Buttons | Routes to |
|---|---|---|
| `binary-conflict` (stale CLI shim — CASKHUB-N/W, ~89 events) | **Replace with Homebrew Version** | existing `adoptReplacing` → `install --force` |
| `app-conflict` on plain install (unmanaged app — CASKHUB-D, ~26 events) | **Adopt Existing App** + **Replace** | existing `.adopt(cask)` intent — goes through the adoption preflight, which matters because a failed `--adopt` rollback can delete the user's app |
| `app-conflict` after a failed `--adopt` | **Replace** only (no pointless adopt retry) | — |
| `missing-uninstall-script` on uninstall (CASKHUB-K, ~9 events) | **Force Uninstall** | existing `.repair` intent → `uninstall --force` |
| `missing-uninstall-script` on **upgrade** | **Repair & Reinstall** | brew upgrade uninstalls internally, so this fires on updates too — a bare force-uninstall there would strand the user with no app (caught in adversarial review) |
| `missing-artifact-source` on upgrade, app path outside Caskroom (user moved the app — CASKHUB-12) | **Repair & Reinstall** | Caskroom staging paths excluded: those are broken downloads a reinstall can't fix |

With complete recovery paths shipped, `binary-conflict` and `app-conflict` join `recoverableFailureClasses` and stop reporting to Sentry — expected to eliminate CASKHUB-N, CASKHUB-D and CASKHUB-W. The user always still sees the error alert; suppression is Sentry-only. Dependency refusals (`Refusing to uninstall`) now name the dependent cask in the error copy (still reported).

## Test plan
- Factory recovery-offer tests per class and subcommand, including the adopt-retry and Caskroom-staging exclusions and the upgrade→repair routing
- Suppression inversion test: conflicts no longer captured, recovery-less classes still captured
- Full suite green locally; two adversarial review agents ran over the diff — the one confirmed critical (upgrade-triggered force-uninstall stranding) is fixed and regression-tested