### PR TITLE
feat: Add native macOS menus and help center

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		41DFD48A30028F7D00608C7A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 41DFD48430028F7D00608C7A /* Assets.xcassets */; };
 		41DFD48B30028F7D00608C7A /* Askpass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD44E30028F7D00608C7A /* Askpass.swift */; };
 		41DFD48C30028F7D00608C7A /* CaskHubApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD44F30028F7D00608C7A /* CaskHubApp.swift */; };
+		B08000000000000000000002 /* CaskHubCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08000000000000000000001 /* CaskHubCommands.swift */; };
+		B08000000000000000000004 /* CaskHubHelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08000000000000000000003 /* CaskHubHelpView.swift */; };
+		B09100000000000000000002 /* CaskHubHelpSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09100000000000000000001 /* CaskHubHelpSearch.swift */; };
 		A29000000000000000000002 /* ApplicationTerminationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29000000000000000000001 /* ApplicationTerminationCoordinator.swift */; };
 		41DFD48D30028F7D00608C7A /* BarrelMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45130028F7D00608C7A /* BarrelMark.swift */; };
 		41DFD48E30028F7D00608C7A /* CaskActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD45230028F7D00608C7A /* CaskActionsView.swift */; };
@@ -125,6 +128,8 @@
 		C12000000000000000000002 /* added_dates.json in Resources */ = {isa = PBXBuildFile; fileRef = D12000000000000000000002 /* added_dates.json */; };
 		ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */; };
 		A29000000000000000000004 /* ApplicationTerminationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29000000000000000000003 /* ApplicationTerminationCoordinatorTests.swift */; };
+		B09000000000000000000002 /* ApplicationMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09000000000000000000001 /* ApplicationMenuTests.swift */; };
+		B09200000000000000000002 /* HelpViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09200000000000000000001 /* HelpViewTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -144,6 +149,9 @@
 		41AD10302F68D00100BEABB8 /* UpdaterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterService.swift; sourceTree = "<group>"; };
 		41DFD44E30028F7D00608C7A /* Askpass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Askpass.swift; sourceTree = "<group>"; };
 		41DFD44F30028F7D00608C7A /* CaskHubApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubApp.swift; sourceTree = "<group>"; };
+		B08000000000000000000001 /* CaskHubCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubCommands.swift; sourceTree = "<group>"; };
+		B08000000000000000000003 /* CaskHubHelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubHelpView.swift; sourceTree = "<group>"; };
+		B09100000000000000000001 /* CaskHubHelpSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubHelpSearch.swift; sourceTree = "<group>"; };
 		A29000000000000000000001 /* ApplicationTerminationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationCoordinator.swift; sourceTree = "<group>"; };
 		41DFD45130028F7D00608C7A /* BarrelMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarrelMark.swift; sourceTree = "<group>"; };
 		41DFD45230028F7D00608C7A /* CaskActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskActionsView.swift; sourceTree = "<group>"; };
@@ -256,6 +264,8 @@
 		D12000000000000000000002 /* added_dates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = added_dates.json; sourceTree = "<group>"; };
 		ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewTests.swift; sourceTree = "<group>"; };
 		A29000000000000000000003 /* ApplicationTerminationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationCoordinatorTests.swift; sourceTree = "<group>"; };
+		B09000000000000000000001 /* ApplicationMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationMenuTests.swift; sourceTree = "<group>"; };
+		B09200000000000000000001 /* HelpViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpViewTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -285,6 +295,8 @@
 				A29000000000000000000001 /* ApplicationTerminationCoordinator.swift */,
 				41DFD44E30028F7D00608C7A /* Askpass.swift */,
 				41DFD44F30028F7D00608C7A /* CaskHubApp.swift */,
+				B08000000000000000000001 /* CaskHubCommands.swift */,
+				B09100000000000000000001 /* CaskHubHelpSearch.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -542,6 +554,14 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		B08000000000000000000005 /* Help */ = {
+			isa = PBXGroup;
+			children = (
+				B08000000000000000000003 /* CaskHubHelpView.swift */,
+			);
+			path = Help;
+			sourceTree = "<group>";
+		};
 		41DFD47F30028F7D00608C7A /* Shared */ = {
 			isa = PBXGroup;
 			children = (
@@ -566,6 +586,7 @@
 		41DFD48330028F7D00608C7A /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				B08000000000000000000005 /* Help */,
 				41DFD47930028F7D00608C7A /* Settings */,
 				41DFD47F30028F7D00608C7A /* Shared */,
 				41DFD48130028F7D00608C7A /* Sidebar */,
@@ -606,6 +627,7 @@
 		A29000000000000000000005 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				B09000000000000000000001 /* ApplicationMenuTests.swift */,
 				A29000000000000000000003 /* ApplicationTerminationCoordinatorTests.swift */,
 			);
 			path = App;
@@ -650,6 +672,7 @@
 			isa = PBXGroup;
 			children = (
 				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
+				B09200000000000000000001 /* HelpViewTests.swift */,
 				ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */,
 				A26000000000000000000003 /* UpdateSettingsViewTests.swift */,
 			);
@@ -905,6 +928,9 @@
 				A29000000000000000000002 /* ApplicationTerminationCoordinator.swift in Sources */,
 				41DFD48B30028F7D00608C7A /* Askpass.swift in Sources */,
 				41DFD48C30028F7D00608C7A /* CaskHubApp.swift in Sources */,
+				B08000000000000000000002 /* CaskHubCommands.swift in Sources */,
+				B08000000000000000000004 /* CaskHubHelpView.swift in Sources */,
+				B09100000000000000000002 /* CaskHubHelpSearch.swift in Sources */,
 				41DFD48D30028F7D00608C7A /* BarrelMark.swift in Sources */,
 				41DFD48E30028F7D00608C7A /* CaskActionsView.swift in Sources */,
 				F24000000000000000000002 /* CaskOperationCapsule.swift in Sources */,
@@ -990,6 +1016,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B09000000000000000000002 /* ApplicationMenuTests.swift in Sources */,
 				A29000000000000000000004 /* ApplicationTerminationCoordinatorTests.swift in Sources */,
 				41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */,
 				A29100000000000000000004 /* CaskMetadataProjectorTests.swift in Sources */,
@@ -1001,6 +1028,7 @@
 				F34000000000000000000002 /* HomebrewPackageLaunchTests.swift in Sources */,
 				41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */,
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
+				B09200000000000000000002 /* HelpViewTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,
 				A26000000000000000000004 /* UpdateSettingsViewTests.swift in Sources */,
 				FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */,

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -16,6 +16,7 @@ enum CaskHubMain {
                 ? CommandLine.arguments[flagIndex + 1] : nil
             Askpass.runDialog(token: token)
         }
+        NSWindow.allowsAutomaticWindowTabbing = false
         CaskHubApp.main()
     }
 }
@@ -26,6 +27,8 @@ struct CaskHubApp: App {
     private var terminationCoordinator
 
     @State private var updaterService = UpdaterService()
+    @State private var helpTopic: HelpTopic = .gettingStarted
+    @State private var settingsSection: SettingsSection = .general
 
     @State private var categoryService: CategoryService
     @State private var recentlyAdded: RecentlyAddedService
@@ -64,13 +67,16 @@ struct CaskHubApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        Window("CaskHub", id: CaskHubWindowID.main) {
             ContentView(viewModel: catalog)
                 .frame(minWidth: 1380, minHeight: 640)
                 .background {
                     WindowCloseButtonConfigurator {
                         terminationCoordinator.requestTermination()
                     }
+                }
+                .background {
+                    CaskHubHelpSearchRegistration(selection: $helpTopic)
                 }
                 .onAppear {
                     terminationCoordinator.configure {
@@ -87,17 +93,40 @@ struct CaskHubApp: App {
         }
         .defaultSize(width: 1360, height: 880)
         .windowStyle(.hiddenTitleBar)
+        .commandsRemoved()
         .commands {
-            CommandGroup(after: .appInfo) {
-                CheckForUpdatesView(updater: updaterService)
-            }
+            CommandGroup(replacing: .newItem) {}
+            CaskHubApplicationCommands(updater: updaterService)
+            CaskHubViewCommands()
+            CaskHubHelpCommands(selection: $helpTopic)
+        }
+
+        Window("CaskHub Help", id: CaskHubWindowID.help) {
+            CaskHubHelpView(
+                selection: $helpTopic,
+                settingsSelection: $settingsSection,
+                navigateToCatalog: { catalog.selectedSidebar = $0 }
+            )
+            .environment(localHomebrew)
+            .frame(minWidth: 760, minHeight: 520)
+        }
+        .defaultSize(width: 880, height: 620)
+        .windowResizability(.contentMinSize)
+        .commandsRemoved()
+        .commands {
+            CaskHubApplicationCommands(updater: updaterService)
+            CaskHubHelpCommands(selection: $helpTopic)
         }
 
         Settings {
-            SettingsView()
+            SettingsView(selection: $settingsSection)
                 .environment(updaterService)
                 .environment(imageCache)
                 .environment(localHomebrew)
+        }
+        .commands {
+            CaskHubApplicationCommands(updater: updaterService)
+            CaskHubHelpCommands(selection: $helpTopic)
         }
     }
 }

--- a/CaskHub/App/CaskHubCommands.swift
+++ b/CaskHub/App/CaskHubCommands.swift
@@ -112,20 +112,10 @@ struct CaskHubHelpCommands: Commands {
 
             Divider()
 
-            Button(HelpTopic.homebrew.helpMenuTitle) {
-                show(.homebrew)
-            }
-
-            Button(HelpTopic.adoption.helpMenuTitle) {
-                show(.adoption)
-            }
-
-            Button(HelpTopic.installAndUpdate.helpMenuTitle) {
-                show(.installAndUpdate)
-            }
-
-            Button(HelpTopic.permissions.helpMenuTitle) {
-                show(.permissions)
+            ForEach([HelpTopic.homebrew, .adoption, .installAndUpdate, .permissions]) { topic in
+                Button(topic.helpMenuTitle) {
+                    show(topic)
+                }
             }
 
             Divider()

--- a/CaskHub/App/CaskHubCommands.swift
+++ b/CaskHub/App/CaskHubCommands.swift
@@ -1,0 +1,142 @@
+//
+//  CaskHubCommands.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 08/08/2026.
+//
+
+import AppKit
+import SwiftUI
+
+enum CaskHubWindowID {
+    static let main = "main"
+    static let help = "help"
+}
+
+extension FocusedValues {
+    @Entry var catalogViewMode: Binding<ViewMode>?
+    @Entry var sidebarVisibility: Binding<NavigationSplitViewVisibility>?
+}
+
+enum CaskHubViewCommand {
+    static func sidebarTitle(for visibility: NavigationSplitViewVisibility) -> String {
+        visibility == .detailOnly ? "Show Sidebar" : "Hide Sidebar"
+    }
+
+    static func sidebarVisibility(
+        afterToggling visibility: NavigationSplitViewVisibility
+    ) -> NavigationSplitViewVisibility {
+        visibility == .detailOnly ? .all : .detailOnly
+    }
+}
+
+struct CaskHubApplicationCommands: Commands {
+    let updater: UpdaterService
+
+    var body: some Commands {
+        CommandGroup(replacing: .appInfo) {
+            Button {
+                NSApp.orderFrontStandardAboutPanel(nil)
+            } label: {
+                Label("About CaskHub", systemImage: "info.circle")
+            }
+
+            CheckForUpdatesView(updater: updater)
+        }
+    }
+}
+
+struct CaskHubViewCommands: Commands {
+    @FocusedBinding(\.catalogViewMode) private var viewMode
+    @FocusedBinding(\.sidebarVisibility) private var sidebarVisibility
+
+    var body: some Commands {
+        CommandGroup(replacing: .sidebar) {
+            Button(sidebarTitle) {
+                guard let sidebarVisibility else { return }
+                self.sidebarVisibility = CaskHubViewCommand.sidebarVisibility(
+                    afterToggling: sidebarVisibility
+                )
+            }
+            .keyboardShortcut("s", modifiers: [.control, .command])
+            .disabled(sidebarVisibility == nil)
+        }
+
+        CommandGroup(after: .sidebar) {
+            Divider()
+
+            Toggle("Grid", isOn: gridSelection)
+                .keyboardShortcut("1", modifiers: .command)
+                .disabled(viewMode == nil)
+
+            Toggle("List", isOn: listSelection)
+                .keyboardShortcut("2", modifiers: .command)
+                .disabled(viewMode == nil)
+        }
+    }
+
+    private var sidebarTitle: String {
+        guard let sidebarVisibility else { return "Show Sidebar" }
+        return CaskHubViewCommand.sidebarTitle(for: sidebarVisibility)
+    }
+
+    private var gridSelection: Binding<Bool> {
+        Binding(
+            get: { viewMode == .grid },
+            set: { isSelected in
+                if isSelected { viewMode = .grid }
+            }
+        )
+    }
+
+    private var listSelection: Binding<Bool> {
+        Binding(
+            get: { viewMode == .list },
+            set: { isSelected in
+                if isSelected { viewMode = .list }
+            }
+        )
+    }
+}
+
+struct CaskHubHelpCommands: Commands {
+    @Binding var selection: HelpTopic
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        CommandGroup(replacing: .help) {
+            Button(HelpTopic.gettingStarted.helpMenuTitle) {
+                show(.gettingStarted)
+            }
+            .keyboardShortcut("?", modifiers: .command)
+
+            Divider()
+
+            Button(HelpTopic.homebrew.helpMenuTitle) {
+                show(.homebrew)
+            }
+
+            Button(HelpTopic.adoption.helpMenuTitle) {
+                show(.adoption)
+            }
+
+            Button(HelpTopic.installAndUpdate.helpMenuTitle) {
+                show(.installAndUpdate)
+            }
+
+            Button(HelpTopic.permissions.helpMenuTitle) {
+                show(.permissions)
+            }
+
+            Divider()
+
+            Link("Report an Issue", destination: CaskHubLinks.issues)
+            Link("CaskHub Website", destination: CaskHubLinks.website)
+        }
+    }
+
+    private func show(_ topic: HelpTopic) {
+        selection = topic
+        openWindow(id: CaskHubWindowID.help)
+    }
+}

--- a/CaskHub/App/CaskHubHelpSearch.swift
+++ b/CaskHub/App/CaskHubHelpSearch.swift
@@ -1,0 +1,163 @@
+//
+//  CaskHubHelpSearch.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 09/08/2026.
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+final class CaskHubHelpSearchHandler: NSObject, NSUserInterfaceItemSearching {
+    typealias SelectionAction = @MainActor @Sendable (HelpTopic) -> Void
+
+    nonisolated private let items: [SearchItem]
+    nonisolated private let onSelect: SelectionAction
+
+    init(onSelect: @escaping SelectionAction) {
+        self.onSelect = onSelect
+        items = HelpTopic.allCases.map {
+            SearchItem(
+                topic: $0,
+                title: $0.helpMenuTitle,
+                searchText: ([$0.helpMenuTitle, $0.title] + $0.searchKeywords)
+                    .joined(separator: " ")
+            )
+        }
+    }
+
+    nonisolated func searchForItems(
+        withSearch searchString: String,
+        resultLimit: Int,
+        matchedItemHandler handleMatchedItems: @escaping ([Any]) -> Void
+    ) {
+        guard resultLimit > 0 else {
+            handleMatchedItems([])
+            return
+        }
+
+        let query = searchString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            handleMatchedItems([])
+            return
+        }
+
+        let queryTerms = query.split(whereSeparator: \.isWhitespace).map(String.init)
+        let matches = items.lazy
+            .filter { item in
+                queryTerms.allSatisfy {
+                    item.searchText.localizedCaseInsensitiveContains($0)
+                }
+            }
+            .prefix(resultLimit)
+        handleMatchedItems(Array(matches))
+    }
+
+    nonisolated func localizedTitles(forItem item: Any) -> [String] {
+        guard let item = item as? SearchItem else { return [] }
+        return [item.title]
+    }
+
+    nonisolated func performAction(forItem item: Any) {
+        guard let item = item as? SearchItem else { return }
+        let onSelect = onSelect
+        Task { @MainActor in
+            onSelect(item.topic)
+        }
+    }
+}
+
+extension HelpTopic {
+    var helpMenuTitle: String {
+        switch self {
+        case .gettingStarted: "CaskHub Help"
+        case .homebrew: "Homebrew Setup"
+        case .installAndUpdate: "Updating Apps"
+        case .adoption: "Adopting Apps"
+        case .permissions: "App Management Permission"
+        case .troubleshooting: "Troubleshooting"
+        }
+    }
+
+    fileprivate var searchKeywords: [String] {
+        switch self {
+        case .gettingStarted:
+            ["welcome", "browse", "catalog", "discover", "manage"]
+        case .homebrew:
+            ["brew", "install homebrew", "setup", "binary", "custom location", "prefix"]
+        case .installAndUpdate:
+            ["install", "update", "upgrade", "greedy", "download", "cancel"]
+        case .adoption:
+            ["adopt", "existing app", "package installer", "manage app"]
+        case .permissions:
+            ["permission", "privacy", "security", "app management", "system settings"]
+        case .troubleshooting:
+            ["error", "failure", "repair", "replace", "reinstall", "diagnose"]
+        }
+    }
+}
+
+private struct SearchItem: Sendable {
+    let topic: HelpTopic
+    let title: String
+    let searchText: String
+}
+
+@MainActor
+struct CaskHubHelpSearchRegistration: NSViewRepresentable {
+    @Binding var selection: HelpTopic
+    @Environment(\.openWindow) private var openWindow
+
+    func makeCoordinator() -> CaskHubHelpSearchCoordinator {
+        CaskHubHelpSearchCoordinator()
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        updateSelectionAction(on: context.coordinator)
+        context.coordinator.register()
+        return NSView()
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        updateSelectionAction(on: context.coordinator)
+        context.coordinator.register()
+    }
+
+    static func dismantleNSView(
+        _ view: NSView,
+        coordinator: CaskHubHelpSearchCoordinator
+    ) {
+        coordinator.unregister()
+    }
+
+    private func updateSelectionAction(on coordinator: CaskHubHelpSearchCoordinator) {
+        coordinator.selectionAction = { topic in
+            selection = topic
+            openWindow(id: CaskHubWindowID.help)
+        }
+    }
+}
+
+@MainActor
+final class CaskHubHelpSearchCoordinator {
+    typealias SelectionAction = @MainActor (HelpTopic) -> Void
+
+    var selectionAction: SelectionAction = { _ in }
+    private var isRegistered = false
+    private lazy var searchHandler = CaskHubHelpSearchHandler { [weak self] topic in
+        self?.selectionAction(topic)
+    }
+
+    func register() {
+        guard !isRegistered else { return }
+        NSApp.registerUserInterfaceItemSearchHandler(searchHandler)
+        isRegistered = true
+    }
+
+    func unregister() {
+        guard isRegistered else { return }
+        NSApp.unregisterUserInterfaceItemSearchHandler(searchHandler)
+        isRegistered = false
+    }
+}

--- a/CaskHub/App/CaskHubHelpSearch.swift
+++ b/CaskHub/App/CaskHubHelpSearch.swift
@@ -10,21 +10,21 @@ import SwiftUI
 
 @MainActor
 final class CaskHubHelpSearchHandler: NSObject, NSUserInterfaceItemSearching {
-    typealias SelectionAction = @MainActor @Sendable (HelpTopic) -> Void
+    typealias SelectionAction = @MainActor (HelpTopic) -> Void
 
-    nonisolated private let items: [SearchItem]
-    nonisolated private let onSelect: SelectionAction
+    var onSelect: SelectionAction
 
-    init(onSelect: @escaping SelectionAction) {
+    nonisolated private let items = HelpTopic.allCases.map {
+        SearchItem(
+            topic: $0,
+            title: $0.helpMenuTitle,
+            searchText: ([$0.helpMenuTitle, $0.title] + $0.searchKeywords)
+                .joined(separator: " ")
+        )
+    }
+
+    init(onSelect: @escaping SelectionAction = { _ in }) {
         self.onSelect = onSelect
-        items = HelpTopic.allCases.map {
-            SearchItem(
-                topic: $0,
-                title: $0.helpMenuTitle,
-                searchText: ([$0.helpMenuTitle, $0.title] + $0.searchKeywords)
-                    .joined(separator: " ")
-            )
-        }
     }
 
     nonisolated func searchForItems(
@@ -61,9 +61,8 @@ final class CaskHubHelpSearchHandler: NSObject, NSUserInterfaceItemSearching {
 
     nonisolated func performAction(forItem item: Any) {
         guard let item = item as? SearchItem else { return }
-        let onSelect = onSelect
         Task { @MainActor in
-            onSelect(item.topic)
+            self.onSelect(item.topic)
         }
     }
 }
@@ -109,55 +108,31 @@ struct CaskHubHelpSearchRegistration: NSViewRepresentable {
     @Binding var selection: HelpTopic
     @Environment(\.openWindow) private var openWindow
 
-    func makeCoordinator() -> CaskHubHelpSearchCoordinator {
-        CaskHubHelpSearchCoordinator()
+    func makeCoordinator() -> CaskHubHelpSearchHandler {
+        CaskHubHelpSearchHandler()
     }
 
     func makeNSView(context: Context) -> NSView {
         updateSelectionAction(on: context.coordinator)
-        context.coordinator.register()
+        NSApp.registerUserInterfaceItemSearchHandler(context.coordinator)
         return NSView()
     }
 
     func updateNSView(_ view: NSView, context: Context) {
         updateSelectionAction(on: context.coordinator)
-        context.coordinator.register()
     }
 
     static func dismantleNSView(
         _ view: NSView,
-        coordinator: CaskHubHelpSearchCoordinator
+        coordinator: CaskHubHelpSearchHandler
     ) {
-        coordinator.unregister()
+        NSApp.unregisterUserInterfaceItemSearchHandler(coordinator)
     }
 
-    private func updateSelectionAction(on coordinator: CaskHubHelpSearchCoordinator) {
-        coordinator.selectionAction = { topic in
+    private func updateSelectionAction(on handler: CaskHubHelpSearchHandler) {
+        handler.onSelect = { topic in
             selection = topic
             openWindow(id: CaskHubWindowID.help)
         }
-    }
-}
-
-@MainActor
-final class CaskHubHelpSearchCoordinator {
-    typealias SelectionAction = @MainActor (HelpTopic) -> Void
-
-    var selectionAction: SelectionAction = { _ in }
-    private var isRegistered = false
-    private lazy var searchHandler = CaskHubHelpSearchHandler { [weak self] topic in
-        self?.selectionAction(topic)
-    }
-
-    func register() {
-        guard !isRegistered else { return }
-        NSApp.registerUserInterfaceItemSearchHandler(searchHandler)
-        isRegistered = true
-    }
-
-    func unregister() {
-        guard isRegistered else { return }
-        NSApp.unregisterUserInterfaceItemSearchHandler(searchHandler)
-        isRegistered = false
     }
 }

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @AppStorage("viewMode") private var viewMode: ViewMode = .grid
     @FocusState private var searchFocused: Bool
+    @State private var sidebarVisibility: NavigationSplitViewVisibility = .all
     @State private var showsResultsHeader = false
     @State private var searchSignalTask: Task<Void, Never>?
 
@@ -26,7 +27,7 @@ struct ContentView: View {
     )
 
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $sidebarVisibility) {
             SidebarView(
                 selection: Binding(
                     get: { viewModel.selectedSidebar },
@@ -115,6 +116,9 @@ struct ContentView: View {
         .containerBackground(for: .window) {
             WindowBackdrop()
         }
+        .focusedSceneValue(\.catalogViewMode, $viewMode)
+        .focusedSceneValue(\.sidebarVisibility, $sidebarVisibility)
+        .windowToolbarFullScreenVisibility(.onHover)
         .tint(Color.chTerracotta)
         .task {
             await viewModel.load()

--- a/CaskHub/Views/Help/CaskHubHelpView.swift
+++ b/CaskHub/Views/Help/CaskHubHelpView.swift
@@ -1,0 +1,344 @@
+//
+//  CaskHubHelpView.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 08/08/2026.
+//
+
+import SwiftUI
+
+enum CaskHubLinks {
+    static let website = URL(string: "https://caskhub.app")!
+    static let repository = URL(string: "https://github.com/alielsokary/CaskHub")!
+    static let issues = URL(string: "https://github.com/alielsokary/CaskHub/issues/new/choose")!
+    static let homebrew = URL(string: "https://brew.sh")!
+}
+
+enum HelpTopic: String, CaseIterable, Identifiable, Sendable {
+    case gettingStarted
+    case homebrew
+    case installAndUpdate
+    case adoption
+    case permissions
+    case troubleshooting
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .gettingStarted: "Getting Started"
+        case .homebrew: "Homebrew Setup"
+        case .installAndUpdate: "Install & Update"
+        case .adoption: "Adopting Apps"
+        case .permissions: "Permissions"
+        case .troubleshooting: "Troubleshooting"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .gettingStarted: "sparkles"
+        case .homebrew: "shippingbox"
+        case .installAndUpdate: "arrow.down.circle"
+        case .adoption: "arrow.triangle.2.circlepath"
+        case .permissions: "hand.raised"
+        case .troubleshooting: "wrench.and.screwdriver"
+        }
+    }
+}
+
+struct CaskHubHelpView: View {
+    @Binding var selection: HelpTopic
+    @Binding var settingsSelection: SettingsSection
+    let navigateToCatalog: (SidebarSelection) -> Void
+
+    @Environment(LocalHomebrewService.self) private var localHomebrew
+    @Environment(\.openSettings) private var openSettings
+    @Environment(\.openWindow) private var openWindow
+    @AppStorage(SidebarView.showAdoptKey) private var showAdoptApps = true
+
+    var body: some View {
+        NavigationSplitView {
+            List(HelpTopic.allCases, selection: $selection) { topic in
+                Label(topic.title, systemImage: topic.icon)
+                    .tag(topic)
+            }
+            .listStyle(.sidebar)
+            .navigationSplitViewColumnWidth(min: 190, ideal: 210, max: 240)
+        } detail: {
+            ScrollView {
+                topicContent
+                    .frame(maxWidth: 680, alignment: .leading)
+                    .padding(32)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .background(Color(nsColor: .windowBackgroundColor))
+        }
+        .tint(Color.chTerracotta)
+    }
+
+    @ViewBuilder
+    private var topicContent: some View {
+        switch selection {
+        case .gettingStarted:
+            HelpPage(
+                title: "Welcome to CaskHub",
+                subtitle: "Browse the Homebrew catalog freely, then use your local Homebrew installation to manage apps."
+            ) {
+                HelpSection(title: "Browse", icon: "square.grid.2x2") {
+                    Text("""
+                    Explore featured apps, top charts, recent releases, and categories. Browsing does not require \
+                    Homebrew to be installed.
+                    """)
+                }
+
+                HelpSection(title: "Manage", icon: "shippingbox") {
+                    Text("Install new apps, update Homebrew-managed apps, or adopt compatible apps already installed on your Mac.")
+                }
+
+                HStack {
+                    Button("Browse Apps") {
+                        openCatalog(.discover(.browse))
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button("Check Homebrew Setup") {
+                        selection = .homebrew
+                    }
+                }
+            }
+
+        case .homebrew:
+            HelpPage(
+                title: "Homebrew Setup",
+                subtitle: "Homebrew is only required when CaskHub needs to install, update, adopt, repair, or uninstall an app."
+            ) {
+                HelpSection(title: "Current Status", icon: homebrewStatusIcon) {
+                    Text(homebrewStatusText)
+
+                    if localHomebrew.brewVersion == nil {
+                        Text("Install Homebrew from its official website, return to CaskHub, and the app will detect it automatically.")
+                    }
+                }
+
+                HelpSection(title: "Custom Locations", icon: "folder") {
+                    Text("""
+                    If Homebrew lives outside /opt/homebrew or /usr/local, choose its binary or installation folder \
+                    in CaskHub Settings.
+                    """)
+                }
+
+                HStack {
+                    Link("Open brew.sh", destination: CaskHubLinks.homebrew)
+                        .buttonStyle(.borderedProminent)
+
+                    Button("Open Homebrew Settings") {
+                        openSettings(section: .homebrew)
+                    }
+                }
+            }
+
+        case .installAndUpdate:
+            HelpPage(
+                title: "Install & Update",
+                subtitle: "CaskHub runs operations through your real brew binary, so the same apps remain manageable from Terminal."
+            ) {
+                HelpSection(title: "Installing", icon: "arrow.down.circle") {
+                    Text("""
+                    Choose Install on any catalog card. CaskHub shows live progress and lets you cancel downloads \
+                    while Homebrew supports cancellation safely.
+                    """)
+                }
+
+                HelpSection(title: "Updating", icon: "arrow.triangle.2.circlepath") {
+                    Text("""
+                    The Updates page lists Homebrew-managed apps with meaningful updates. Update All asks for \
+                    confirmation before starting the batch.
+                    """)
+                }
+
+                HelpSection(title: "Greedy Updates", icon: "checkmark.circle") {
+                    Text("""
+                    Enable Greedy to include casks that normally update themselves. Leave it off when you prefer \
+                    each app's built-in updater.
+                    """)
+                }
+
+                Button("Show Available Updates") {
+                    openCatalog(.library(.updates))
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+        case .adoption:
+            HelpPage(
+                title: "Adopting Apps",
+                subtitle: "Adoption brings a compatible app installed outside Homebrew under Homebrew management."
+            ) {
+                HelpSection(title: "What Changes", icon: "arrow.triangle.2.circlepath") {
+                    Text("""
+                    CaskHub asks Homebrew to create its management records for the existing app. Your documents, \
+                    accounts, and app preferences stay in their normal locations.
+                    """)
+                }
+
+                HelpSection(title: "Package Installers", icon: "shippingbox.fill") {
+                    Text("""
+                    Apps installed from a package may need Homebrew's installer to run again. CaskHub explains \
+                    this and asks before continuing.
+                    """)
+                }
+
+                HelpSection(title: "When Adoption Cannot Continue", icon: "exclamationmark.triangle") {
+                    Text("""
+                    If the installed bundle does not match the cask, CaskHub can offer Homebrew's version instead. \
+                    Review that recovery action before accepting it.
+                    """)
+                }
+
+                Button("Show Adoptable Apps") {
+                    showAdoptApps = true
+                    openCatalog(.library(.adopt))
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+        case .permissions:
+            HelpPage(
+                title: "App Management Permission",
+                subtitle: "macOS may require permission before CaskHub can modify an application installed in /Applications."
+            ) {
+                HelpSection(title: "Why It Is Needed", icon: "hand.raised") {
+                    Text("""
+                    Some adoption and update operations need to replace or modify another app's bundle. macOS \
+                    protects those changes with App Management permission.
+                    """)
+                }
+
+                HelpSection(title: "How to Grant It", icon: "gearshape") {
+                    Text("""
+                    Open System Settings → Privacy & Security → App Management, then enable CaskHub. Return to \
+                    CaskHub afterward; a pending adoption can resume automatically.
+                    """)
+                }
+
+                HStack {
+                    Button("Open System Settings") {
+                        AppManagementPermission.openSystemSettings()
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button("View Permission Status") {
+                        openSettings(section: .general)
+                    }
+                }
+            }
+
+        case .troubleshooting:
+            HelpPage(
+                title: "Troubleshooting",
+                subtitle: "Start with the recovery action CaskHub presents for the affected app."
+            ) {
+                HelpSection(title: "Homebrew Not Found", icon: "magnifyingglass") {
+                    Text("Confirm Homebrew is installed. If it uses a custom prefix, select that location in Homebrew Settings.")
+                }
+
+                HelpSection(title: "Permission Denied", icon: "lock") {
+                    Text("""
+                    Grant App Management permission and retry. CaskHub only requests this when an operation may \
+                    modify another app bundle.
+                    """)
+                }
+
+                HelpSection(title: "Repair or Replace", icon: "wrench.and.screwdriver") {
+                    Text("""
+                    Interrupted or mismatched installations can expose Repair & Reinstall or Replace with Homebrew \
+                    Version. These actions appear only when they match the detected failure.
+                    """)
+                }
+
+                HStack {
+                    Button("Open Homebrew Settings") {
+                        openSettings(section: .homebrew)
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Link("Report an Issue", destination: CaskHubLinks.issues)
+                        .buttonStyle(.bordered)
+                }
+            }
+        }
+    }
+
+    private var homebrewStatusIcon: String {
+        localHomebrew.brewVersion == nil ? "xmark.circle" : "checkmark.circle.fill"
+    }
+
+    private var homebrewStatusText: String {
+        guard let version = localHomebrew.brewVersion else {
+            return "Homebrew was not found on this Mac."
+        }
+        return "Homebrew is available: \(version)"
+    }
+
+    private func openCatalog(_ destination: SidebarSelection) {
+        navigateToCatalog(destination)
+        openWindow(id: CaskHubWindowID.main)
+    }
+
+    private func openSettings(section: SettingsSection) {
+        settingsSelection = section
+        openSettings()
+    }
+}
+
+private struct HelpPage<Content: View>: View {
+    let title: String
+    let subtitle: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.largeTitle.bold())
+                Text(subtitle)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            content
+        }
+    }
+}
+
+private struct HelpSection<Content: View>: View {
+    let title: String
+    let icon: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 10) {
+                Label(title, systemImage: icon)
+                    .font(.headline)
+                content
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(6)
+        }
+    }
+}
+
+#Preview {
+    CaskHubHelpView(
+        selection: .constant(.gettingStarted),
+        settingsSelection: .constant(.general),
+        navigateToCatalog: { _ in }
+    )
+    .environment(LocalHomebrewService())
+    .frame(width: 880, height: 620)
+}

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -8,40 +8,57 @@
 import AppKit
 import SwiftUI
 
+enum SettingsSection: Hashable {
+    case general
+    case appearance
+    case homebrew
+    case privacy
+    case updates
+    case about
+}
+
 struct SettingsView: View {
+    @Binding var selection: SettingsSection
+
     var body: some View {
-        TabView {
+        TabView(selection: $selection) {
             GeneralSettingsView()
                 .tabItem {
                     Label("General", systemImage: "gearshape")
                 }
+                .tag(SettingsSection.general)
             AppearanceSettingsView()
                 .tabItem {
                     Label("Appearance", systemImage: "paintbrush")
                 }
+                .tag(SettingsSection.appearance)
             HomebrewSettingsView()
                 .tabItem {
                     Label("Homebrew", systemImage: "shippingbox")
                 }
+                .tag(SettingsSection.homebrew)
             PrivacySettingsView()
                 .tabItem {
                     Label("Privacy", systemImage: "hand.raised")
                 }
+                .tag(SettingsSection.privacy)
             UpdateSettingsView()
                 .tabItem {
                     Label("Updates", systemImage: "arrow.triangle.2.circlepath")
                 }
+                .tag(SettingsSection.updates)
             AboutSettingsView()
                 .tabItem {
                     Label("About", systemImage: "info.circle")
                 }
+                .tag(SettingsSection.about)
         }
         .frame(width: 460, height: 480)
     }
 }
 
 struct AboutSettingsView: View {
-    static let issuesURL = URL(string: "https://github.com/alielsokary/CaskHub/issues/new/choose")!
+    static let issuesURL = CaskHubLinks.issues
 
     private var version: String {
         let info = Bundle.main.infoDictionary
@@ -68,8 +85,7 @@ struct AboutSettingsView: View {
                 .font(.callout)
                 .padding(.top, 4)
 
-            Link("github.com/alielsokary/CaskHub",
-                 destination: URL(string: "https://github.com/alielsokary/CaskHub")!)
+            Link("github.com/alielsokary/CaskHub", destination: CaskHubLinks.repository)
                 .font(.callout)
 
             Spacer()
@@ -375,7 +391,7 @@ struct PrivacySettingsView: View {
 }
 
 #Preview {
-    SettingsView()
+    SettingsView(selection: .constant(.general))
         .environment(UpdaterService())
         .environment(ImageCacheService())
         .environment(LocalHomebrewService())

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -58,8 +58,6 @@ struct SettingsView: View {
 }
 
 struct AboutSettingsView: View {
-    static let issuesURL = CaskHubLinks.issues
-
     private var version: String {
         let info = Bundle.main.infoDictionary
         let short = info?["CFBundleShortVersionString"] as? String ?? "—"
@@ -103,7 +101,7 @@ struct AboutSettingsView: View {
 
                         Spacer()
 
-                        Link("View", destination: Self.issuesURL)
+                        Link("View", destination: CaskHubLinks.issues)
                             .buttonStyle(.bordered)
                     }
                     .frame(maxWidth: .infinity)

--- a/CaskHubTests/App/ApplicationMenuTests.swift
+++ b/CaskHubTests/App/ApplicationMenuTests.swift
@@ -1,0 +1,132 @@
+//
+//  ApplicationMenuTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 09/08/2026.
+//
+
+@testable import CaskHub
+import AppKit
+import XCTest
+
+final class ApplicationMenuTests: XCTestCase {
+    @MainActor
+    func test_help_search_finds_topics_by_title_and_workflow_keywords() throws {
+        let searchHandler = CaskHubHelpSearchHandler { _ in }
+
+        let homebrewResults = searchResults(for: "brew", using: searchHandler)
+        XCTAssertEqual(
+            homebrewResults.flatMap(searchHandler.localizedTitles(forItem:)),
+            ["Homebrew Setup"]
+        )
+
+        let permissionResults = searchResults(for: "privacy", using: searchHandler)
+        XCTAssertEqual(
+            permissionResults.flatMap(searchHandler.localizedTitles(forItem:)),
+            ["App Management Permission"]
+        )
+
+        let updateResults = searchResults(for: "install greedy", using: searchHandler)
+        XCTAssertEqual(
+            updateResults.flatMap(searchHandler.localizedTitles(forItem:)),
+            ["Updating Apps"]
+        )
+
+        let limitedResults = searchResults(for: "app", limit: 2, using: searchHandler)
+        XCTAssertEqual(limitedResults.count, 2)
+    }
+
+    @MainActor
+    func test_help_search_selection_routes_to_matching_topic() async throws {
+        var selectedTopic: HelpTopic?
+        let selectionExpectation = expectation(description: "Help topic selected")
+        let searchHandler = CaskHubHelpSearchHandler {
+            selectedTopic = $0
+            selectionExpectation.fulfill()
+        }
+        let result = try XCTUnwrap(
+            searchResults(for: "adopt", using: searchHandler).first
+        )
+
+        searchHandler.performAction(forItem: result)
+        await fulfillment(of: [selectionExpectation], timeout: 1)
+
+        XCTAssertEqual(selectedTopic, .adoption)
+    }
+
+    @MainActor
+    func test_application_menu_contract() throws {
+        let mainMenu = try XCTUnwrap(NSApp.mainMenu)
+        let topLevelTitles = mainMenu.items.map(\.title)
+
+        XCTAssertFalse(topLevelTitles.contains("File"), "Unexpected menus: \(topLevelTitles)")
+
+        let applicationMenu = try XCTUnwrap(mainMenu.items.first?.submenu)
+        let applicationTitles = applicationMenu.items
+            .filter { !$0.isSeparatorItem }
+            .map(\.title)
+        let aboutIndex = try XCTUnwrap(applicationTitles.firstIndex(of: "About CaskHub"))
+        let aboutItem = try XCTUnwrap(applicationMenu.item(withTitle: "About CaskHub"))
+        XCTAssertNotNil(aboutItem.image)
+        let updateIndex = try XCTUnwrap(
+            applicationTitles.firstIndex(of: "Check for Updates…")
+        )
+        XCTAssertLessThan(aboutIndex, updateIndex, "Application menu: \(applicationTitles)")
+        let rawAboutIndex = applicationMenu.index(of: aboutItem)
+        let updateItem = try XCTUnwrap(applicationMenu.item(withTitle: "Check for Updates…"))
+        XCTAssertEqual(applicationMenu.index(of: updateItem), rawAboutIndex + 1)
+
+        let viewMenu = try XCTUnwrap(mainMenu.item(withTitle: "View")?.submenu)
+        let viewTitles = viewMenu.items.filter { !$0.isSeparatorItem }.map(\.title)
+        let hasSidebarCommand = viewTitles.contains("Show Sidebar")
+            || viewTitles.contains("Hide Sidebar")
+        XCTAssertTrue(hasSidebarCommand, "View menu: \(viewTitles)")
+        XCTAssertTrue(viewTitles.contains("Grid"), "View menu: \(viewTitles)")
+        XCTAssertTrue(viewTitles.contains("List"), "View menu: \(viewTitles)")
+        XCTAssertFalse(viewTitles.contains("Show Tab Bar"), "View menu: \(viewTitles)")
+        XCTAssertFalse(viewTitles.contains("Show All Tabs"), "View menu: \(viewTitles)")
+
+        let windowMenu = try XCTUnwrap(mainMenu.item(withTitle: "Window")?.submenu)
+        let windowTitles = windowMenu.items.filter { !$0.isSeparatorItem }.map(\.title)
+        XCTAssertFalse(windowTitles.contains("CaskHub"), "Window menu: \(windowTitles)")
+        XCTAssertFalse(windowTitles.contains("CaskHub Help"), "Window menu: \(windowTitles)")
+
+        let helpMenu = try XCTUnwrap(mainMenu.item(withTitle: "Help")?.submenu)
+        let helpTitles = helpMenu.items.filter { !$0.isSeparatorItem }.map(\.title)
+        XCTAssertTrue(helpTitles.contains("CaskHub Help"), "Help menu: \(helpTitles)")
+        XCTAssertTrue(helpTitles.contains("Homebrew Setup"), "Help menu: \(helpTitles)")
+        XCTAssertTrue(helpTitles.contains("Adopting Apps"), "Help menu: \(helpTitles)")
+        XCTAssertTrue(helpTitles.contains("App Management Permission"), "Help menu: \(helpTitles)")
+
+        let helpItem = try XCTUnwrap(helpMenu.item(withTitle: "CaskHub Help"))
+        let helpAction = try XCTUnwrap(helpItem.action)
+        XCTAssertTrue(NSApp.sendAction(helpAction, to: helpItem.target, from: helpItem))
+
+        let deadline = Date().addingTimeInterval(2)
+        while !NSApp.windows.contains(where: { $0.title == "CaskHub Help" }), Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        }
+
+        let helpWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "CaskHub Help" })
+        )
+        addTeardownBlock { @MainActor in
+            helpWindow.close()
+        }
+    }
+
+    @MainActor
+    private func searchResults(
+        for query: String,
+        limit: Int = 10,
+        using searchHandler: CaskHubHelpSearchHandler
+    ) -> [Any] {
+        var results: [Any] = []
+        searchHandler.searchForItems(
+            withSearch: query,
+            resultLimit: limit,
+            matchedItemHandler: { results = $0 }
+        )
+        return results
+    }
+}

--- a/CaskHubTests/App/ApplicationMenuTests.swift
+++ b/CaskHubTests/App/ApplicationMenuTests.swift
@@ -97,7 +97,12 @@ final class ApplicationMenuTests: XCTestCase {
         XCTAssertTrue(helpTitles.contains("Homebrew Setup"), "Help menu: \(helpTitles)")
         XCTAssertTrue(helpTitles.contains("Adopting Apps"), "Help menu: \(helpTitles)")
         XCTAssertTrue(helpTitles.contains("App Management Permission"), "Help menu: \(helpTitles)")
+    }
 
+    @MainActor
+    func test_help_menu_opens_help_window() throws {
+        let mainMenu = try XCTUnwrap(NSApp.mainMenu)
+        let helpMenu = try XCTUnwrap(mainMenu.item(withTitle: "Help")?.submenu)
         let helpItem = try XCTUnwrap(helpMenu.item(withTitle: "CaskHub Help"))
         let helpAction = try XCTUnwrap(helpItem.action)
         XCTAssertTrue(NSApp.sendAction(helpAction, to: helpItem.target, from: helpItem))

--- a/CaskHubTests/Views/ContentViewTests.swift
+++ b/CaskHubTests/Views/ContentViewTests.swift
@@ -172,6 +172,23 @@ final class ContentViewTests: XCTestCase {
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
         window.close()
     }
+
+    func test_sidebar_command_toggles_between_visible_and_hidden() {
+        XCTAssertEqual(
+            CaskHubViewCommand.sidebarVisibility(afterToggling: .all),
+            .detailOnly
+        )
+        XCTAssertEqual(
+            CaskHubViewCommand.sidebarVisibility(afterToggling: .detailOnly),
+            .all
+        )
+    }
+
+    func test_sidebar_command_title_describes_the_next_action() {
+        XCTAssertEqual(CaskHubViewCommand.sidebarTitle(for: .all), "Hide Sidebar")
+        XCTAssertEqual(CaskHubViewCommand.sidebarTitle(for: .detailOnly), "Show Sidebar")
+    }
+
 }
 
 final class SidebarViewTests: XCTestCase {

--- a/CaskHubTests/Views/HelpViewTests.swift
+++ b/CaskHubTests/Views/HelpViewTests.swift
@@ -1,0 +1,41 @@
+//
+//  HelpViewTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 09/08/2026.
+//
+
+@testable import CaskHub
+import SwiftUI
+import XCTest
+
+final class HelpViewTests: XCTestCase {
+    func test_help_topics_cover_the_core_caskhub_workflows() {
+        XCTAssertEqual(
+            HelpTopic.allCases,
+            [
+                .gettingStarted,
+                .homebrew,
+                .installAndUpdate,
+                .adoption,
+                .permissions,
+                .troubleshooting
+            ]
+        )
+    }
+
+    @MainActor
+    func test_help_center_renders_every_topic() {
+        for topic in HelpTopic.allCases {
+            let view = CaskHubHelpView(
+                selection: .constant(topic),
+                settingsSelection: .constant(.general),
+                navigateToCatalog: { _ in }
+            )
+            .environment(LocalHomebrewService())
+            let hosting = NSHostingView(rootView: AnyView(view))
+            hosting.frame = NSRect(x: 0, y: 0, width: 880, height: 620)
+            hosting.layoutSubtreeIfNeeded()
+        }
+    }
+}

--- a/CaskHubTests/Views/UpdateSettingsViewTests.swift
+++ b/CaskHubTests/Views/UpdateSettingsViewTests.swift
@@ -22,7 +22,7 @@ final class UpdateSettingsViewTests: XCTestCase {
     @MainActor
     func test_about_support_uses_caskhub_issue_chooser() {
         XCTAssertEqual(
-            AboutSettingsView.issuesURL.absoluteString,
+            CaskHubLinks.issues.absoluteString,
             "https://github.com/alielsokary/CaskHub/issues/new/choose"
         )
     }


### PR DESCRIPTION
## Summary
- replace redundant default macOS commands with focused application, View, Window, and Help behavior
- add a searchable CaskHub Help window covering setup, installs, updates, adoption, permissions, and troubleshooting
- preserve native About and updater menu presentation, sidebar and layout commands, and singleton window behavior
- add runtime menu/search coverage plus Help rendering and sidebar command tests

## Validation
- xcodebuild: ApplicationMenuTests, ContentViewTests, SettingsViewTests, and HelpViewTests passed
- strict SwiftLint: 0 violations across changed Swift files
- git diff --check passed