### PR TITLE
chore: prefill issue titles with [BUG]/[FEATURE] prefixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,7 @@
 ---
 name: 🐛 Bug Report
 about: Something in the app is broken or misbehaving
+title: "[BUG] "
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,6 +1,7 @@
 ---
 name: ✨ Feature Request
 about: Suggest an idea or improvement for CaskHub
+title: "[FEATURE] "
 labels: enhancement
 ---
 


### PR DESCRIPTION
## Summary
Adds `title:` frontmatter to both issue templates so the title field is prefilled when opening a new issue:

- Bug Report → `[BUG] `
- Feature Request → `[FEATURE] `

Trailing space included so filers can type directly after the prefix.