### PR TITLE
feat: localize category names

### DIFF
--- a/CaskHub/Resources/Localizable.xcstrings
+++ b/CaskHub/Resources/Localizable.xcstrings
@@ -1961,6 +1961,330 @@
         }
       }
     },
+    "category.ai" : {
+      "comment" : "Category name (categories.json id: ai)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI & LLMs"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 与大模型"
+          }
+        }
+      }
+    },
+    "category.audioMusic" : {
+      "comment" : "Category name (categories.json id: audioMusic)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio & Music"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音频与音乐"
+          }
+        }
+      }
+    },
+    "category.browsers" : {
+      "comment" : "Category name (categories.json id: browsers)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browsers"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浏览器"
+          }
+        }
+      }
+    },
+    "category.cloudStorage" : {
+      "comment" : "Category name (categories.json id: cloudStorage)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloud & Storage"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "云与存储"
+          }
+        }
+      }
+    },
+    "category.communication" : {
+      "comment" : "Category name (categories.json id: communication)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Communication"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通讯"
+          }
+        }
+      }
+    },
+    "category.designGraphics" : {
+      "comment" : "Category name (categories.json id: designGraphics)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Design & Graphics"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设计与图形"
+          }
+        }
+      }
+    },
+    "category.developerTools" : {
+      "comment" : "Category name (categories.json id: developerTools)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Developer Tools"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开发者工具"
+          }
+        }
+      }
+    },
+    "category.financeCrypto" : {
+      "comment" : "Category name (categories.json id: financeCrypto)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finance & Crypto"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金融与加密货币"
+          }
+        }
+      }
+    },
+    "category.games" : {
+      "comment" : "Category name (categories.json id: games)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Games"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "游戏"
+          }
+        }
+      }
+    },
+    "category.menuBar" : {
+      "comment" : "Category name (categories.json id: menuBar)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu Bar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "菜单栏"
+          }
+        }
+      }
+    },
+    "category.officeTools" : {
+      "comment" : "Category name (categories.json id: officeTools)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Office Tools"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "办公工具"
+          }
+        }
+      }
+    },
+    "category.other" : {
+      "comment" : "Category name (categories.json id: other)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Other"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
+        }
+      }
+    },
+    "category.productivity" : {
+      "comment" : "Category name (categories.json id: productivity)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Productivity"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "效率"
+          }
+        }
+      }
+    },
+    "category.scienceEducation" : {
+      "comment" : "Category name (categories.json id: scienceEducation)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Science & Education"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "科学与教育"
+          }
+        }
+      }
+    },
+    "category.screensaverWallpaper" : {
+      "comment" : "Category name (categories.json id: screensaverWallpaper)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Screensaver & Wallpaper"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "屏保与壁纸"
+          }
+        }
+      }
+    },
+    "category.securityPrivacy" : {
+      "comment" : "Category name (categories.json id: securityPrivacy)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Security & Privacy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全与隐私"
+          }
+        }
+      }
+    },
+    "category.utilities" : {
+      "comment" : "Category name (categories.json id: utilities)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilities"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实用工具"
+          }
+        }
+      }
+    },
+    "category.videoMedia" : {
+      "comment" : "Category name (categories.json id: videoMedia)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video & Media"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "视频与媒体"
+          }
+        }
+      }
+    },
     "error.adoptMissingComponent" : {
       "comment" : "Error when adoption is blocked by a missing binary the cask ships",
       "extractionState" : "manual",

--- a/CaskHub/Services/Catalog/CategoryService.swift
+++ b/CaskHub/Services/Catalog/CategoryService.swift
@@ -10,6 +10,12 @@ import Observation
 
 typealias CategoryID = String
 
+/// Falls back to the pipeline's English name when the catalog has no
+/// `category.<id>` entry yet (e.g. a new category shipped via data sync).
+nonisolated func localizedCategoryName(_ id: CategoryID, fallback: String) -> String {
+    Bundle.main.localizedString(forKey: "category.\(id)", value: fallback, table: nil)
+}
+
 nonisolated struct CategoryDefinition: Codable, Hashable {
     let displayName: String
     let icon: String
@@ -47,7 +53,9 @@ final class CategoryService {
             .sorted { lhs, rhs in
                 if lhs.key == "other" { return false }
                 if rhs.key == "other" { return true }
-                return lhs.value.displayName.localizedCaseInsensitiveCompare(rhs.value.displayName) == .orderedAscending
+                let lhsName = localizedCategoryName(lhs.key, fallback: lhs.value.displayName)
+                let rhsName = localizedCategoryName(rhs.key, fallback: rhs.value.displayName)
+                return lhsName.localizedCaseInsensitiveCompare(rhsName) == .orderedAscending
             }
             .map { (id: $0.key, definition: $0.value) }
     }
@@ -102,6 +110,7 @@ final class CategoryService {
     }
 
     func displayName(for categoryID: CategoryID) -> String {
-        categoryDefinitions[categoryID]?.displayName ?? categoryID
+        guard let definition = categoryDefinitions[categoryID] else { return categoryID }
+        return localizedCategoryName(categoryID, fallback: definition.displayName)
     }
 }

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel+Projection.swift
@@ -100,7 +100,7 @@ extension CaskCatalogViewModel {
                     annualDownloadCounts: analyticsByPeriod[.days365] ?? [:],
                     categoryMappings: categoryService.tokenMappings,
                     orderedCategories: categoryService.orderedCategories.map {
-                        (id: $0.id, displayName: $0.definition.displayName)
+                        (id: $0.id, displayName: categoryService.displayName(for: $0.id))
                     },
                     recentTokens: recentlyAdded.recentTokens(
                         within: recentlyAddedWindow.rawValue

--- a/CaskHub/ViewModels/Catalog/Projection/CaskMetadataProjector.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CaskMetadataProjector.swift
@@ -33,7 +33,8 @@ enum CaskCategoryProjector {
         for categoryID: CategoryID,
         definitions: [CategoryID: CategoryDefinition]
     ) -> String {
-        definitions[categoryID]?.displayName ?? categoryID
+        guard let definition = definitions[categoryID] else { return categoryID }
+        return localizedCategoryName(categoryID, fallback: definition.displayName)
     }
 }
 

--- a/CaskHub/Views/Sidebar/SidebarView.swift
+++ b/CaskHub/Views/Sidebar/SidebarView.swift
@@ -43,7 +43,7 @@ struct SidebarView: View {
                     ForEach(categoryService.orderedCategories, id: \.id) { entry in
                         row(
                             .category(entry.id),
-                            title: entry.definition.displayName,
+                            title: categoryService.displayName(for: entry.id),
                             icon: entry.definition.icon,
                             count: categoryCounts[entry.id]
                         )

--- a/CaskHubTests/Catalog/CaskCatalogSortTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogSortTests.swift
@@ -9,6 +9,16 @@
 import XCTest
 
 final class CaskCatalogSortTests: XCTestCase {
+    func test_every_bundled_category_has_localized_name_entry() throws {
+        let url = try XCTUnwrap(Bundle.main.url(forResource: "categories", withExtension: "json"))
+        let catalog = try JSONDecoder().decode(CaskCategoryData.self, from: Data(contentsOf: url))
+        let sentinel = "⟪missing⟫"
+        for id in catalog.categories.keys {
+            let value = Bundle.main.localizedString(forKey: "category.\(id)", value: sentinel, table: nil)
+            XCTAssertNotEqual(value, sentinel, "Localizable.xcstrings has no category.\(id) entry")
+        }
+    }
+
     private func detectedApplication(named name: String) -> DetectedApplication {
         DetectedApplication(
             url: URL(fileURLWithPath: "/Applications/\(name)"),

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ You can opt out of both at any time in **Settings → Privacy**.
 
 CaskHub speaks your language. Currently available in:
 
-- **English**
-- **简体中文 (Simplified Chinese)** — translated by [@carty900-jpg](https://github.com/carty900-jpg)
+- 🇬🇧 **English**
+- 🇨🇳 **简体中文 (Simplified Chinese)** — translated by [@carty900-jpg](https://github.com/carty900-jpg)
 
 macOS picks the language automatically from your system preferences; a per-app override is available under **System Settings → General → Language & Region → Applications**.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ CaskHub also sends anonymous crash reports through [Sentry](https://sentry.io) t
 
 You can opt out of both at any time in **Settings → Privacy**.
 
+## Localization
+
+CaskHub speaks your language. Currently available in:
+
+- **English**
+- **简体中文 (Simplified Chinese)** — translated by [@carty900-jpg](https://github.com/carty900-jpg)
+
+macOS picks the language automatically from your system preferences; a per-app override is available under **System Settings → General → Language & Region → Applications**.
+
+Want CaskHub in your language? Translations live in a single [String Catalog](CaskHub/Resources/Localizable.xcstrings) — open an issue or PR to add yours.
+
 ## Contributing
 
 Interested in contributing to CaskHub? We welcome contributions of all kinds!


### PR DESCRIPTION
## Summary
Category names from categories.json now localize through the string catalog, keyed by stable category id (`category.developerTools` etc.) with the pipeline's English `displayName` as fallback — a new category shipped via data sync degrades to English, never a raw key.

- Single lookup helper; all four display paths route through it (sidebar, browse sections, top bar title, info popover main/subcategories).
- Sidebar ordering now sorts by the localized name, so zh gets pinyin order instead of English alphabetical. "Other" stays pinned last.
- 18 manual catalog entries with en + zh-Hans values.
- Guard test: every id in bundled categories.json must have a `category.<id>` entry — fails the suite when the pipeline adds a category, so translations get added consciously.

Stacked on #126 (needs its zh catalog); diff collapses to the last commit once that merges.