### PR TITLE
fix: Stabilize macOS application menu items

### DIFF
--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -67,62 +67,58 @@ struct CaskHubApp: App {
     }
 
     var body: some Scene {
-        Window("CaskHub", id: CaskHubWindowID.main) {
-            ContentView(viewModel: catalog)
-                .frame(minWidth: 1380, minHeight: 640)
-                .background {
-                    WindowCloseButtonConfigurator {
-                        terminationCoordinator.requestTermination()
+        Group {
+            Window("CaskHub", id: CaskHubWindowID.main) {
+                ContentView(viewModel: catalog)
+                    .frame(minWidth: 1380, minHeight: 640)
+                    .background {
+                        WindowCloseButtonConfigurator {
+                            terminationCoordinator.requestTermination()
+                        }
                     }
-                }
-                .background {
-                    CaskHubHelpSearchRegistration(selection: $helpTopic)
-                }
-                .onAppear {
-                    terminationCoordinator.configure {
-                        localHomebrew.hasActiveOperations
+                    .background {
+                        CaskHubHelpSearchRegistration(selection: $helpTopic)
                     }
-                }
-                .onChange(of: selectedTheme, initial: true) { _, newValue in
-                    AppTheme.apply(newValue)
-                }
-                .environment(categoryService)
-                .environment(recentlyAdded)
-                .environment(localHomebrew)
-                .environment(imageCache)
-        }
-        .defaultSize(width: 1360, height: 880)
-        .windowStyle(.hiddenTitleBar)
-        .commandsRemoved()
-        .commands {
-            CommandGroup(replacing: .newItem) {}
-            CaskHubApplicationCommands(updater: updaterService)
-            CaskHubViewCommands()
-            CaskHubHelpCommands(selection: $helpTopic)
-        }
+                    .onAppear {
+                        terminationCoordinator.configure {
+                            localHomebrew.hasActiveOperations
+                        }
+                    }
+                    .onChange(of: selectedTheme, initial: true) { _, newValue in
+                        AppTheme.apply(newValue)
+                    }
+                    .environment(categoryService)
+                    .environment(recentlyAdded)
+                    .environment(localHomebrew)
+                    .environment(imageCache)
+            }
+            .defaultSize(width: 1360, height: 880)
+            .windowStyle(.hiddenTitleBar)
+            .commandsRemoved()
+            .commands {
+                CommandGroup(replacing: .newItem) {}
+                CaskHubViewCommands()
+            }
 
-        Window("CaskHub Help", id: CaskHubWindowID.help) {
-            CaskHubHelpView(
-                selection: $helpTopic,
-                settingsSelection: $settingsSection,
-                navigateToCatalog: { catalog.selectedSidebar = $0 }
-            )
-            .environment(localHomebrew)
-            .frame(minWidth: 760, minHeight: 520)
-        }
-        .defaultSize(width: 880, height: 620)
-        .windowResizability(.contentMinSize)
-        .commandsRemoved()
-        .commands {
-            CaskHubApplicationCommands(updater: updaterService)
-            CaskHubHelpCommands(selection: $helpTopic)
-        }
-
-        Settings {
-            SettingsView(selection: $settingsSection)
-                .environment(updaterService)
-                .environment(imageCache)
+            Window("CaskHub Help", id: CaskHubWindowID.help) {
+                CaskHubHelpView(
+                    selection: $helpTopic,
+                    settingsSelection: $settingsSection,
+                    navigateToCatalog: { catalog.selectedSidebar = $0 }
+                )
                 .environment(localHomebrew)
+                .frame(minWidth: 760, minHeight: 520)
+            }
+            .defaultSize(width: 880, height: 620)
+            .windowResizability(.contentMinSize)
+            .commandsRemoved()
+
+            Settings {
+                SettingsView(selection: $settingsSection)
+                    .environment(updaterService)
+                    .environment(imageCache)
+                    .environment(localHomebrew)
+            }
         }
         .commands {
             CaskHubApplicationCommands(updater: updaterService)

--- a/CaskHubTests/App/ApplicationMenuTests.swift
+++ b/CaskHubTests/App/ApplicationMenuTests.swift
@@ -100,8 +100,30 @@ final class ApplicationMenuTests: XCTestCase {
     }
 
     @MainActor
+    func test_opening_application_menu_preserves_its_items() throws {
+        let applicationMenu = try XCTUnwrap(NSApp.mainMenu?.items.first?.submenu)
+        let expectedItems = applicationMenuContract(applicationMenu)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            applicationMenu.cancelTracking()
+        }
+        _ = applicationMenu.popUp(
+            positioning: nil,
+            at: NSPoint(x: 20, y: 20),
+            in: nil
+        )
+
+        let openedItems = applicationMenuContract(applicationMenu)
+        XCTAssertGreaterThanOrEqual(openedItems.count, expectedItems.count)
+        XCTAssertEqual(Array(openedItems.prefix(expectedItems.count)), expectedItems)
+    }
+
+    @MainActor
     func test_help_menu_opens_help_window() throws {
         let mainMenu = try XCTUnwrap(NSApp.mainMenu)
+        let applicationMenu = try XCTUnwrap(mainMenu.items.first?.submenu)
+        let expectedApplicationItems = applicationMenuContract(applicationMenu)
+        let expectedApplicationItemIDs = applicationMenu.items.map(ObjectIdentifier.init)
         let helpMenu = try XCTUnwrap(mainMenu.item(withTitle: "Help")?.submenu)
         let helpItem = try XCTUnwrap(helpMenu.item(withTitle: "CaskHub Help"))
         let helpAction = try XCTUnwrap(helpItem.action)
@@ -115,8 +137,55 @@ final class ApplicationMenuTests: XCTestCase {
         let helpWindow = try XCTUnwrap(
             NSApp.windows.first(where: { $0.title == "CaskHub Help" })
         )
+        helpWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        let activeApplicationItems = applicationMenuContract(applicationMenu)
+        XCTAssertEqual(
+            Array(activeApplicationItems.prefix(expectedApplicationItems.count)),
+            expectedApplicationItems
+        )
+        XCTAssertEqual(
+            Array(applicationMenu.items.map(ObjectIdentifier.init)
+                .prefix(expectedApplicationItemIDs.count)),
+            expectedApplicationItemIDs
+        )
         addTeardownBlock { @MainActor in
             helpWindow.close()
+        }
+    }
+
+    @MainActor
+    func test_settings_window_keeps_application_menu_items_stable() throws {
+        let applicationMenu = try XCTUnwrap(NSApp.mainMenu?.items.first?.submenu)
+        let expectedItems = applicationMenuContract(applicationMenu)
+        let expectedItemIDs = applicationMenu.items.map(ObjectIdentifier.init)
+        let existingWindowIDs = Set(NSApp.windows.map(ObjectIdentifier.init))
+        let settingsItem = try XCTUnwrap(applicationMenu.item(withTitle: "Settings…"))
+        let settingsAction = try XCTUnwrap(settingsItem.action)
+
+        XCTAssertTrue(NSApp.sendAction(settingsAction, to: settingsItem.target, from: settingsItem))
+
+        let deadline = Date().addingTimeInterval(2)
+        while NSApp.windows.allSatisfy({ existingWindowIDs.contains(ObjectIdentifier($0)) }),
+              Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        }
+
+        let settingsWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { !existingWindowIDs.contains(ObjectIdentifier($0)) })
+        )
+        settingsWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        let activeItems = applicationMenuContract(applicationMenu)
+        XCTAssertEqual(Array(activeItems.prefix(expectedItems.count)), expectedItems)
+        XCTAssertEqual(
+            Array(applicationMenu.items.map(ObjectIdentifier.init).prefix(expectedItemIDs.count)),
+            expectedItemIDs
+        )
+        addTeardownBlock { @MainActor in
+            settingsWindow.close()
         }
     }
 
@@ -134,4 +203,27 @@ final class ApplicationMenuTests: XCTestCase {
         )
         return results
     }
+
+    @MainActor
+    private func applicationMenuContract(_ menu: NSMenu) -> [ApplicationMenuItemContract] {
+        menu.items.map {
+            ApplicationMenuItemContract(
+                title: $0.title,
+                isSeparator: $0.isSeparatorItem,
+                keyEquivalent: $0.keyEquivalent,
+                keyEquivalentModifierMask: $0.keyEquivalentModifierMask,
+                hasImage: $0.image != nil,
+                hasSubmenu: $0.submenu != nil
+            )
+        }
+    }
+}
+
+private struct ApplicationMenuItemContract: Equatable {
+    let title: String
+    let isSeparator: Bool
+    let keyEquivalent: String
+    let keyEquivalentModifierMask: NSEvent.ModifierFlags
+    let hasImage: Bool
+    let hasSubmenu: Bool
 }


### PR DESCRIPTION
## Summary

- Give the shared application and Help commands one scene-level owner
- Preserve the existing menu titles, ordering, shortcuts, images, submenus, and actions
- Add integration coverage for menu opening and Help/Settings scene transitions
- Prevent SwiftUI from swapping duplicate menu-item representations and emitting AppKit identity/height warnings

## Validation

- full CaskHub test suite
- strict SwiftLint for the changed files
- signed Debug build
- application launch/process smoke check
- filtered runtime log for the warning signatures

## Checklist

- [x] Base branch is develop (not master)
- [x] Title uses a conventional prefix + Sentence-case subject
- [x] Tests added or updated (Codecov patch target: 80%)
- [x] SwiftLint build phase passes locally
- [x] No changes to CaskHub/Resources/*.json or CHANGELOG.md