### PR TITLE
feat: bring browse sections and house pick to list view

### DIFF
--- a/CaskHub/DesignSystem/Tokens/TypographyTokens.swift
+++ b/CaskHub/DesignSystem/Tokens/TypographyTokens.swift
@@ -32,6 +32,7 @@ enum CHType {
     static let downloadLabel = Font.custom(uiFamily, size: 10).weight(.semibold)
     static let downloadProgress = Font.custom(uiFamily, size: 9).weight(.semibold)
     static let label = Font.custom(uiFamily, size: 10).weight(.heavy) // + .kerning(trackingLabel), uppercase
+    static let labelSm = Font.custom(uiFamily, size: 9).weight(.heavy) // row eyebrow
 
     // Mono — versions, counts, keycaps, status bar
     static let metaMono = Font.custom(monoFamily, size: 9.5)

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -202,7 +202,6 @@ struct ContentView: View {
     private var showsBrowseSections: Bool {
         selectedSidebar == .discover(.browse)
             && viewModel.appliedSearchText.isEmpty
-            && viewMode == .grid
     }
 
     private var sortOptions: [SortOption] {
@@ -265,26 +264,56 @@ private extension ContentView {
         .frame(maxWidth: .infinity)
     }
 
+    @ViewBuilder
     var listContent: some View {
-        LazyVStack(spacing: 0) {
-            ForEach(viewModel.displayedCasks) { cask in
-                CaskRowView(
-                    cask: cask,
-                    downloads: viewModel.formattedDownloads(for: cask.token),
-                    category: categoryInfo(for: cask),
-                    localState: viewModel.localState(for: cask)
-                )
-                .padding(.vertical, 6)
+        if showsBrowseSections {
+            VStack(alignment: .leading, spacing: CHSpace.s4) {
+                if let hero = heroCask {
+                    VStack(spacing: 0) {
+                        CaskRowView(
+                            cask: hero,
+                            downloads: viewModel.formattedDownloads(for: hero.token),
+                            category: categoryInfo(for: hero),
+                            localState: viewModel.localState(for: hero),
+                            eyebrow: "✷ HOUSE PICK"
+                        )
+                        .padding(.vertical, 6)
 
-                Color.chHairline
-                    .frame(height: 1)
+                        Color.chHairline
+                            .frame(height: 1)
+                    }
+                }
+                ForEach(viewModel.browseSections) { section in
+                    browseSectionView(section)
+                }
             }
-            if viewModel.hasMoreToReveal {
-                RevealSentinel { viewModel.revealMore() }
+            .frame(width: CHSize.contentWidth, alignment: .leading)
+            .frame(maxWidth: .infinity)
+        } else {
+            LazyVStack(spacing: 0) {
+                caskList(viewModel.displayedCasks)
+                if viewModel.hasMoreToReveal {
+                    RevealSentinel { viewModel.revealMore() }
+                }
             }
+            .frame(width: CHSize.contentWidth)
+            .frame(maxWidth: .infinity)
         }
-        .frame(width: CHSize.contentWidth)
-        .frame(maxWidth: .infinity)
+    }
+
+    func caskList(_ casks: [Cask]) -> some View {
+        ForEach(casks) { cask in
+            CaskRowView(
+                cask: cask,
+                downloads: viewModel.formattedDownloads(for: cask.token),
+                category: categoryInfo(for: cask),
+                localState: viewModel.localState(for: cask)
+            )
+            .padding(.vertical, 6)
+
+            Color.chHairline
+                .frame(height: 1)
+        }
     }
 
     // showsReveal stays off for browse shelves — global reveal state, not theirs.
@@ -322,7 +351,14 @@ private extension ContentView {
                 }
                 .buttonStyle(.plain)
             }
-            caskGrid(section.casks)
+            switch viewMode {
+            case .grid:
+                caskGrid(section.casks)
+            case .list:
+                LazyVStack(spacing: 0) {
+                    caskList(section.casks)
+                }
+            }
         }
         .padding(.top, CHSpace.s3)
     }

--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -13,6 +13,7 @@ struct CaskRowView: View {
     var downloads: String?
     var category: CaskCategoryPresentation?
     var localState: CaskLocalState?
+    var eyebrow: LocalizedStringKey?
 
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @State private var showDeleteConfirmation = false
@@ -37,6 +38,13 @@ struct CaskRowView: View {
 
     private var appInfo: some View {
         VStack(alignment: .leading, spacing: 2) {
+            if let eyebrow {
+                Text(eyebrow)
+                    .font(CHType.labelSm)
+                    .kerning(CHType.trackingLabel)
+                    .foregroundStyle(Color.chTextBrand)
+                    .padding(.bottom, 4)
+            }
             Text(cask.displayName)
                 .font(CHType.cardTitle)
                 .foregroundStyle(Color.chTextTitle)


### PR DESCRIPTION
## Summary
- Browse in list view now shows the same shelves as grid: House Pick hero, Most Popular, Recently Added, and the category sections, each with its View All link.
- The hero renders as a regular list row with a "✷ HOUSE PICK" eyebrow (new optional `eyebrow` on `CaskRowView`), so icon size, meta format, action button, and menu slot align pixel-perfect with the rows below.
- New `CHType.labelSm` token (9pt heavy + `trackingLabel`) keeps the row eyebrow compact; the grid hero card is untouched.
- Extracted `caskList(_:)` so flat list pages and browse shelves share one row renderer.

## Test plan
- Build succeeds (`xcodebuild -scheme CaskHub`).
- Browse + list mode: hero row, sections with headers and View All, no sort control (matches grid behavior).
- Browse + grid mode unchanged; other sidebar pages keep flat list with reveal sentinel.