### PR TITLE
fix: keep modal dialogs and askpass disk I/O out of hang telemetry

### DIFF
--- a/CaskHub/App/ApplicationTerminationCoordinator.swift
+++ b/CaskHub/App/ApplicationTerminationCoordinator.swift
@@ -31,7 +31,9 @@ final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate {
             alert.addButton(withTitle: String(localized: "Keep Running"))
             alert.buttons.first?.hasDestructiveAction = true
             alert.buttons.last?.keyEquivalent = "\u{1b}"
-            return alert.runModal() == .alertFirstButtonReturn
+            return CrashReporter.withHangTrackingPaused {
+                alert.runModal()
+            } == .alertFirstButtonReturn
         }
         super.init()
     }

--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -101,11 +101,6 @@ final class HomebrewMutationCoordinator {
         }
 
         let askpass = await AskpassScriptManager.create(token: token)
-        defer {
-            if let askpass {
-                Task { await AskpassScriptManager.remove(at: askpass) }
-            }
-        }
 
         var environment = ProcessInfo.processInfo.environment
         environment.merge(environmentOverrides) { _, override in override }
@@ -115,20 +110,28 @@ final class HomebrewMutationCoordinator {
             environment["SUDO_ASKPASS"] = askpass.path
         }
 
-        let result = try await commandExecutor.execute(
-            HomebrewCommandRequest(
-                token: token,
-                executableURL: brewURL,
-                arguments: arguments,
-                environment: environment
-            ),
-            onStart: { [self] in
-                operationStore.send(.setCancellable(cancellable), for: token)
-            },
-            onChunk: { [self] text in
-                consumeBrewOutput(text, token: token)
-            }
-        )
+        // defer can't await; remove the script deterministically on both exits.
+        let result: BrewProcessResult
+        do {
+            result = try await commandExecutor.execute(
+                HomebrewCommandRequest(
+                    token: token,
+                    executableURL: brewURL,
+                    arguments: arguments,
+                    environment: environment
+                ),
+                onStart: { [self] in
+                    operationStore.send(.setCancellable(cancellable), for: token)
+                },
+                onChunk: { [self] text in
+                    consumeBrewOutput(text, token: token)
+                }
+            )
+        } catch {
+            if let askpass { await AskpassScriptManager.remove(at: askpass) }
+            throw error
+        }
+        if let askpass { await AskpassScriptManager.remove(at: askpass) }
 
         guard result.exitCode != 0 else { return }
         throw LocalHomebrewError.brewCommandFailed(

--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -100,9 +100,11 @@ final class HomebrewMutationCoordinator {
             throw LocalHomebrewError.brewBinaryNotFound
         }
 
-        let askpass = AskpassScriptManager.create(token: token)
+        let askpass = await AskpassScriptManager.create(token: token)
         defer {
-            if let askpass { AskpassScriptManager.remove(at: askpass) }
+            if let askpass {
+                Task { await AskpassScriptManager.remove(at: askpass) }
+            }
         }
 
         var environment = ProcessInfo.processInfo.environment

--- a/CaskHub/Services/Homebrew/Infrastructure/AskpassScriptManager.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/AskpassScriptManager.swift
@@ -8,11 +8,13 @@
 import Foundation
 
 nonisolated enum AskpassScriptManager {
+    // @concurrent: callers are MainActor; these touch disk and must not run there.
+    @concurrent
     static func create(
         token: String,
         directory: URL? = nil,
         executableURL: URL? = Bundle.main.executableURL
-    ) -> URL? {
+    ) async -> URL? {
         guard let executablePath = executableURL?.path else { return nil }
         let safeToken = token.filter {
             $0.isLetter || $0.isNumber || "-_+@.".contains($0)
@@ -55,7 +57,8 @@ nonisolated enum AskpassScriptManager {
         return url
     }
 
-    static func remove(at url: URL) {
+    @concurrent
+    static func remove(at url: URL) async {
         try? FileManager.default.removeItem(at: url)
     }
 

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -20,6 +20,13 @@ protocol CrashReporterProvider {
     func addBreadcrumb(_ message: String, data: [String: String])
     func setTag(_ key: String, value: String)
     func startSpan(name: String, operation: String) -> CrashSpan
+    func pauseHangTracking()
+    func resumeHangTracking()
+}
+
+extension CrashReporterProvider {
+    func pauseHangTracking() {}
+    func resumeHangTracking() {}
 }
 
 enum CrashReporter {
@@ -106,6 +113,23 @@ enum CrashReporter {
         guard isEnabled else { return NoOpCrashSpan() }
         return provider.startSpan(name: name, operation: operation)
     }
+
+    // Hang detection pings the main queue in the default run-loop mode; app-modal
+    // panels spin NSModalPanelRunLoopMode, so any dialog open >2s reports as a
+    // fake hang. Pause around every runModal-style nested run loop.
+    static func pauseHangTracking() {
+        provider.pauseHangTracking()
+    }
+
+    static func resumeHangTracking() {
+        provider.resumeHangTracking()
+    }
+
+    static func withHangTrackingPaused<T>(_ body: () throws -> T) rethrows -> T {
+        pauseHangTracking()
+        defer { resumeHangTracking() }
+        return try body()
+    }
 }
 
 struct NoOpCrashSpan: CrashSpan {
@@ -179,6 +203,14 @@ final class SentryProvider: CrashReporterProvider {
     func startSpan(name: String, operation: String) -> CrashSpan {
         guard started else { return NoOpCrashSpan() }
         return SentrySpanHandle(span: SentrySDK.startTransaction(name: name, operation: operation))
+    }
+
+    func pauseHangTracking() {
+        SentrySDK.pauseAppHangTracking()
+    }
+
+    func resumeHangTracking() {
+        SentrySDK.resumeAppHangTracking()
     }
 }
 

--- a/CaskHub/Services/Updates/UpdaterService.swift
+++ b/CaskHub/Services/Updates/UpdaterService.swift
@@ -50,7 +50,7 @@ final class UpdaterService: NSObject, SPUUpdaterDelegate {
         controller = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: self,
-            userDriverDelegate: nil
+            userDriverDelegate: self
         )
         // Sparkle allows a forced launch check here, before its scheduled cycle starts.
         Self.checkForUpdatesOnLaunch(using: controller.updater)
@@ -106,6 +106,23 @@ final class UpdaterService: NSObject, SPUUpdaterDelegate {
             )
         }
         return false
+    }
+}
+
+// Sparkle's error/info alerts run app-modal; pausing keeps them from being
+// reported as app hangs while the user reads the dialog.
+extension UpdaterService: SPUStandardUserDriverDelegate {
+    nonisolated func standardUserDriverWillShowModalAlert() {
+        // Sparkle calls delegate methods on the main thread.
+        MainActor.assumeIsolated {
+            CrashReporter.pauseHangTracking()
+        }
+    }
+
+    nonisolated func standardUserDriverDidShowModalAlert() {
+        MainActor.assumeIsolated {
+            CrashReporter.resumeHangTracking()
+        }
     }
 }
 

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -336,7 +336,8 @@ private struct HomebrewSettingsContent: View {
         panel.message = String(
             localized: "Select the brew binary or the Homebrew installation folder"
         )
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let response = CrashReporter.withHangTrackingPaused { panel.runModal() }
+        guard response == .OK, let url = panel.url else { return }
         Task { await locationModel.applySelection(url) }
     }
 }

--- a/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
@@ -235,19 +235,21 @@ final class AdoptionSurfaceTests: XCTestCase {
         )
     }
 
-    func test_askpass_scripts_are_unique_shell_safe_and_removable() throws {
+    func test_askpass_scripts_are_unique_shell_safe_and_removable() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("askpass-tests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
         let executable = URL(fileURLWithPath: "/Applications/Cask Hub's.app/Contents/MacOS/CaskHub")
 
-        let first = try XCTUnwrap(AskpassScriptManager.create(
+        let firstScript = await AskpassScriptManager.create(
             token: "first; unsafe", directory: directory, executableURL: executable
-        ))
-        let second = try XCTUnwrap(AskpassScriptManager.create(
+        )
+        let secondScript = await AskpassScriptManager.create(
             token: "second", directory: directory, executableURL: executable
-        ))
+        )
+        let first = try XCTUnwrap(firstScript)
+        let second = try XCTUnwrap(secondScript)
 
         XCTAssertNotEqual(first, second)
         XCTAssertTrue(first.lastPathComponent.hasPrefix("askpass-"))
@@ -257,8 +259,8 @@ final class AdoptionSurfaceTests: XCTestCase {
         let permissions = try FileManager.default.attributesOfItem(atPath: first.path)[.posixPermissions] as? Int
         XCTAssertEqual(permissions, 0o700)
 
-        AskpassScriptManager.remove(at: first)
-        AskpassScriptManager.remove(at: second)
+        await AskpassScriptManager.remove(at: first)
+        await AskpassScriptManager.remove(at: second)
         XCTAssertFalse(FileManager.default.fileExists(atPath: first.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: second.path))
     }

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -342,6 +342,15 @@ final class SpyCrashReporterProvider: CrashReporterProvider {
     var breadcrumbs: [(message: String, data: [String: String])] = []
     var tags: [String: String] = [:]
     var spans: [SpanRecord] = []
+    var hangTrackingEvents: [String] = []
+
+    func pauseHangTracking() {
+        hangTrackingEvents.append("pause")
+    }
+
+    func resumeHangTracking() {
+        hangTrackingEvents.append("resume")
+    }
 
     func start(enabled: Bool) {
         startedWith.append(enabled)

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -439,4 +439,19 @@ final class CrashReporterTests: XCTestCase {
         span.finish()
         XCTAssertTrue(spy.spans.isEmpty)
     }
+
+    // MARK: - Hang tracking pause
+
+    func test_with_hang_tracking_paused_brackets_the_body() {
+        let value = CrashReporter.withHangTrackingPaused { 7 }
+        XCTAssertEqual(value, 7)
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
+    }
+
+    func test_hang_tracking_resumes_when_body_throws() {
+        XCTAssertThrowsError(
+            try CrashReporter.withHangTrackingPaused { throw URLError(.badURL) }
+        )
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
+    }
 }

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -454,4 +454,10 @@ final class CrashReporterTests: XCTestCase {
         )
         XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
     }
+
+    func test_sentry_provider_pause_resume_are_safe_without_started_sdk() {
+        let provider = SentryProvider()
+        provider.pauseHangTracking()
+        provider.resumeHangTracking()
+    }
 }

--- a/CaskHubTests/Views/UpdateSettingsViewTests.swift
+++ b/CaskHubTests/Views/UpdateSettingsViewTests.swift
@@ -20,6 +20,20 @@ final class UpdateSettingsViewTests: XCTestCase {
     }
 
     @MainActor
+    func test_sparkle_modal_alert_hooks_pause_and_resume_hang_tracking() {
+        let spy = SpyCrashReporterProvider()
+        let original = CrashReporter.provider
+        defer { CrashReporter.provider = original }
+        CrashReporter.provider = spy
+
+        let updater = UpdaterService()
+        updater.standardUserDriverWillShowModalAlert()
+        updater.standardUserDriverDidShowModalAlert()
+
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
+    }
+
+    @MainActor
     func test_about_support_uses_caskhub_issue_chooser() {
         XCTAssertEqual(
             CaskHubLinks.issues.absoluteString,


### PR DESCRIPTION
## What

Two root-cause fixes for the remaining app-attributable classes in the 0.6.9 App Hanging stream (963 events / 439 users last 7d on 0.6.9+466).

### 1. Modal-dialog false positives (~13% of CASKHUB-M, all of CASKHUB-15)

Sentry V1 hang detection pings the main queue in the **default** run-loop mode. App-modal panels spin `NSModalPanelRunLoopMode`, so the ping starves and every dialog open >2s is recorded as a hang while the app is fully responsive. Evidence: 2/15 sampled CASKHUB-M events on 0.6.9 are Sparkle `NSAlert runModal` stacks; CASKHUB-15's culprit is the quit-confirm `runModal` in `ApplicationTerminationCoordinator`.

Fix: `CrashReporter.withHangTrackingPaused` (pause → body → resume, resume guaranteed on throw) wrapping the three app-modal sites:
- Sparkle update alerts via `SPUStandardUserDriverDelegate.standardUserDriver{Will,Did}ShowModalAlert` (verified in Sparkle 2.9.4 source: fired immediately before/after `runModal`)
- Quit confirmation alert
- Brew-prefix `NSOpenPanel`

`pauseAppHangTracking()`/`resumeAppHangTracking()` verified public in pinned sentry-cocoa 9.21.0. The `--askpass` helper process needs nothing — it exits before `CrashReporter.start()`.

### 2. Askpass script disk I/O on the main actor (CASKHUB-3H)

`HomebrewMutationCoordinator` is `@MainActor`; `AskpassScriptManager.create`/`remove` were nonisolated **sync**, so `createDirectory` + atomic write + chmod ran on the main thread at the start of every brew mutation and `removeItem` at the end. CASKHUB-3H caught `remove` blocking >2s. Both are now `@concurrent async`, so the file I/O runs on the global executor.

## Evidence base

15-event stack sample of CASKHUB-M on 0.6.9+466 across distinct users + per-issue latest-event stacks for the 14 top hang groups, each root-cause traced in-repo and adversarially verified. Everything else in the stream is system/environment-side (swap-pressure layout commits, WindowServer/fontd/lsd sync IPC, macOS 27 beta noise) or already fixed in develop awaiting release (CASKHUB-Z/23 resolver index, CASKHUB-2H recentTokens memoization — both re-verified against the develop diff).

## Tests

- `test_with_hang_tracking_paused_brackets_the_body`
- `test_hang_tracking_resumes_when_body_throws`
- `test_askpass_scripts_are_unique_shell_safe_and_removable` adapted to async
- Full suite green locally