### PR TITLE
fix: List-view menu actions silently no-op (NSMenuItem target deallocated)

### DIFF
--- a/CaskHub/Views/Shared/CaskRowView.swift
+++ b/CaskHub/Views/Shared/CaskRowView.swift
@@ -238,6 +238,8 @@ struct CaskRowActionsMenuButton: View {
         ) -> NSMenuItem {
             let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
             item.target = self
+            // target is weak; menu must retain the coordinator until dismissed
+            item.representedObject = self
             item.image = NSImage(systemSymbolName: systemImage, accessibilityDescription: title)
             item.isEnabled = isEnabled
             item.toolTip = toolTip

--- a/CaskHubTests/Homebrew/Presentation/CaskListActionTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskListActionTests.swift
@@ -149,6 +149,29 @@ final class CaskListActionTests: XCTestCase {
         )
     }
 
+    func test_presented_menu_keeps_item_targets_alive_after_presentation() throws {
+        let recorder = ActionRecorder()
+        var presentedMenu: NSMenu?
+        let button = CaskRowActionsMenuButton(
+            showsUpdate: true,
+            isBusy: false,
+            uninstallAvailability: .available,
+            onInfo: { recorder.calls.append("info") },
+            onUpdate: { recorder.calls.append("update") },
+            onUninstall: { recorder.calls.append("uninstall") },
+            presentMenu: { presentedMenu = $0 }
+        )
+
+        button.presentActionsMenu()
+
+        let menu = try XCTUnwrap(presentedMenu)
+        XCTAssertTrue(menu.items.allSatisfy { $0.isSeparatorItem || $0.target != nil })
+        menu.performActionForItem(at: 0)
+        menu.performActionForItem(at: 1)
+        menu.performActionForItem(at: 3)
+        XCTAssertEqual(recorder.calls, ["info", "update", "uninstall"])
+    }
+
     func test_row_action_menu_preserves_unavailable_uninstall_hint() {
         let hint = String(
             localized: "Adopt this app first so CaskHub can manage/uninstall it."


### PR DESCRIPTION
## Summary
Fixes #152.

`CaskRowActionsMenuButton.presentActionsMenu()` built its `Coordinator` as a throwaway temporary. `NSMenuItem.target` is `weak`, and nothing retained the coordinator, so ARC freed it as soon as `makeMenu()` returned — every click on Info/Update/Uninstall in the list view's "•••" menu dispatched to a nil target and died silently in the responder chain. `autoenablesItems = false` kept the items looking enabled, matching the reported symptom.

## Fix
Each menu item now also holds the coordinator through `representedObject` (a strong property), so the menu owns its action handler for exactly its own lifetime — no timing assumptions about synchronous `popUp`, and it's released with the menu. Chosen over the issue's `@State` suggestion, which would retain the coordinator past the menu's life and go stale across SwiftUI view recreation.

## Testing
- New regression test `test_presented_menu_keeps_item_targets_alive_after_presentation` — verified red on unfixed code (targets nil after presentation), green with fix; asserts all three actions fire through the real `NSMenuItem` target/action path.
- Full `CaskListActionTests` suite passes (9/9).
- SwiftLint clean on both changed files.