### PR TITLE
fix: Ignore Cellar formula shims in external CLI detection

### DIFF
--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
@@ -256,8 +256,11 @@ extension HomebrewInstallationScanner {
                     let fileSize = values.fileSize,
                     fileSize > 0
                 else { continue }
-                // Shims into app bundles belong to that app (OrbStack docker).
-                guard !entry.resolvingSymlinksInPath().path.contains(".app/")
+                // Shims into app bundles belong to that app (OrbStack docker);
+                // Cellar binaries belong to a formula (docker CLI), not a cask.
+                let resolvedPath = entry.resolvingSymlinksInPath().path
+                guard !resolvedPath.contains(".app/"),
+                      !resolvedPath.contains("/Cellar/")
                 else { continue }
                 if paths[entry.lastPathComponent] == nil {
                     paths[entry.lastPathComponent] = entry

--- a/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
+++ b/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
@@ -206,6 +206,16 @@ final class CaskHubTests: XCTestCase {
             at: root.appendingPathComponent("docker"), withDestinationURL: appBinary
         )
 
+        let cellarBinary = root.appendingPathComponent("Cellar/docker/28.0.1/bin/hugo")
+        try FileManager.default.createDirectory(
+            at: cellarBinary.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: cellarBinary.path, contents: Data("#!/bin/sh\n".utf8))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: cellarBinary.path)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("hugo"), withDestinationURL: cellarBinary
+        )
+
         let scan = HomebrewInstallationScanner.scanBinaryDirectories(
             fileManager: FileManager.default,
             directories: [root]
@@ -216,6 +226,10 @@ final class CaskHubTests: XCTestCase {
         XCTAssertNil(
             scan["docker"],
             "a shim into an app bundle belongs to that app, not a standalone CLI"
+        )
+        XCTAssertNil(
+            scan["hugo"],
+            "a symlink into the Cellar belongs to a formula, not an external cask install"
         )
     }
 


### PR DESCRIPTION
## Summary

Follow-up hardening for #159. The OrbStack app-bundle shim case is already handled on `develop` (045f6fa, unreleased), but the same misattribution class survives for Homebrew **formula** binaries: the `docker` formula (common alongside colima) links `docker` into the prefix `bin` from the Cellar. Bare filename matching then marks the `docker-desktop` cask as Installed via `externalExecutable` even though only the CLI formula is present.

## Change

`scanBinaryDirectories` now also skips executables whose resolved path is inside a `Cellar` — a Cellar binary is owned by a formula and is never evidence of an external cask install.

## Testing

- Extended `test_binary_scan_detects_executables_in_homebrew_prefix` with a Cellar-linked binary; asserts it is excluded.
- Full test target passes locally (`** TEST SUCCEEDED **`).

Fixes #159