### PR TITLE
chore: demote Page.opened repeats and Cask.actionStarted to breadcrumb-only

### DIFF
--- a/CaskHub/Services/Telemetry/Analytics+Events.swift
+++ b/CaskHub/Services/Telemetry/Analytics+Events.swift
@@ -20,7 +20,7 @@ extension Analytics {
         origin: CaskActionOrigin
     ) {
         guard let verb = action.analyticsVerb else { return }
-        send("Cask.actionStarted", parameters: actionParameters(
+        CrashReporter.breadcrumb("Cask.actionStarted", data: actionParameters(
             verb: verb.base, token: token, origin: origin
         ))
     }
@@ -72,9 +72,16 @@ extension Analytics {
 
     // MARK: - Navigation
 
+    static var openedPages = Set<[String: String]>()
+
     /// Fires for every detail-page change: sidebar clicks, category clicks on cards, and View All
     static func pageOpened(_ selection: SidebarSelection) {
-        send("Page.opened", parameters: parameters(for: selection))
+        let parameters = parameters(for: selection)
+        if openedPages.insert(parameters).inserted {
+            send("Page.opened", parameters: parameters)
+        } else {
+            CrashReporter.breadcrumb("Page.opened", data: parameters)
+        }
     }
 
     /// The Browse-shelf "View All" tap, sent alongside the `Page.opened`

--- a/CaskHubTests/Telemetry/AnalyticsTests.swift
+++ b/CaskHubTests/Telemetry/AnalyticsTests.swift
@@ -29,6 +29,7 @@ final class AnalyticsTests: XCTestCase {
         spy = SpyAnalyticsProvider()
         originalProvider = Analytics.provider
         Analytics.provider = spy
+        Analytics.openedPages.removeAll()
         UserDefaults.standard.removeObject(forKey: Analytics.enabledKey)
     }
 
@@ -91,11 +92,17 @@ final class AnalyticsTests: XCTestCase {
         XCTAssertEqual(lastSignal?.parameters, ["cask": "firefox", "origin": "individual"])
     }
 
-    func test_cask_action_started_records_action_token_and_origin() {
+    func test_cask_action_started_breadcrumbs_without_signaling() {
+        let crashSpy = SpyCrashReporterProvider()
+        let originalCrash = CrashReporter.provider
+        CrashReporter.provider = crashSpy
+        defer { CrashReporter.provider = originalCrash }
+
         Analytics.caskActionStarted(.updating, token: "zoom", origin: .updateAll)
 
-        XCTAssertEqual(lastSignal?.name, "Cask.actionStarted")
-        XCTAssertEqual(lastSignal?.parameters, [
+        XCTAssertTrue(spy.signals.isEmpty)
+        XCTAssertEqual(crashSpy.breadcrumbs.last?.message, "Cask.actionStarted")
+        XCTAssertEqual(crashSpy.breadcrumbs.last?.data, [
             "action": "update",
             "cask": "zoom",
             "origin": "updateAll"
@@ -169,6 +176,24 @@ final class AnalyticsTests: XCTestCase {
             lastSignal?.parameters,
             ["page": "category", "category": "productivity"]
         )
+    }
+
+    func test_page_opened_signals_once_per_page_and_breadcrumbs_repeats() {
+        let crashSpy = SpyCrashReporterProvider()
+        let originalCrash = CrashReporter.provider
+        CrashReporter.provider = crashSpy
+        defer { CrashReporter.provider = originalCrash }
+
+        Analytics.pageOpened(.discover(.browse))
+        Analytics.pageOpened(.library(.installed))
+        Analytics.pageOpened(.discover(.browse))
+
+        XCTAssertEqual(spy.signals.map(\.name), ["Page.opened", "Page.opened"])
+        XCTAssertEqual(
+            spy.signals.map(\.parameters),
+            [["page": "browse"], ["page": "installed"]]
+        )
+        XCTAssertEqual(crashSpy.breadcrumbs.count, 3)
     }
 
     func test_view_all_tapped_carries_destination_parameters() {


### PR DESCRIPTION
## Summary

TelemetryDeck signal volume is dominated by high-frequency events that carry little analytical value beyond their first occurrence. `Page.opened` alone is ~79k events (~13.6 per user), and `Cask.actionStarted` (~38k) is fully derivable from the outcome signals (`Cask.<verb>ed` / `Cask.actionFailed`).

- `Page.opened`: dedupe per session — first visit to each page sends the TelemetryDeck signal, repeat visits record only the Sentry breadcrumb. Unique-user page reach stays exact.
- `Cask.actionStarted`: demoted to breadcrumb-only — no TelemetryDeck signal.

Sentry breadcrumbs are unaffected in both cases: every navigation and every action start still lands in crash-report context.

Expected impact: roughly 100k+ fewer signals at current volumes, with dashboards keeping their meaning.

## Testing

- Rewrote `test_cask_action_started` to assert breadcrumb-without-signal.
- Added `test_page_opened_signals_once_per_page_and_breadcrumbs_repeats`.
- Full suite passes locally.
