### PR TITLE
fix: App Management shown as granted when permission was never enabled

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		A29100000000000000000002 /* CaskMetadataProjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000001 /* CaskMetadataProjector.swift */; };
 		A29100000000000000000004 /* CaskMetadataProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000003 /* CaskMetadataProjectorTests.swift */; };
 		A29100000000000000000007 /* InstallationDateIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000006 /* InstallationDateIndexTests.swift */; };
+		A29100000000000000000407 /* AppManagementPermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000406 /* AppManagementPermissionTests.swift */; };
 		A29100000000000000000107 /* HomebrewOutputDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000106 /* HomebrewOutputDiagnosticsTests.swift */; };
 		A29100000000000000000207 /* CatalogScrollSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000206 /* CatalogScrollSupport.swift */; };
 		A29100000000000000000307 /* BrewOutputAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000306 /* BrewOutputAggregator.swift */; };
@@ -209,6 +210,7 @@
 		A29100000000000000000001 /* CaskMetadataProjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskMetadataProjector.swift; sourceTree = "<group>"; };
 		A29100000000000000000003 /* CaskMetadataProjectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskMetadataProjectorTests.swift; sourceTree = "<group>"; };
 		A29100000000000000000006 /* InstallationDateIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationDateIndexTests.swift; sourceTree = "<group>"; };
+		A29100000000000000000406 /* AppManagementPermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppManagementPermissionTests.swift; sourceTree = "<group>"; };
 		A29100000000000000000106 /* HomebrewOutputDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewOutputDiagnosticsTests.swift; sourceTree = "<group>"; };
 		A29100000000000000000206 /* CatalogScrollSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogScrollSupport.swift; sourceTree = "<group>"; };
 		A29100000000000000000306 /* BrewOutputAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewOutputAggregator.swift; sourceTree = "<group>"; };
@@ -759,6 +761,7 @@
 		F32000000000000000000029 /* Infrastructure */ = {
 			isa = PBXGroup;
 			children = (
+				A29100000000000000000406 /* AppManagementPermissionTests.swift */,
 				E24000000000000000000004 /* BrewProcessRunnerTests.swift */,
 				E29000000000000000000013 /* HomebrewCommandExecutorTests.swift */,
 				A29100000000000000000106 /* HomebrewOutputDiagnosticsTests.swift */,
@@ -1049,6 +1052,7 @@
 				F29000000000000000000013 /* HomebrewCommandExecutorTests.swift in Sources */,
 				A29100000000000000000107 /* HomebrewOutputDiagnosticsTests.swift in Sources */,
 				A29100000000000000000007 /* InstallationDateIndexTests.swift in Sources */,
+				A29100000000000000000407 /* AppManagementPermissionTests.swift in Sources */,
 				F29000000000000000000019 /* CaskActionPresentationTests.swift in Sources */,
 				F2900000000000000000001F /* DownloadMetadataProviderTests.swift in Sources */,
 				F24000000000000000000004 /* BrewProcessRunnerTests.swift in Sources */,

--- a/CaskHub/Services/Homebrew/Infrastructure/AppManagementPermission.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/AppManagementPermission.swift
@@ -8,12 +8,16 @@
 import AppKit
 import Foundation
 
-/// macOS "App Management" privacy permission (System Settings → Privacy & Security
-/// → App Management). There is no query API — status is probed by asking the kernel,
-/// via `access(2)`, whether CaskHub may write inside app bundles it doesn't own.
+/// macOS "App Management" privacy permission. No query API, and `access(2)` never
+/// consults the gate (TCC enforces actual writes only), so status is probed
+/// Homebrew-style: attempt a harmless write inside protected bundles.
 enum AppManagementPermission {
     enum Status: Equatable {
         case granted, denied, unknown
+    }
+
+    enum WriteAttempt {
+        case allowed, blocked, skipped
     }
 
     @MainActor
@@ -23,24 +27,43 @@ enum AppManagementPermission {
         )
     }
 
-    /// Non-invasive probe: `access(2)` consults the App Management gate, so a bundle
-    /// whose Contents is POSIX-writable (per its ownership bits) yet fails W_OK can
-    /// only mean TCC is denying us. Nothing is written. One such bundle proves
-    /// denied; "granted" needs every candidate writable, because same-team and
-    /// never-Gatekeeper-registered bundles pass regardless of the permission.
-    /// (Never pre-filter targets with isWritableFile — it calls access(2) too, and
-    /// silently drops exactly the bundles that would report the denial.)
     nonisolated static func probe() -> Status {
-        var sawWritable = false
-        for bundle in probeTargets() {
-            let contents = bundle.appendingPathComponent("Contents").path
-            guard posixWritable(contents) else { continue }
-            if access(contents, W_OK) != 0 {
+        probe(targets: probeTargets(), attempt: attemptWrite)
+    }
+
+    /// One blocked write proves denied; allowed writes are weaker evidence (bundles
+    /// CaskHub installed itself are exempt), so granted needs three acceptances.
+    nonisolated static func probe(
+        targets: [URL],
+        attempt: (URL) -> WriteAttempt
+    ) -> Status {
+        var allowed = 0
+        for bundle in targets {
+            switch attempt(bundle) {
+            case .blocked:
                 return .denied
+            case .allowed:
+                allowed += 1
+                if allowed == 3 { return .granted }
+            case .skipped:
+                continue
             }
-            sawWritable = true
         }
-        return sawWritable ? .granted : .unknown
+        return allowed > 0 ? .granted : .unknown
+    }
+
+    /// After the posixWritable guard only the TCC gate returns EPERM; EACCES (ACLs) is not it.
+    private nonisolated static func attemptWrite(in bundle: URL) -> WriteAttempt {
+        let contents = bundle.appendingPathComponent("Contents").path
+        guard posixWritable(contents) else { return .skipped }
+        let probePath = contents + "/.com.caskhub.permission-probe." + UUID().uuidString
+        let fd = open(probePath, O_CREAT | O_WRONLY | O_EXCL, 0o644)
+        guard fd >= 0 else {
+            return errno == EPERM ? .blocked : .skipped
+        }
+        close(fd)
+        unlink(probePath)
+        return .allowed
     }
 
     /// Bundles macOS actually protects: provenance-tracked (untracked bundles aren't

--- a/CaskHubTests/Homebrew/Infrastructure/AppManagementPermissionTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/AppManagementPermissionTests.swift
@@ -1,0 +1,66 @@
+//
+//  AppManagementPermissionTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 10/08/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+final class AppManagementPermissionTests: XCTestCase {
+    private let targets = [
+        URL(fileURLWithPath: "/Applications/A.app"),
+        URL(fileURLWithPath: "/Applications/B.app"),
+        URL(fileURLWithPath: "/Applications/C.app"),
+        URL(fileURLWithPath: "/Applications/D.app"),
+        URL(fileURLWithPath: "/Applications/E.app")
+    ]
+
+    func test_probe_reports_denied_on_first_blocked_write_and_stops() {
+        var attempted: [URL] = []
+        let status = AppManagementPermission.probe(targets: targets) { url in
+            attempted.append(url)
+            return url.lastPathComponent == "B.app" ? .blocked : .allowed
+        }
+        XCTAssertEqual(status, .denied)
+        XCTAssertEqual(attempted, Array(targets.prefix(2)))
+    }
+
+    func test_probe_reports_denied_when_block_follows_allowed_writes() {
+        let status = AppManagementPermission.probe(targets: targets) { url in
+            url.lastPathComponent == "C.app" ? .blocked : .allowed
+        }
+        XCTAssertEqual(status, .denied)
+    }
+
+    func test_probe_reports_granted_after_three_allowed_writes_and_stops() {
+        var attempted: [URL] = []
+        let status = AppManagementPermission.probe(targets: targets) { url in
+            attempted.append(url)
+            return .allowed
+        }
+        XCTAssertEqual(status, .granted)
+        XCTAssertEqual(attempted.count, 3)
+    }
+
+    func test_probe_reports_granted_when_single_candidate_allows() {
+        let status = AppManagementPermission.probe(targets: [targets[0]]) { _ in .allowed }
+        XCTAssertEqual(status, .granted)
+    }
+
+    func test_probe_skips_unwritable_candidates_without_verdict() {
+        let status = AppManagementPermission.probe(targets: targets) { url in
+            url.lastPathComponent == "D.app" ? .allowed : .skipped
+        }
+        XCTAssertEqual(status, .granted)
+    }
+
+    func test_probe_reports_unknown_when_no_candidate_accepts_a_write() {
+        XCTAssertEqual(
+            AppManagementPermission.probe(targets: targets) { _ in .skipped },
+            .unknown
+        )
+        XCTAssertEqual(AppManagementPermission.probe(targets: []) { _ in .allowed }, .unknown)
+    }
+}


### PR DESCRIPTION
## Problem

Reddit report (reproduced on a clean VM): Settings → Permissions shows App Management as **Granted** on machines where the permission was never enabled.

## Root cause

`AppManagementPermission.probe()` asked `access(contents, W_OK)` and assumed the kernel routes it through the App Management TCC gate. It does not — `access(2)` answers from POSIX mode bits alone, while the gate is enforced only when a write is actually attempted.

Verified on macOS 26.6.1 with a scratch app holding an explicit TCC denial (`kTCCServiceSystemPolicyAppBundles`, `auth_value=0`):

- `access(W_OK)` passed on **all 50** provenance-tracked candidate bundles → old probe verdict: granted
- a real `open(O_CREAT)` inside one of those bundles failed with **EPERM**

Since the old probe returned denied only when `access()` failed, it reported granted on effectively every machine.

## Fix

Probe the way Homebrew does ([Homebrew/brew#15483](https://github.com/Homebrew/brew/pull/15483)): attempt a trace-free write — `O_EXCL`-create then immediately unlink a hidden file — inside protected bundles.

- **EPERM** on a POSIX-writable `Contents` can only be the App Management gate → `denied` (probing stops at the first block)
- an allowed write is weaker evidence (bundles CaskHub itself installed are exempt), so `granted` needs three distinct bundles to accept — or every candidate, when fewer exist
- EACCES (ACLs) and other errors skip the candidate instead of feeding the verdict

Verdict aggregation is now a pure `probe(targets:attempt:)` function with unit tests; the syscall shim stays thin.

## Verification

- 6 new unit tests cover the verdict logic (denied wins, three-success cap, skip handling, unknown on no candidates); full suite green
- End-to-end with a scratch .app identity holding zero TCC grants: verdict **DENIED** at the first candidate, no files written
- Same binary under Terminal (App Management enabled): verdict **GRANTED** after exactly 3 allowed writes

Note: the first probe from a denied context registers CaskHub in the System Settings App Management pane (silent denied entry), which gives the user a visible toggle to enable.