### PR TITLE
chore: switch to official homebrew-cask distribution

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,8 +3,8 @@ name: Publish release
 # When a release PR merges to master, publish the draft release that the
 # Release build workflow created. Publishing creates the tag and makes the
 # zip's download URL (already referenced by master's appcast.xml) live.
-# Then bump the Homebrew tap (alielsokary/homebrew-tap) to the new version;
-# TAP_DEPLOY_KEY is a write deploy key on the tap repo.
+# The official homebrew/homebrew-cask cask is bumped by BrewTestBot autobump
+# (livecheck on github_latest) — no tap bump needed here.
 
 on:
   push:
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Publish draft release matching the merged version
-        id: publish
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -29,36 +28,6 @@ jobs:
           if [ "$(gh release view "$VERSION" --json isDraft --jq .isDraft 2>/dev/null)" = "true" ]; then
             gh release edit "$VERSION" --draft=false --latest
             echo "Published $VERSION"
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           else
             echo "No draft release for $VERSION — nothing to publish."
-          fi
-
-      - name: Check out Homebrew tap
-        if: steps.publish.outputs.version
-        uses: actions/checkout@v4
-        with:
-          repository: alielsokary/homebrew-tap
-          ssh-key: ${{ secrets.TAP_DEPLOY_KEY }}
-          path: tap
-
-      - name: Bump caskhub cask
-        if: steps.publish.outputs.version
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.publish.outputs.version }}
-        run: |
-          gh release download "$VERSION" --pattern "CaskHub-$VERSION.zip" --output caskhub.zip
-          SHA="$(sha256sum caskhub.zip | cut -d' ' -f1)"
-          sed -i -E \
-            -e "s|^  version \".*\"|  version \"$VERSION\"|" \
-            -e "s|^  sha256 \".*\"|  sha256 \"$SHA\"|" \
-            tap/Casks/caskhub.rb
-          if git -C tap diff --quiet; then
-            echo "Cask already at $VERSION — nothing to bump."
-          else
-            git -C tap config user.name "Ali Elsokary"
-            git -C tap config user.email "ali.elsokary.w@gmail.com"
-            git -C tap commit -am "feat: bump caskhub to $VERSION"
-            git -C tap push
           fi

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CaskHub is 100% free and open source, no subscription, no premium tier, no ads, 
 Or install with Homebrew:
 
 ```bash
-brew install --cask alielsokary/tap/caskhub
+brew install --cask caskhub
 ```
 
 ## Features

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,14 +51,14 @@ There is no bug bounty program, since CaskHub is free software with no revenue, 
 ### In scope (report privately)
 
 - The CaskHub app itself: all code in this repository
-- The release and update pipeline: GitHub Releases artifacts, the [Homebrew tap](https://github.com/alielsokary/homebrew-tap) cask, and the Sparkle appcast (releases are Developer ID-signed and notarized; updates are EdDSA-verified)
+- The release and update pipeline: GitHub Releases artifacts, the official [Homebrew cask](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/caskhub.rb), and the Sparkle appcast (releases are Developer ID-signed and notarized; updates are EdDSA-verified)
 - The [caskhub.app](https://caskhub.app) website content
 
 Examples of in-scope issues:
 
 - Executing attacker-controlled code through CaskHub, e.g. command injection via cask metadata into the `brew` commands CaskHub runs
 - Bypassing or downgrading Sparkle update signature verification
-- Tampering with CaskHub's release artifacts, appcast, or tap through the project's CI
+- Tampering with CaskHub's release artifacts or appcast through the project's CI
 - CaskHub leaking sensitive user data
 
 ### Out of scope (report elsewhere or publicly)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,7 @@ There is no bug bounty program, since CaskHub is free software with no revenue, 
 ### In scope (report privately)
 
 - The CaskHub app itself: all code in this repository
-- The release and update pipeline: GitHub Releases artifacts, the official [Homebrew cask](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/caskhub.rb), and the Sparkle appcast (releases are Developer ID-signed and notarized; updates are EdDSA-verified)
+- The release and update pipeline: GitHub Releases artifacts, the official [Homebrew cask](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/c/caskhub.rb), and the Sparkle appcast (releases are Developer ID-signed and notarized; updates are EdDSA-verified)
 - The [caskhub.app](https://caskhub.app) website content
 
 Examples of in-scope issues:

--- a/docs/index.html
+++ b/docs/index.html
@@ -361,7 +361,7 @@
     <p class="lede rise d3">Browse, search, install, update, and uninstall thousands of Mac apps distributed through Homebrew, with original app icons, categories, popularity charts, and one-click actions, all in a clean native SwiftUI interface.</p>
     <div class="terminal rise d4">
       <span class="prompt" aria-hidden="true">$</span>
-      <code id="brew-cmd">brew install --cask alielsokary/tap/caskhub</code>
+      <code id="brew-cmd">brew install --cask caskhub</code>
       <button class="copy-btn" id="copy" aria-label="Copy install command">
         <svg class="dup" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>
         <svg class="check" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m4 12 5 5L20 6"/></svg>


### PR DESCRIPTION
CaskHub was accepted into [homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/caskhub.rb) (currently at 0.6.9), so the personal tap is no longer the install path.

## Changes
- **publish-release.yml**: removed the tap-bump steps (checkout of `alielsokary/homebrew-tap` + version/sha256 sed + push). The official cask has `livecheck` on `github_latest`, so BrewTestBot autobump opens a version PR on homebrew-cask after each GitHub release — no CI step needed on our side. The workflow now only publishes the draft release.
- **README.md**: install command is now `brew install --cask caskhub`.
- **SECURITY.md**: scope now references the official Homebrew cask instead of the personal tap.
- **docs/index.html**: website install command updated (goes live on caskhub.app when this reaches master).

## Follow-up after next release
Verify the BrewTestBot bump PR appears on homebrew-cask; fallback is `brew bump-cask-pr --version x.y.z caskhub`.