### PR TITLE
fix: show standard Sparkle update prompt instead of silent download + install prompt

### DIFF
--- a/Configs/Info.plist
+++ b/Configs/Info.plist
@@ -2,8 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SUAllowsAutomaticUpdates</key>
+	<false/>
 	<key>SUAutomaticallyUpdate</key>
-	<true/>
+	<false/>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/alielsokary/CaskHub/master/appcast.xml</string>
 	<key>SUPublicEDKey</key>


### PR DESCRIPTION
## Problem

The update dialog always showed "CaskHub X has been downloaded and is ready to use! Would you like to install it and relaunch?" instead of the standard Sparkle prompt ("X is now available—you have Y. Would you like to download it now?") with Install/Later/Skip options.

## Root cause

A since-removed silent-update opt-out (01398ce, shipped in 0.6.4–0.6.9) set `automaticallyDownloadsUpdates` programmatically. Sparkle's setter persists `SUAutomaticallyUpdate = true` into user defaults, and defaults take precedence over the Info.plist value — so flipping the plist key alone had no effect for anyone who ever ran 0.6.4–0.6.9. `brew uninstall --zap` doesn't clear it either, since the zap stanza doesn't cover the sandbox container prefs.

## Fix

Add `SUAllowsAutomaticUpdates = false` to Info.plist. Per Sparkle 2 source, this key is read from Info.plist only (`boolNumberForInfoDictionaryKey`), gates auto-download entirely, and cannot be overridden by stale user defaults. Also flip `SUAutomaticallyUpdate` to `false` as the clean first-run default.

## Verification

- Reproduced the stale-defaults override locally: with plist `SUAutomaticallyUpdate = false` alone, Sparkle still re-downloaded and re-staged the update in `~/Library/Caches/com.mag.caskhub/org.sparkle-project.Sparkle` (defaults `true` won).
- The dev machine still carries the stale `true` defaults, replicating a worst-case affected user — rebuild with this branch should show the standard interactive prompt there.

## Notes

- Users updating from ≤0.6.9 will see the old "ready to install" prompt one last time — that dialog is rendered by the installed app.
- Follow-up (separate tap PR): add `~/Library/Containers/com.mag.caskhub` to the cask zap stanza.