### PR TITLE
fix: Conflicting cask install handling

### DIFF
--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -77,7 +77,7 @@ struct CaskActionsView: View {
                 )
         } else {
             ActionCapsuleButton(action: .install, fullWidth: fullWidth) {
-                localHomebrew.send(.install(token: cask.token))
+                localHomebrew.send(.install(cask))
             }
         }
     }

--- a/CaskHub/Resources/Localizable.xcstrings
+++ b/CaskHub/Resources/Localizable.xcstrings
@@ -465,6 +465,24 @@
         }
       }
     },
+    "alert.installConflict.title" : {
+      "comment" : "Alert title when an installed Homebrew cask conflicts with the requested cask",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Can't Install %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法安装 %@"
+          }
+        }
+      }
+    },
     "alert.quitDuringOperation" : {
       "comment" : "Quit confirmation body while a brew operation is running",
       "extractionState" : "manual",
@@ -1379,6 +1397,42 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "macOS 阻止了 CaskHub 修改这台 Mac 上的应用。请在「系统设置 → 隐私与安全性 → App 管理」中启用 CaskHub，然后重试。"
+          }
+        }
+      }
+    },
+    "error.caskConflict" : {
+      "comment" : "Error when a requested Homebrew cask conflicts with an installed Homebrew cask",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Homebrew cask “%@” conflicts with the installed cask “%@”. Uninstall “%@” before trying again."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew Cask“%@”与已安装的 Cask“%@”冲突。请先卸载“%@”，然后重试。"
+          }
+        }
+      }
+    },
+    "error.caskConflictUnknown" : {
+      "comment" : "Fallback error when Homebrew reports a cask conflict without naming the installed cask",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This Homebrew cask conflicts with another installed cask. Uninstall the conflicting cask before trying again."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 Homebrew Cask 与另一个已安装的 Cask 冲突。请先卸载冲突的 Cask，然后重试。"
           }
         }
       }

--- a/CaskHub/Services/Homebrew/Domain/CaskOperationState.swift
+++ b/CaskHub/Services/Homebrew/Domain/CaskOperationState.swift
@@ -20,6 +20,7 @@ nonisolated struct CaskOperationFailure: Equatable, Sendable {
     enum Kind: Equatable, Sendable {
         case homebrewMissing
         case appManagementDenied
+        case installationPreflight
         case adoptionPreflight
         case brewCommand
         case applicationUnavailable

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewError.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewError.swift
@@ -102,6 +102,7 @@ enum LocalHomebrewError: LocalizedError {
         "adopt-version-mismatch",
         "app-conflict",
         "binary-conflict",
+        "cask-conflict",
         "checksum-mismatch",
         "network-failure",
         "permission-denied",
@@ -117,6 +118,29 @@ enum LocalHomebrewError: LocalizedError {
             options: .regularExpression
         ) else { return nil }
         return String(stderr[range].dropFirst("required by ".count))
+    }
+
+    static func conflictingCask(stderr: String) -> String? {
+        guard let range = stderr.range(
+            of: #"conflicts with '[A-Za-z0-9@._+/-]+'"#,
+            options: .regularExpression
+        ) else { return nil }
+        return String(
+            stderr[range]
+                .dropFirst("conflicts with '".count)
+                .dropLast()
+        )
+    }
+
+    static func caskConflictDescription(
+        requestedCask: String,
+        installedCask: String
+    ) -> String {
+        String(localized: .errorCaskConflict(
+            requestedCask,
+            installedCask,
+            installedCask
+        ))
     }
 
     /// A previous interrupted operation parked the real .app inside the Caskroom
@@ -155,6 +179,15 @@ enum LocalHomebrewError: LocalizedError {
                     + "it yet. Adopt keeps your current copy and hands management to "
                     + "Homebrew; Replace installs Homebrew's copy fresh. Settings and "
                     + "data are kept either way."
+            case "cask-conflict":
+                let requestedCask = args.drop(while: { $0 != "--cask" }).dropFirst().first
+                guard let requestedCask,
+                      let installedCask = Self.conflictingCask(stderr: trimmed)
+                else { return String(localized: .errorCaskConflictUnknown) }
+                return Self.caskConflictDescription(
+                    requestedCask: requestedCask,
+                    installedCask: installedCask
+                )
             case "cask-dependency":
                 let dependent = Self.dependentCask(stderr: trimmed)
                 return "This can't be uninstalled because "

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Intents.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Intents.swift
@@ -6,7 +6,7 @@
 //
 
 enum CaskIntent {
-    case install(token: String)
+    case install(Cask)
     case uninstall(token: String)
     case repair(token: String)
     case repairAndReinstall(token: String)
@@ -51,8 +51,8 @@ extension LocalHomebrewService {
 
     private func handleMutationIntent(_ intent: CaskIntent) -> Bool {
         switch intent {
-        case let .install(token):
-            Task { try? await install(token: token) }
+        case let .install(cask):
+            Task { try? await install(cask) }
         case let .uninstall(token):
             Task { try? await uninstall(token: token) }
         case let .repair(token):

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
@@ -8,6 +8,25 @@
 import Foundation
 
 extension LocalHomebrewService {
+    func install(_ cask: Cask) async throws {
+        if let conflict = cask.conflictsWith?.caskTokens.first(where: {
+            installedCasks[$0] != nil
+        }) {
+            operationStore.send(
+                .fail(CaskOperationFailure(
+                    kind: .installationPreflight,
+                    message: LocalHomebrewError.caskConflictDescription(
+                        requestedCask: cask.token,
+                        installedCask: conflict
+                    )
+                )),
+                for: cask.token
+            )
+            return
+        }
+        try await install(token: cask.token)
+    }
+
     func install(token: String) async throws {
         try await runMutation(
             .installing,

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -236,7 +236,9 @@ enum CaskActionAlertFactory {
         service: LocalHomebrewService
     ) -> (alert: NSAlert, actions: [() -> Void]) {
         let alert = NSAlert()
-        alert.messageText = "\(cask.displayName) Failed"
+        alert.messageText = failure.kind == .installationPreflight
+            ? String(localized: .alertInstallConflictTitle(cask.displayName))
+            : "\(cask.displayName) Failed"
         if failure.message.count <= 500 {
             alert.informativeText = failure.message
         } else {

--- a/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
@@ -230,6 +230,21 @@ final class AdoptionViewRenderTests: XCTestCase {
     }
 
     @MainActor
+    func test_installation_preflight_alert_does_not_call_the_conflict_a_failure() {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("install-conflict-alert"))
+        let failure = CaskOperationFailure(
+            kind: .installationPreflight,
+            message: "conflict"
+        )
+
+        let (alert, _) = CaskActionAlertFactory.errorAlert(
+            for: makeCask("zen-privacy", name: "Zen"), failure: failure, service: service
+        )
+
+        XCTAssertEqual(alert.messageText, "Can't Install Zen")
+    }
+
+    @MainActor
     func test_error_alert_scrolls_long_output_instead_of_growing() {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("alert-scroll"))
         let message = String(repeating: "brew output line\n", count: 60)

--- a/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
@@ -158,6 +158,25 @@ final class AdoptionSurfaceTests: XCTestCase {
         XCTAssertTrue(generic.errorDescription?.contains("boom") == true)
     }
 
+    func test_cask_conflict_has_actionable_description_and_is_not_reportable() {
+        let stderr = "Error: zen-privacy: Cask 'zen-privacy' conflicts with 'zen'."
+        let error = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "zen-privacy"],
+            exitCode: 1,
+            stderr: stderr
+        )
+
+        XCTAssertEqual(LocalHomebrewError.conflictingCask(stderr: stderr), "zen")
+        XCTAssertEqual(
+            error.errorDescription,
+            LocalHomebrewError.caskConflictDescription(
+                requestedCask: "zen-privacy",
+                installedCask: "zen"
+            )
+        )
+        XCTAssertFalse(error.shouldReport)
+    }
+
     @MainActor
     func test_open_and_external_lookups_handle_missing_bundles() {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("open-missing"))
@@ -221,6 +240,48 @@ final class AdoptionSurfaceTests: XCTestCase {
         XCTAssertFalse(askpassPath.map(FileManager.default.fileExists(atPath:)) ?? true)
         XCTAssertNotNil(service.operationStore.state(for: "firefox")?.failure)
         XCTAssertNil(service.operationStore.state(for: "firefox")?.action)
+    }
+
+    @MainActor
+    func test_install_preflight_blocks_an_installed_conflicting_cask() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(runner: runner)
+        updateInstalledCask(installation("zen", version: "1.21.13b"), in: service)
+        let zenPrivacy = makeCask(
+            "zen-privacy",
+            name: "Zen",
+            conflictingCaskTokens: ["zen"]
+        )
+
+        try await service.install(zenPrivacy)
+
+        let failure = try XCTUnwrap(service.operationStore.state(for: "zen-privacy")?.failure)
+        XCTAssertEqual(failure.kind, .installationPreflight)
+        XCTAssertEqual(
+            failure.message,
+            LocalHomebrewError.caskConflictDescription(
+                requestedCask: "zen-privacy",
+                installedCask: "zen"
+            )
+        )
+        XCTAssertTrue(runner.requests.isEmpty)
+    }
+
+    @MainActor
+    func test_install_preflight_allows_a_cask_when_its_conflict_is_not_installed() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(runner: runner)
+        let zenPrivacy = makeCask(
+            "zen-privacy",
+            conflictingCaskTokens: ["zen"]
+        )
+
+        try await service.install(zenPrivacy)
+
+        XCTAssertEqual(
+            runner.requests.map(\.arguments),
+            [["install", "--cask", "zen-privacy"]]
+        )
     }
 
     @MainActor

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -171,7 +171,8 @@ final class CrashReporterTests: XCTestCase {
                 + "'/opt/homebrew/Caskroom/zed/1.10.3/Zed.app'.",
             "chmod: /Applications/Example.app/Contents/MacOS/example: Operation not permitted",
             "SHA256 mismatch",
-            "Download failed: curl: (6) Could not resolve host: example.com"
+            "Download failed: curl: (6) Could not resolve host: example.com",
+            "Error: zen-privacy: Cask 'zen-privacy' conflicts with 'zen'."
         ]
         for stderr in failures {
             CrashReporter.capture(LocalHomebrewError.brewCommandFailed(


### PR DESCRIPTION
## Summary
- preflight declared Homebrew cask conflicts before starting an install
- show a localized, actionable alert naming the requested and installed casks
- parse Homebrew conflict output as a fallback when catalog state is stale
- treat declared cask conflicts as expected user state instead of reporting them to Sentry

## Root cause
The catalog install intent carried only the cask token, so the install workflow could not inspect the catalog `conflicts_with` metadata. Homebrew then rejected the request with `CaskConflictError`, which CaskHub surfaced as a generic failure and reported under CASKHUB-4K.

## Behavior
CaskHub now blocks the operation before invoking Homebrew when a declared conflicting cask is installed. It does not automatically uninstall the existing cask because that would be destructive. Homebrew officially treats declared cask conflicts as mutually exclusive.

## Verification
- `swiftlint lint --strict --no-cache`
- full macOS test suite
- signed Debug build and code-signature verification
- app launch smoke check
- focused coverage for blocked and allowed installs, alert presentation, fallback parsing, and Sentry suppression