### PR TITLE
fix: Classify Homebrew failures and guide recovery

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		A12000000000000000000007 /* CaskAdoptionPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000006 /* CaskAdoptionPlanTests.swift */; };
 		A12000000000000000000009 /* CaskAdoptionWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000008 /* CaskAdoptionWorkflowTests.swift */; };
 		B0E000000000000000000002 /* LocalHomebrewError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E000000000000000000001 /* LocalHomebrewError.swift */; };
+		B0F000000000000000000002 /* HomebrewCommandFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F000000000000000000001 /* HomebrewCommandFailure.swift */; };
+		B0F000000000000000000004 /* HomebrewCommandFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F000000000000000000003 /* HomebrewCommandFailureTests.swift */; };
 		A12000000000000000000002 /* LocalHomebrewService+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000002 /* LocalHomebrewService+State.swift */; };
 		A12000000000000000000003 /* LocalHomebrewService+Adoption.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */; };
 		A12000000000000000000004 /* ZombieDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000004 /* ZombieDetectionTests.swift */; };
@@ -236,6 +238,8 @@
 		B12000000000000000000006 /* CaskAdoptionPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskAdoptionPlanTests.swift; sourceTree = "<group>"; };
 		B12000000000000000000008 /* CaskAdoptionWorkflowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskAdoptionWorkflowTests.swift; sourceTree = "<group>"; };
 		B0E000000000000000000001 /* LocalHomebrewError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewError.swift; sourceTree = "<group>"; };
+		B0F000000000000000000001 /* HomebrewCommandFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewCommandFailure.swift; sourceTree = "<group>"; };
+		B0F000000000000000000003 /* HomebrewCommandFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewCommandFailureTests.swift; sourceTree = "<group>"; };
 		B12000000000000000000002 /* LocalHomebrewService+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+State.swift"; sourceTree = "<group>"; };
 		B12000000000000000000003 /* LocalHomebrewService+Adoption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocalHomebrewService+Adoption.swift"; sourceTree = "<group>"; };
 		B12000000000000000000004 /* ZombieDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZombieDetectionTests.swift; sourceTree = "<group>"; };
@@ -624,6 +628,7 @@
 				B12000000000000000000005 /* CaskAdoptionPlan.swift */,
 				E24000000000000000000001 /* CaskOperationProgress.swift */,
 				E29000000000000000000001 /* CaskOperationState.swift */,
+				B0F000000000000000000001 /* HomebrewCommandFailure.swift */,
 				41DFD47130028F7D00608C7A /* InstallReceipt.swift */,
 				E29000000000000000000009 /* InstallationSnapshot.swift */,
 				B0E000000000000000000001 /* LocalHomebrewError.swift */,
@@ -761,6 +766,7 @@
 				B12000000000000000000006 /* CaskAdoptionPlanTests.swift */,
 				E24000000000000000000003 /* CaskOperationProgressTests.swift */,
 				E29000000000000000000003 /* CaskOperationStateTests.swift */,
+				B0F000000000000000000003 /* HomebrewCommandFailureTests.swift */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -1008,6 +1014,7 @@
 				C15000000000000000000002 /* InstallationCatalogBuilder.swift in Sources */,
 				A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */,
 				A12000000000000000000005 /* CaskAdoptionPlan.swift in Sources */,
+				B0F000000000000000000002 /* HomebrewCommandFailure.swift in Sources */,
 				B0E000000000000000000002 /* LocalHomebrewError.swift in Sources */,
 				F24000000000000000000001 /* CaskOperationProgress.swift in Sources */,
 				F29000000000000000000001 /* CaskOperationState.swift in Sources */,
@@ -1083,6 +1090,7 @@
 				F26000000000000000000001 /* CaskListActionTests.swift in Sources */,
 				F24000000000000000000003 /* CaskOperationProgressTests.swift in Sources */,
 				F29000000000000000000003 /* CaskOperationStateTests.swift in Sources */,
+				B0F000000000000000000004 /* HomebrewCommandFailureTests.swift in Sources */,
 				F29000000000000000000007 /* CaskOperationStoreTests.swift in Sources */,
 				F2900000000000000000000B /* InstallationSnapshotTests.swift in Sources */,
 				F29000000000000000000013 /* HomebrewCommandExecutorTests.swift in Sources */,

--- a/CaskHub/DesignSystem/Components/CaskActionsView.swift
+++ b/CaskHub/DesignSystem/Components/CaskActionsView.swift
@@ -39,7 +39,10 @@ struct CaskActionsView: View {
         if let inFlight = presentation.activeAction {
             inFlightCapsule(for: inFlight, presentation: presentation)
         } else if state.isHomebrewInstalled {
-            installedActions(state)
+            installedActions(
+                state,
+                mutationBlocked: presentation.isHomebrewMutationBlocked
+            )
         } else if state.isAdoptable {
             HStack(spacing: 8) {
                 if isAdoptPage {
@@ -49,6 +52,9 @@ struct CaskActionsView: View {
                     ) {
                         localHomebrew.send(.requestAdoption(cask))
                     }
+                    .disabledDuringHomebrewUpdate(
+                        presentation.isHomebrewMutationBlocked
+                    )
                 } else {
                     openButton(fullWidth: fullWidth) {
                         localHomebrew.send(.openExternal(cask))
@@ -79,23 +85,33 @@ struct CaskActionsView: View {
             ActionCapsuleButton(action: .install, fullWidth: fullWidth) {
                 localHomebrew.send(.install(cask))
             }
+            .disabledDuringHomebrewUpdate(
+                presentation.isHomebrewMutationBlocked
+            )
         }
     }
 
     @ViewBuilder
-    private func installedActions(_ state: CaskLocalState) -> some View {
+    private func installedActions(
+        _ state: CaskLocalState,
+        mutationBlocked: Bool
+    ) -> some View {
         if state.isZombie {
             ActionCapsuleButton(action: .cleanup, fullWidth: fullWidth) {
                 localHomebrew.send(.repair(token: cask.token))
             }
             .help(String(localized: .actionCleanupZombieHelp(cask.displayName)))
+            .disabledDuringHomebrewUpdate(mutationBlocked)
         } else {
-            managedActions(state)
+            managedActions(state, mutationBlocked: mutationBlocked)
         }
     }
 
     @ViewBuilder
-    private func managedActions(_ state: CaskLocalState) -> some View {
+    private func managedActions(
+        _ state: CaskLocalState,
+        mutationBlocked: Bool
+    ) -> some View {
         HStack(spacing: 8) {
             if state.canOpen {
                 openButton(
@@ -106,7 +122,10 @@ struct CaskActionsView: View {
                 }
             }
             if state.hasAvailableUpdate {
-                updateButton(fullWidth: fullWidth) {
+                updateButton(
+                    fullWidth: fullWidth,
+                    mutationBlocked: mutationBlocked
+                ) {
                     localHomebrew.send(.update(token: cask.token))
                 }
             }
@@ -125,6 +144,7 @@ struct CaskActionsView: View {
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
+                .disabledDuringHomebrewUpdate(mutationBlocked)
             }
         }
     }
@@ -143,11 +163,17 @@ struct CaskActionsView: View {
     }
 
     @ViewBuilder
-    private func updateButton(fullWidth: Bool, action: @escaping () -> Void) -> some View {
+    private func updateButton(
+        fullWidth: Bool,
+        mutationBlocked: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
         if usesIconOnlyOpenAndUpdate {
             ActionCapsuleIconButton(action: .update, onTap: action)
+                .disabledDuringHomebrewUpdate(mutationBlocked)
         } else {
             ActionCapsuleButton(action: .update, fullWidth: fullWidth, onTap: action)
+                .disabledDuringHomebrewUpdate(mutationBlocked)
         }
     }
 
@@ -165,6 +191,19 @@ struct CaskActionsView: View {
             fullWidth: fullWidth,
             onCancel: { localHomebrew.send(.cancel(token: token)) }
         )
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func disabledDuringHomebrewUpdate(_ disabled: Bool) -> some View {
+        if disabled {
+            self
+                .disabled(true)
+                .help(String(localized: "Wait for the current action to finish."))
+        } else {
+            self
+        }
     }
 }
 

--- a/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
+++ b/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
@@ -124,7 +124,7 @@ struct CaskOperationCapsule: View {
 
     private var accentColor: Color {
         switch action {
-        case .updating:
+        case .updating, .updatingHomebrew:
             return .chActionUpdateFg
         case .installing, .adopting, .repairing:
             return .chActionInstallFg

--- a/CaskHub/DesignSystem/Components/TopBarView.swift
+++ b/CaskHub/DesignSystem/Components/TopBarView.swift
@@ -21,7 +21,8 @@ struct TopBarView: View {
     var onSelectWindow: ((RecentlyAddedWindow) -> Void)?
     var onUpdateAll: (() -> Void)?
     var updateAllCount = 0
-    var isUpdatingAll = false
+    var isUpdatingAll: Bool
+    var isUpdatingHomebrew: Bool
     var greedyUpdates: Bool?
     var onToggleGreedy: ((Bool) -> Void)?
     var showsSort = true
@@ -67,34 +68,6 @@ struct TopBarView: View {
         }
         .padding(EdgeInsets(top: 8, leading: 20, bottom: 8, trailing: 10))
         .glassPanel(radius: 999, surface: .chSurfaceToolbar)
-    }
-
-    // MARK: - Update All chip
-
-    private var updateAllChip: some View {
-        Button {
-            showUpdateAllConfirmation = true
-        } label: {
-            HStack(spacing: 6) {
-                if isUpdatingAll {
-                    ProgressView().controlSize(.mini)
-                } else {
-                    Image(systemName: CaskActionStyle.update.icon)
-                        .font(.system(size: 10, weight: .bold))
-                }
-                Text(isUpdatingAll ? "Updating…" : "Update All")
-                    .font(CHType.button)
-            }
-            .foregroundStyle(Color.chActionUpdateFg)
-            .padding(.vertical, 5)
-            .padding(.horizontal, 14)
-            .background(Capsule().fill(Color.chActionUpdateBg))
-            .overlay(Capsule().strokeBorder(Color.chActionUpdateBorder, lineWidth: 1))
-            .contentShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .disabled(isUpdatingAll)
-        .updateAllConfirmation($showUpdateAllConfirmation, count: updateAllCount, onConfirm: onUpdateAll)
     }
 
     // MARK: - Greedy updates chip
@@ -282,6 +255,43 @@ struct TopBarView: View {
         .frame(width: 240)
         .background(Capsule().fill(Color.chSurfaceField))
         .overlay(Capsule().strokeBorder(Color.chHairlineStrong, lineWidth: 1))
+    }
+}
+
+private extension TopBarView {
+    var updateAllChip: some View {
+        Button {
+            showUpdateAllConfirmation = true
+        } label: {
+            HStack(spacing: 6) {
+                if isUpdatingAll {
+                    ProgressView().controlSize(.mini)
+                } else {
+                    Image(systemName: CaskActionStyle.update.icon)
+                        .font(.system(size: 10, weight: .bold))
+                }
+                Text(isUpdatingAll ? "Updating…" : "Update All")
+                    .font(CHType.button)
+            }
+            .foregroundStyle(Color.chActionUpdateFg)
+            .padding(.vertical, 5)
+            .padding(.horizontal, 14)
+            .background(Capsule().fill(Color.chActionUpdateBg))
+            .overlay(Capsule().strokeBorder(Color.chActionUpdateBorder, lineWidth: 1))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(isUpdatingAll || isUpdatingHomebrew)
+        .help(
+            isUpdatingHomebrew
+                ? String(localized: "Wait for the current action to finish.")
+                : String(localized: "Update All")
+        )
+        .updateAllConfirmation(
+            $showUpdateAllConfirmation,
+            count: updateAllCount,
+            onConfirm: onUpdateAll
+        )
     }
 }
 

--- a/CaskHub/Resources/Localizable.xcstrings
+++ b/CaskHub/Resources/Localizable.xcstrings
@@ -3376,6 +3376,176 @@
         }
       }
     },
+    "Homebrew could not extract this disk image because its layout is read-only. Try again once; if it repeats, the cask needs to be corrected upstream." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 无法提取此磁盘映像，因为其布局为只读。请重试一次；如果问题再次出现，则需要由上游修正该 Cask。"
+          }
+        }
+      }
+    },
+    "Homebrew could not prepare its Portable Ruby runtime. Check access to GitHub and GHCR, then update Homebrew and try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 无法准备 Portable Ruby 运行环境。请检查能否访问 GitHub 和 GHCR，然后更新 Homebrew 并重试。"
+          }
+        }
+      }
+    },
+    "Homebrew could not reach a required download host. Check your network, VPN, proxy, and DNS settings, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 无法访问所需的下载主机。请检查网络、VPN、代理和 DNS 设置，然后重试。"
+          }
+        }
+      }
+    },
+    "Homebrew could not write to one of its temporary or installation folders. Run `brew doctor`, correct the permissions it reports, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 无法写入其临时目录或安装目录。请运行 `brew doctor`，修正它报告的权限问题，然后重试。"
+          }
+        }
+      }
+    },
+    "Homebrew found an existing item at the destination. Remove or move that item manually, then try again.\n\n%@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 在目标位置发现了现有项目。请手动移除或移动该项目，然后重试。\n\n%@"
+          }
+        }
+      }
+    },
+    "Homebrew Update Failed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 更新失败"
+          }
+        }
+      }
+    },
+    "Homebrew tried to run code for the wrong processor architecture. Select the compatible Homebrew path in Settings, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 尝试为错误的处理器架构运行代码。请在设置中选择兼容的 Homebrew 路径，然后重试。"
+          }
+        }
+      }
+    },
+    "Homebrew's temporary download state changed while the operation was finishing. Try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作即将完成时，Homebrew 的临时下载状态发生了变化。请重试。"
+          }
+        }
+      }
+    },
+    "macOS canceled opening the disk image. Try again and approve the disk image if macOS asks for confirmation." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS 取消了打开磁盘映像。请重试；如果 macOS 要求确认，请允许打开该磁盘映像。"
+          }
+        }
+      }
+    },
+    "The disk image is already in use. Eject any mounted copy of it, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此磁盘映像正在使用中。请推出已挂载的副本，然后重试。"
+          }
+        }
+      }
+    },
+    "The download is missing valid macOS quarantine metadata. Remove the cached download and let Homebrew download it again; do not bypass the security check." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载内容缺少有效的 macOS 隔离属性。请删除缓存的下载内容，让 Homebrew 重新下载；不要绕过此安全检查。"
+          }
+        }
+      }
+    },
+    "There is not enough free storage to complete this operation. Free some space, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用存储空间不足，无法完成此操作。请释放一些空间，然后重试。"
+          }
+        }
+      }
+    },
+    "This Homebrew installation cannot read the current cask definition. Update Homebrew, then try again. If it still fails, run `brew doctor` in Terminal." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 Homebrew 安装无法读取当前的 Cask 定义。请更新 Homebrew 后重试。如果仍然失败，请在“终端”中运行 `brew doctor`。"
+          }
+        }
+      }
+    },
+    "Update Homebrew" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 Homebrew"
+          }
+        }
+      }
+    },
+    "Updating Homebrew…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在更新 Homebrew…"
+          }
+        }
+      }
+    },
+    "Your administrator has restricted the command Homebrew needs to run. Contact your administrator or install this app using your organization's approved method." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的管理员限制了 Homebrew 所需命令的运行。请联系管理员，或使用组织批准的方法安装此应用。"
+          }
+        }
+      }
+    },
+    "Your Homebrew settings require a checksum, but this cask uses an unversioned download without one. Remove `--require-sha` from `HOMEBREW_CASK_OPTS` to install it." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的 Homebrew 设置要求校验和，但此 Cask 使用不带校验和的未版本化下载。请从 `HOMEBREW_CASK_OPTS` 中移除 `--require-sha` 以安装它。"
+          }
+        }
+      }
+    },
     "Year" : {
       "localizations" : {
         "zh-Hans" : {

--- a/CaskHub/Services/Homebrew/Coordination/CaskOperationFailureFactory.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskOperationFailureFactory.swift
@@ -10,7 +10,8 @@ import Foundation
 enum CaskOperationFailureFactory {
     static func make(
         from error: Error,
-        strandedCopyExists: Bool
+        strandedCopyExists: Bool,
+        title: String? = nil
     ) -> CaskOperationFailure {
         let message = (error as? LocalHomebrewError)?.errorDescription
             ?? error.localizedDescription
@@ -24,23 +25,22 @@ enum CaskOperationFailureFactory {
         case LocalHomebrewError.appBundleNotFound:
             kind = .applicationUnavailable
 
-        case let LocalHomebrewError.brewCommandFailed(arguments, exitCode, stderr):
-            if LocalHomebrewError.isAppManagementDenial(stderr: stderr) {
+        case let LocalHomebrewError.brewCommandFailed(failure):
+            let arguments = failure.arguments
+            let stderr = failure.diagnostic
+            if failure.kind == .permissionDenied {
                 kind = .appManagementDenied
                 recoveries.insert(.openAppManagementSettings)
             }
-            if LocalHomebrewError.isAdoptMismatch(
-                args: arguments,
-                stderr: stderr
-            ), !LocalHomebrewError.isStrandedApp(stderr: stderr) {
+            if failure.kind == .adoptVersionMismatch {
                 recoveries.insert(.replaceWithHomebrew)
             }
-            if LocalHomebrewError.isStrandedApp(stderr: stderr)
+            if failure.kind == .strandedCaskroomApp
                 || (arguments.first == "upgrade" && strandedCopyExists) {
                 recoveries.insert(.repairAndReinstall)
             }
             recoveries.formUnion(classRecoveries(
-                failureClass: LocalHomebrewError.failureClass(stderr: stderr, exitCode: exitCode),
+                failureKind: failure.kind,
                 arguments: arguments,
                 stderr: stderr
             ))
@@ -52,35 +52,38 @@ enum CaskOperationFailureFactory {
         return CaskOperationFailure(
             kind: kind,
             message: message,
+            title: title,
             recoveries: recoveries
         )
     }
 
     private static func classRecoveries(
-        failureClass: String,
+        failureKind: HomebrewFailureKind,
         arguments: [String],
         stderr: String
     ) -> Set<CaskRecoveryAction> {
-        switch failureClass {
-        case "pkg-newer-installed", "pkg-already-installed", "pkg-upgrade-failed":
+        switch failureKind {
+        case .packageNewerInstalled, .packageAlreadyInstalled, .packageUpgradeFailed:
             return [.replaceWithHomebrew]
-        case "binary-conflict":
+        case .binaryConflict:
             return [.replaceWithHomebrew]
-        case "app-conflict":
+        case .appConflict:
             // No adopt retry after a failed --adopt.
             let canAdopt = arguments.first == "install" && !arguments.contains("--adopt")
             return canAdopt ? [.adoptExisting, .replaceWithHomebrew] : [.replaceWithHomebrew]
-        case "missing-uninstall-script":
+        case .missingUninstallScript:
             // Fires on upgrades too — a bare force-uninstall there strands the user.
             switch arguments.first {
             case "uninstall": return [.forceUninstall]
             case "upgrade": return [.repairAndReinstall]
             default: return []
             }
-        case "missing-artifact-source"
+        case .missingArtifactSource
             where arguments.first == "upgrade" && !stderr.contains("Caskroom"):
             // A missing Caskroom staging path is a broken download; reinstall can't help.
             return [.repairAndReinstall]
+        case .homebrewRuntimeIncompatible:
+            return [.updateHomebrew]
         default:
             return []
         }

--- a/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
@@ -39,7 +39,7 @@ final class CaskOperationStore {
     }
 
     func beginUpdateAll() -> Bool {
-        guard !isUpdatingAll else { return false }
+        guard !isUpdatingAll, !isUpdatingHomebrew else { return false }
         isUpdatingAll = true
         return true
     }
@@ -60,6 +60,18 @@ final class CaskOperationStore {
         guard let state = boxes[token]?.state else { return true }
         if case .running = state { return false }
         return true
+    }
+
+    func canBeginOperation(_ action: CaskAction, for token: String) -> Bool {
+        if action == .updatingHomebrew {
+            return !hasActiveOperations
+        }
+        guard !isUpdatingHomebrew else { return false }
+        return canBeginOperation(for: token)
+    }
+
+    var isUpdatingHomebrew: Bool {
+        boxes.values.contains { $0.state?.action == .updatingHomebrew }
     }
 
     var pendingPermissions: [String: CaskAdoptionRequest] {

--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -96,7 +96,10 @@ final class HomebrewMutationCoordinator {
         _ request: HomebrewMutationSequenceRequest,
         callbacks: HomebrewMutationCallbacks
     ) async throws {
-        guard operationStore.canBeginOperation(for: request.token) else { return }
+        guard operationStore.canBeginOperation(
+            request.action,
+            for: request.token
+        ) else { return }
         try preflightBrewLocation(
             token: request.token,
             strandedCopyExists: callbacks.strandedCopyExists()
@@ -236,7 +239,9 @@ extension HomebrewMutationCoordinator {
                     token: token,
                     displayName: displayName,
                     action: action,
-                    phase: action == .uninstalling ? .performing : .preparing
+                    phase: action == .uninstalling || action == .updatingHomebrew
+                        ? .performing
+                        : .preparing
                 ),
                 canCancel: false
             ),
@@ -297,12 +302,14 @@ extension HomebrewMutationCoordinator {
     func recordFailure(
         token: String,
         error: Error,
-        strandedCopyExists: Bool
+        strandedCopyExists: Bool,
+        title: String? = nil
     ) {
         operationStore.send(
             .fail(CaskOperationFailureFactory.make(
                 from: error,
-                strandedCopyExists: strandedCopyExists
+                strandedCopyExists: strandedCopyExists,
+                title: title
             )),
             for: token
         )
@@ -332,7 +339,7 @@ extension HomebrewMutationCoordinator {
                 token: request.token,
                 displayName: request.displayName,
                 action: request.action,
-                phase: .preparing
+                phase: request.action == .updatingHomebrew ? .performing : .preparing
             )),
             for: request.token
         )
@@ -369,17 +376,26 @@ extension HomebrewMutationCoordinator {
             return .continueSequence
         }
 
-        span.finish(error: error)
+        let localError = error as? LocalHomebrewError
+        if localError?.shouldReport == false {
+            span.finish()
+        } else {
+            span.finish(error: error)
+        }
         CrashReporter.capture(error)
         Analytics.caskActionFailed(
             request.action,
             token: request.token,
-            origin: request.origin
+            origin: request.origin,
+            failureKind: localError?.commandFailure?.kind
         )
         recordFailure(
             token: request.token,
             error: error,
-            strandedCopyExists: callbacks.strandedCopyExists()
+            strandedCopyExists: callbacks.strandedCopyExists(),
+            title: request.action == .updatingHomebrew
+                ? String(localized: "Homebrew Update Failed")
+                : nil
         )
         if Self.indicatesStateDesync(error) {
             await callbacks.refresh()
@@ -394,10 +410,10 @@ extension HomebrewMutationCoordinator {
 
     /// Brew disagreeing about install state means the snapshot is stale.
     private static func indicatesStateDesync(_ error: Error) -> Bool {
-        guard case let LocalHomebrewError.brewCommandFailed(_, _, stderr) = error else {
+        guard case let LocalHomebrewError.brewCommandFailed(failure) = error else {
             return false
         }
-        return LocalHomebrewError.failureClass(stderr: stderr) == "not-installed"
+        return failure.kind == .notInstalled
     }
 
 }

--- a/CaskHub/Services/Homebrew/Domain/CaskOperationProgress.swift
+++ b/CaskHub/Services/Homebrew/Domain/CaskOperationProgress.swift
@@ -231,7 +231,7 @@ nonisolated struct CaskOperationStatus: Equatable, Sendable {
         }
         let phaseOrder = [
             "downloading", "checking-download", "using-cache", "verifying", "installing",
-            "updating", "adopting", "uninstalling", "repairing", "preparing",
+            "updating", "updating-homebrew", "adopting", "uninstalling", "repairing", "preparing",
             "canceling", "queued"
         ]
         let details = phaseOrder.compactMap { identifier -> String? in

--- a/CaskHub/Services/Homebrew/Domain/CaskOperationState.swift
+++ b/CaskHub/Services/Homebrew/Domain/CaskOperationState.swift
@@ -12,6 +12,7 @@ nonisolated enum CaskRecoveryAction: CaseIterable, Hashable, Sendable {
     case adoptExisting
     case replaceWithHomebrew
     case repairAndReinstall
+    case updateHomebrew
     case forceUninstall
     case openAppManagementSettings
 }
@@ -28,15 +29,18 @@ nonisolated struct CaskOperationFailure: Equatable, Sendable {
 
     let kind: Kind
     let message: String
+    let title: String?
     let recoveries: Set<CaskRecoveryAction>
 
     init(
         kind: Kind,
         message: String,
+        title: String? = nil,
         recoveries: Set<CaskRecoveryAction> = []
     ) {
         self.kind = kind
         self.message = message
+        self.title = title
         self.recoveries = recoveries
     }
 }

--- a/CaskHub/Services/Homebrew/Domain/HomebrewCommandFailure.swift
+++ b/CaskHub/Services/Homebrew/Domain/HomebrewCommandFailure.swift
@@ -1,0 +1,374 @@
+//
+//  HomebrewCommandFailure.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 12/08/2026.
+//
+
+import Foundation
+
+nonisolated enum HomebrewFailureKind: String, Equatable, Sendable {
+    case adoptVersionMismatch = "adopt-version-mismatch"
+    case appConflict = "app-conflict"
+    case artifactConflict = "artifact-conflict"
+    case binaryConflict = "binary-conflict"
+    case brewAPIUnavailable = "brew-api-unavailable"
+    case brewArchitectureMismatch = "brew-architecture-mismatch"
+    case brewBusy = "brew-busy"
+    case brewLockCleanupRace = "brew-lock-cleanup-race"
+    case caskConflict = "cask-conflict"
+    case caskDependency = "cask-dependency"
+    case checksumMismatch = "checksum-mismatch"
+    case dmgMountBusy = "dmg-mount-busy"
+    case dmgMountCancelled = "dmg-mount-cancelled"
+    case dmgMountFailed = "dmg-mount-failed"
+    case dmgReadOnly = "dmg-read-only"
+    case downloadBroken = "download-broken"
+    case downloadCacheRace = "download-cache-race"
+    case downloadFailed = "download-failed"
+    case exitNonzeroAfterSuccess = "exit-nonzero-after-success"
+    case filesystemPermissionDenied = "filesystem-permission-denied"
+    case homebrewNotWritable = "homebrew-not-writable"
+    case homebrewRuntimeIncompatible = "homebrew-runtime-incompatible"
+    case missingArtifactSource = "missing-artifact-source"
+    case missingUninstallScript = "missing-uninstall-script"
+    case networkFailure = "network-failure"
+    case noDiagnosticOutput = "no-diagnostic-output"
+    case notInstalled = "not-installed"
+    case packageAlreadyInstalled = "pkg-already-installed"
+    case packageInstallerFailed = "pkg-installer-failed"
+    case packageNewerInstalled = "pkg-newer-installed"
+    case packageUpgradeFailed = "pkg-upgrade-failed"
+    case permissionDenied = "permission-denied"
+    case platformUnsupported = "platform-unsupported"
+    case portableRubyUnavailable = "portable-ruby-unavailable"
+    case processKilled = "process-killed"
+    case quarantineInvalid = "quarantine-invalid"
+    case requireSHAPolicy = "require-sha-policy"
+    case strandedCaskroomApp = "stranded-caskroom-app"
+    case storageFull = "storage-full"
+    case sudoDeclined = "sudo-declined"
+    case sudoNotAdmin = "sudo-not-admin"
+    case sudoPolicyDenied = "sudo-policy-denied"
+    case sudoWrongPassword = "sudo-wrong-password"
+    case unknown
+    case unknownCask = "unknown-cask"
+    case upgradeRefused = "upgrade-refused"
+
+    var shouldReport: Bool {
+        switch self {
+        case .adoptVersionMismatch,
+             .appConflict,
+             .artifactConflict,
+             .binaryConflict,
+             .brewArchitectureMismatch,
+             .brewBusy,
+             .brewLockCleanupRace,
+             .caskConflict,
+             .checksumMismatch,
+             .dmgMountBusy,
+             .dmgMountCancelled,
+             .dmgReadOnly,
+             .downloadCacheRace,
+             .filesystemPermissionDenied,
+             .homebrewRuntimeIncompatible,
+             .networkFailure,
+             .permissionDenied,
+             .platformUnsupported,
+             .portableRubyUnavailable,
+             .quarantineInvalid,
+             .requireSHAPolicy,
+             .strandedCaskroomApp,
+             .storageFull,
+             .sudoDeclined,
+             .sudoPolicyDenied,
+             .sudoWrongPassword:
+            false
+        default:
+            true
+        }
+    }
+}
+
+nonisolated struct HomebrewCommandFailure: Equatable, Sendable {
+    let arguments: [String]
+    let exitCode: Int32
+    let diagnostic: String
+    let kind: HomebrewFailureKind
+
+    init(arguments: [String], exitCode: Int32, diagnostic: String) {
+        self.arguments = arguments
+        self.exitCode = exitCode
+        self.diagnostic = diagnostic
+        kind = Self.classify(
+            arguments: arguments,
+            exitCode: exitCode,
+            diagnostic: diagnostic
+        )
+    }
+
+    var subcommand: String? {
+        arguments.first
+    }
+
+    var stableFingerprint: [String]? {
+        guard let subcommand else { return nil }
+        return ["brewCommandFailed", subcommand, kind.rawValue]
+    }
+
+    var rateLimitSignature: String {
+        ["brewCommandFailed", subcommand ?? "missing-subcommand", kind.rawValue]
+            .joined(separator: ":")
+    }
+}
+
+nonisolated extension HomebrewCommandFailure {
+    static func classify(
+        arguments: [String],
+        exitCode: Int32?,
+        diagnostic: String
+    ) -> HomebrewFailureKind {
+        let text = diagnostic.lowercased()
+        return privilegeKind(text: text, diagnostic: diagnostic)
+            ?? processKind(text: text, exitCode: exitCode)
+            ?? installerKind(text: text)
+            ?? diskImageKind(text: text)
+            ?? policyKind(text: text)
+            ?? artifactKind(arguments: arguments, text: text, diagnostic: diagnostic)
+            ?? environmentKind(text: text)
+            ?? downloadKind(text: text)
+            ?? (text.isBlank ? .noDiagnosticOutput : .unknown)
+    }
+
+    private struct Match {
+        let fragments: [String]
+        let kind: HomebrewFailureKind
+    }
+
+    private static func firstMatch(
+        in text: String,
+        _ matches: [Match]
+    ) -> HomebrewFailureKind? {
+        matches.first { match in
+            match.fragments.allSatisfy(text.contains)
+        }?.kind
+    }
+
+    private static func privilegeKind(
+        text: String,
+        diagnostic: String
+    ) -> HomebrewFailureKind? {
+        if isAppManagementDenial(diagnostic) { return .permissionDenied }
+        return firstMatch(in: text, [
+            Match(
+                fragments: ["sorry, you are not allowed to preserve the environment"],
+                kind: .sudoPolicyDenied
+            ),
+            Match(fragments: ["is not allowed to execute"], kind: .sudoPolicyDenied),
+            Match(fragments: ["incorrect password attempt"], kind: .sudoWrongPassword),
+            Match(fragments: ["sudo: no password was provided"], kind: .sudoDeclined),
+            Match(fragments: ["sudo: a password is required"], kind: .sudoDeclined),
+            Match(fragments: ["is not in the sudoers file"], kind: .sudoNotAdmin)
+        ])
+    }
+
+    private static func processKind(
+        text: String,
+        exitCode: Int32?
+    ) -> HomebrewFailureKind? {
+        if let exitCode, [9, 15, 130].contains(exitCode), text.isBlank {
+            return .processKilled
+        }
+        if text.contains("bad cpu type in executable"),
+           text.contains("portable-ruby") || text.contains("homebrew/brew.sh") {
+            return .brewArchitectureMismatch
+        }
+        return firstMatch(in: text, [
+            Match(fragments: ["failed to download ruby"], kind: .portableRubyUnavailable),
+            Match(
+                fragments: ["failed to upgrade homebrew portable ruby"],
+                kind: .portableRubyUnavailable
+            )
+        ])
+    }
+
+    private static func installerKind(text: String) -> HomebrewFailureKind? {
+        firstMatch(in: text, [
+            Match(
+                fragments: ["a newer version of", "is already installed"],
+                kind: .packageNewerInstalled
+            ),
+            Match(
+                fragments: ["installer:", "is already installed"],
+                kind: .packageAlreadyInstalled
+            ),
+            Match(
+                fragments: ["installer:", "the upgrade failed"],
+                kind: .packageUpgradeFailed
+            ),
+            Match(fragments: ["installer: the install failed"], kind: .packageInstallerFailed),
+            Match(fragments: ["/usr/sbin/installer -pkg"], kind: .packageInstallerFailed),
+            Match(
+                fragments: ["uninstall script", "does not exist"],
+                kind: .missingUninstallScript
+            )
+        ])
+    }
+
+    private static func diskImageKind(text: String) -> HomebrewFailureKind? {
+        if text.contains("read-only file system"), text.contains("homebrew-dmg") {
+            return .dmgReadOnly
+        }
+        if text.contains("hdiutil: attach canceled") { return .dmgMountCancelled }
+        if text.contains("hdiutil"), text.contains("attach") {
+            if text.contains("resource busy") || text.contains("ressource ist belegt") {
+                return .dmgMountBusy
+            }
+            return .dmgMountFailed
+        }
+        return nil
+    }
+
+    private static func policyKind(text: String) -> HomebrewFailureKind? {
+        if isHomebrewRuntimeIncompatible(text) { return .homebrewRuntimeIncompatible }
+        return firstMatch(in: text, [
+            Match(
+                fragments: ["does not have a sha256 checksum defined", "--require-sha"],
+                kind: .requireSHAPolicy
+            ),
+            Match(fragments: ["reports different checksum"], kind: .checksumMismatch),
+            Match(fragments: ["sha256 mismatch"], kind: .checksumMismatch),
+            Match(fragments: ["was not quarantined properly"], kind: .quarantineInvalid)
+        ])
+    }
+
+    private static func artifactKind(
+        arguments: [String],
+        text: String,
+        diagnostic: String
+    ) -> HomebrewFailureKind? {
+        if isStrandedApp(diagnostic) { return .strandedCaskroomApp }
+        if text.contains("different from the one being installed")
+            || (arguments.contains("--adopt") && text.contains("already an app at")) {
+            return .adoptVersionMismatch
+        }
+        return firstMatch(in: text, [
+            Match(fragments: ["is not there"], kind: .missingArtifactSource),
+            Match(fragments: ["no cask with this name exists"], kind: .unknownCask),
+            Match(fragments: ["no casks found"], kind: .unknownCask),
+            Match(fragments: ["is not installed"], kind: .notInstalled),
+            Match(fragments: ["already a binary at"], kind: .binaryConflict),
+            Match(fragments: ["already an app at"], kind: .appConflict),
+            Match(fragments: ["conflicts with"], kind: .caskConflict),
+            Match(fragments: ["refusing to uninstall"], kind: .caskDependency),
+            Match(
+                fragments: ["it seems there is already a ", " at '"],
+                kind: .artifactConflict
+            )
+        ])
+    }
+
+    private static func downloadKind(text: String) -> HomebrewFailureKind? {
+        if isNetworkFailure(text) { return .networkFailure }
+        return firstMatch(in: text, [
+            Match(fragments: ["the requested url returned error:"], kind: .downloadBroken),
+            Match(fragments: ["cannot download non-corrupt"], kind: .brewAPIUnavailable),
+            Match(fragments: ["download failed on cask"], kind: .downloadFailed)
+        ])
+    }
+
+    private static func environmentKind(text: String) -> HomebrewFailureKind? {
+        firstMatch(in: text, [
+            Match(fragments: ["process has already locked"], kind: .brewBusy),
+            Match(fragments: ["gave up after waiting"], kind: .brewBusy),
+            Match(fragments: ["please wait for it to finish"], kind: .brewBusy),
+            Match(fragments: ["is already running"], kind: .brewBusy),
+            Match(
+                fragments: ["no such file or directory", ".lock", "dir_s_rmdir"],
+                kind: .brewLockCleanupRace
+            ),
+            Match(
+                fragments: [
+                    "no such file or directory",
+                    ".incomplete",
+                    "library/caches/homebrew/downloads"
+                ],
+                kind: .downloadCacheRace
+            ),
+            Match(fragments: ["no space left on device"], kind: .storageFull),
+            Match(
+                fragments: ["permission denied", "/private/tmp/homebrew"],
+                kind: .filesystemPermissionDenied
+            ),
+            Match(
+                fragments: ["permission denied", "/opt/homebrew"],
+                kind: .filesystemPermissionDenied
+            ),
+            Match(
+                fragments: ["permission denied", "/usr/local/homebrew"],
+                kind: .filesystemPermissionDenied
+            ),
+            Match(fragments: ["not writable by your user"], kind: .homebrewNotWritable),
+            Match(
+                fragments: ["this cask does not run on macos versions"],
+                kind: .platformUnsupported
+            ),
+            Match(fragments: ["depends on hardware architecture"], kind: .platformUnsupported),
+            Match(
+                fragments: ["current os x version is not supported"],
+                kind: .platformUnsupported
+            ),
+            Match(
+                fragments: ["current macos version is not supported"],
+                kind: .platformUnsupported
+            ),
+            Match(fragments: ["requires linux"], kind: .platformUnsupported),
+            Match(fragments: ["error: not upgrading"], kind: .upgradeRefused),
+            Match(fragments: ["successfully upgraded!"], kind: .exitNonzeroAfterSuccess)
+        ])
+    }
+
+    private static func isAppManagementDenial(_ diagnostic: String) -> Bool {
+        if diagnostic.localizedCaseInsensitiveContains(
+            "does not have App Management permissions"
+        ) {
+            return true
+        }
+        return diagnostic.components(separatedBy: .newlines).contains { line in
+            line.localizedCaseInsensitiveContains("Operation not permitted")
+                && line.contains("/Applications/")
+                && line.localizedCaseInsensitiveContains(".app")
+        }
+    }
+
+    private static func isStrandedApp(_ diagnostic: String) -> Bool {
+        diagnostic.localizedCaseInsensitiveContains("already an App at")
+            && diagnostic.localizedCaseInsensitiveContains("Caskroom")
+    }
+
+    private static func isHomebrewRuntimeIncompatible(_ text: String) -> Bool {
+        if text.contains("cask_loader.rb"), text.contains("undefined method") {
+            return true
+        }
+        guard text.contains("definition is invalid") else { return false }
+        return text.contains("undefined method")
+            || text.contains("command_wrapper")
+            || text.contains("postflight_steps")
+            || text.contains("unknown key:")
+    }
+
+    private static func isNetworkFailure(_ text: String) -> Bool {
+        let curlCodes = [5, 6, 7, 18, 28, 35, 56, 92]
+        return curlCodes.contains { text.contains("curl: (\($0))") }
+            || text.contains("nameresolutionerror")
+            || text.contains("could not resolve host")
+            || text.contains("failed to resolve")
+    }
+
+}
+
+private nonisolated extension String {
+    var isBlank: Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewError.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewError.swift
@@ -11,7 +11,19 @@ enum LocalHomebrewError: LocalizedError {
     case brewBinaryNotFound
     case incompatibleBrewPath
     case appBundleNotFound(token: String)
-    case brewCommandFailed(args: [String], exitCode: Int32, stderr: String)
+    case brewCommandFailed(HomebrewCommandFailure)
+
+    static func brewCommandFailed(
+        args: [String],
+        exitCode: Int32,
+        stderr: String
+    ) -> Self {
+        .brewCommandFailed(HomebrewCommandFailure(
+            arguments: args,
+            exitCode: exitCode,
+            diagnostic: stderr
+        ))
+    }
 
     /// Expected user or environment state is not an app defect.
     var shouldReport: Bool {
@@ -20,97 +32,15 @@ enum LocalHomebrewError: LocalizedError {
             return false
         case .appBundleNotFound:
             return true
-        case let .brewCommandFailed(_, code, stderr):
-            return !Self.nonReportableFailureClasses.contains(
-                Self.failureClass(stderr: stderr, exitCode: code)
-            )
+        case let .brewCommandFailed(failure):
+            return failure.kind.shouldReport
         }
     }
 
-    /// Coarse classes for Sentry grouping — one issue per way brew fails, not per cask.
-    static func failureClass(stderr: String, exitCode: Int32? = nil) -> String {
-        if isStrandedApp(stderr: stderr) { return "stranded-caskroom-app" }
-        if isAppManagementDenial(stderr: stderr) { return "permission-denied" }
-        if stderr.contains("A newer version of"),
-           stderr.contains("is already installed") {
-            return "pkg-newer-installed"
-        }
-        if stderr.contains("installer:"),
-           stderr.contains("is already installed") {
-            return "pkg-already-installed"
-        }
-        if stderr.contains("installer:"), stderr.contains("The upgrade failed") {
-            return "pkg-upgrade-failed"
-        }
-        if stderr.contains("uninstall script"), stderr.contains("does not exist") {
-            return "missing-uninstall-script"
-        }
-        if let exitCode, [9, 15, 130].contains(exitCode),  // SIGKILL/SIGTERM/SIGINT
-           stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return "process-killed"
-        }
-        return failurePatterns.first { stderr.contains($0.fragment) }?.classification
-            ?? "uncategorized"
+    var commandFailure: HomebrewCommandFailure? {
+        guard case let .brewCommandFailed(failure) = self else { return nil }
+        return failure
     }
-
-    private static let failurePatterns: [(fragment: String, classification: String)] = [
-        // First: a failed prompt outranks incidental fragments below it.
-        ("sudo: no password was provided", "sudo-declined"),
-        ("sudo: a password is required", "sudo-declined"),
-        ("incorrect password attempt", "sudo-wrong-password"),
-        ("is not in the sudoers file", "sudo-not-admin"),
-        ("is not there", "missing-artifact-source"),
-        ("different from the one being installed", "adopt-version-mismatch"),
-        ("No Cask with this name exists", "unknown-cask"),
-        ("No casks found", "unknown-cask"),
-        ("is not installed", "not-installed"),
-        // Checksum above the download family: brew wraps some in download phrasing.
-        ("reports different checksum", "checksum-mismatch"),
-        ("SHA256 mismatch", "checksum-mismatch"),
-        // Installer/dmg above the download family: vendor pkg scripts run curl too.
-        ("attach failed - Resource busy", "dmg-mount-busy"),
-        ("installer: The install failed", "pkg-installer-failed"),
-        ("/usr/sbin/installer -pkg", "pkg-installer-failed"),
-        // HTTP errors (curl 22) split out: persistent 404s flag dead casks.
-        ("The requested URL returned error:", "download-broken"),
-        ("curl: (5)", "network-failure"),
-        ("curl: (6)", "network-failure"),
-        ("curl: (7)", "network-failure"),
-        ("curl: (18)", "network-failure"),
-        ("curl: (28)", "network-failure"),
-        ("curl: (35)", "network-failure"),
-        ("curl: (56)", "network-failure"),
-        ("curl: (92)", "network-failure"),
-        ("Cannot download non-corrupt", "brew-api-unavailable"),
-        ("Download failed on Cask", "download-failed"),
-        ("already a Binary at", "binary-conflict"),
-        ("already an App at", "app-conflict"),
-        ("conflicts with", "cask-conflict"),
-        ("Refusing to uninstall", "cask-dependency"),
-        ("This cask does not run on macOS versions", "platform-unsupported"),
-        ("depends on hardware architecture", "platform-unsupported"),
-        ("requires Linux", "platform-unsupported"),
-        ("is already running", "brew-busy"),
-        ("Please wait for it to finish", "brew-busy"),
-        ("not writable by your user", "homebrew-not-writable"),
-        ("Error: Not upgrading", "upgrade-refused"),
-        // Last: success text must never outrank a real error line above.
-        ("successfully upgraded!", "exit-nonzero-after-success")
-    ]
-
-    private static let nonReportableFailureClasses: Set<String> = [
-        "adopt-version-mismatch",
-        "app-conflict",
-        "binary-conflict",
-        "cask-conflict",
-        "checksum-mismatch",
-        "network-failure",
-        "permission-denied",
-        "platform-unsupported",
-        "stranded-caskroom-app",
-        "sudo-declined",
-        "sudo-wrong-password"
-    ]
 
     /// "…because it is required by <token>, which is currently installed."
     static func dependentCask(stderr: String) -> String? {
@@ -144,12 +74,9 @@ enum LocalHomebrewError: LocalizedError {
         ))
     }
 
-    /// A previous interrupted operation parked the real .app inside the Caskroom
-    /// version directory; every upgrade then fails until the copy is cleared.
-    static func isStrandedApp(stderr: String) -> Bool {
-        stderr.contains("already an App at") && stderr.contains("Caskroom")
-    }
+}
 
+extension LocalHomebrewError {
     var errorDescription: String? {
         switch self {
         case .brewBinaryNotFound:
@@ -167,29 +94,32 @@ enum LocalHomebrewError: LocalizedError {
             )
         case let .appBundleNotFound(token):
             return String(localized: "Couldn't find an installed app for \(token).")
-        case let .brewCommandFailed(args, code, stderr):
+        case let .brewCommandFailed(failure):
+            let args = failure.arguments
+            let code = failure.exitCode
+            let stderr = failure.diagnostic
             let cmd = (["brew"] + args).joined(separator: " ")
             let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            if Self.isAppManagementDenial(stderr: trimmed) {
+            if failure.kind == .permissionDenied {
                 return String(localized: .errorAppManagementDenied)
             }
-            if Self.isStrandedApp(stderr: trimmed) {
+            if failure.kind == .strandedCaskroomApp {
                 return String(localized: .errorStaleUpgradeRecord)
             }
-            if Self.isAdoptMismatch(args: args, stderr: trimmed) {
+            if failure.kind == .adoptVersionMismatch {
                 return String(localized: .errorAdoptVersionMismatch)
             }
-            switch Self.failureClass(stderr: trimmed, exitCode: code) {
-            case "binary-conflict":
+            switch failure.kind {
+            case .binaryConflict:
                 return "A leftover command-line tool from a previous installation "
                     + "is in the way. Replacing with Homebrew's version overwrites it — "
                     + "your settings and data are kept."
-            case "app-conflict":
+            case .appConflict:
                 return "This app is already on your Mac, but Homebrew doesn't manage "
                     + "it yet. Adopt keeps your current copy and hands management to "
                     + "Homebrew; Replace installs Homebrew's copy fresh. Settings and "
                     + "data are kept either way."
-            case "cask-conflict":
+            case .caskConflict:
                 let requestedCask = args.drop(while: { $0 != "--cask" }).dropFirst().first
                 guard let requestedCask,
                       let installedCask = Self.conflictingCask(stderr: trimmed)
@@ -198,62 +128,150 @@ enum LocalHomebrewError: LocalizedError {
                     requestedCask: requestedCask,
                     installedCask: installedCask
                 )
-            case "cask-dependency":
+            case .caskDependency:
                 let dependent = Self.dependentCask(stderr: trimmed)
                 return "This can't be uninstalled because "
                     + (dependent.map { "“\($0)” needs it" } ?? "another installed app needs it")
                     + ". Uninstall \(dependent.map { "“\($0)”" } ?? "that app") first, "
                     + "then try again."
-            case "missing-uninstall-script" where args.first == "upgrade":
+            case .missingUninstallScript where args.first == "upgrade":
                 return "The app's uninstall helper is missing, which blocks the "
                     + "update. Repair & Reinstall clears it and installs the new "
                     + "version fresh — your settings and data are kept."
-            case "missing-uninstall-script":
+            case .missingUninstallScript:
                 return "The app's uninstall helper is missing, so Homebrew can't run "
                     + "its normal cleanup. Force Uninstall removes the app anyway."
-            case "sudo-declined":
+            case .sudoDeclined:
                 return "This step needs your administrator password. "
                     + "Try again and enter your password when CaskHub asks for it."
-            case "sudo-wrong-password":
+            case .sudoWrongPassword:
                 return "The password wasn't accepted. "
                     + "Try again and re-enter your administrator password."
-            case "sudo-not-admin":
+            case .sudoNotAdmin:
                 return "This step needs an administrator account. "
                     + "Your macOS user doesn't have administrator rights, so Homebrew "
                     + "can't complete it."
-            case "process-killed":
+            case .sudoPolicyDenied:
+                return String(
+                    localized: """
+                    Your administrator has restricted the command Homebrew needs to run. \
+                    Contact your administrator or install this app using your organization's approved method.
+                    """
+                )
+            case .processKilled:
                 return "The operation was interrupted before it finished. Try again."
-            case "pkg-newer-installed":
+            case .packageNewerInstalled:
                 return "The vendor installer refused because a newer version is already "
                     + "installed. Downgrade & Adopt can download Homebrew's version first, "
                     + "remove the current package with the cask's uninstall steps, and then "
                     + "install the older version."
-            case "pkg-already-installed":
+            case .packageAlreadyInstalled:
                 return "The vendor installer refused to reinstall the version already on this "
                     + "Mac. Replace with Homebrew Version can download it first, remove the "
                     + "current package with the cask's uninstall steps, and install it fresh."
-            case "pkg-upgrade-failed":
+            case .packageUpgradeFailed:
                 return "The vendor package installer could not upgrade the existing app in "
                     + "place. Replace with Homebrew Version can stage the download, remove the "
                     + "current package with the cask's uninstall steps, and install it fresh."
-            case "brew-busy":
+            case .brewBusy:
                 return "Another Homebrew process is using the same download or installation "
                     + "files. Wait for it to finish, then try again."
-            case "homebrew-not-writable":
+            case .brewLockCleanupRace, .downloadCacheRace:
+                return String(
+                    localized: "Homebrew's temporary download state changed while the operation was finishing. Try again."
+                )
+            case .brewArchitectureMismatch:
+                return String(
+                    localized: """
+                    Homebrew tried to run code for the wrong processor architecture. \
+                    Select the compatible Homebrew path in Settings, then try again.
+                    """
+                )
+            case .homebrewRuntimeIncompatible:
+                return String(
+                    localized: """
+                    This Homebrew installation cannot read the current cask definition. \
+                    Update Homebrew, then try again. If it still fails, run `brew doctor` in Terminal.
+                    """
+                )
+            case .portableRubyUnavailable:
+                return String(
+                    localized: """
+                    Homebrew could not prepare its Portable Ruby runtime. \
+                    Check access to GitHub and GHCR, then update Homebrew and try again.
+                    """
+                )
+            case .dmgMountCancelled:
+                return String(
+                    localized: "macOS canceled opening the disk image. Try again and approve the disk image if macOS asks for confirmation."
+                )
+            case .dmgMountBusy:
+                return String(
+                    localized: "The disk image is already in use. Eject any mounted copy of it, then try again."
+                )
+            case .dmgReadOnly:
+                return String(
+                    localized: """
+                    Homebrew could not extract this disk image because its layout is read-only. \
+                    Try again once; if it repeats, the cask needs to be corrected upstream.
+                    """
+                )
+            case .requireSHAPolicy:
+                return String(
+                    localized: """
+                    Your Homebrew settings require a checksum, but this cask uses an unversioned download without one. \
+                    Remove `--require-sha` from `HOMEBREW_CASK_OPTS` to install it.
+                    """
+                )
+            case .artifactConflict:
+                return String(
+                    localized: """
+                    Homebrew found an existing item at the destination. \
+                    Remove or move that item manually, then try again.
+
+                    \(trimmed)
+                    """
+                )
+            case .networkFailure:
+                return String(
+                    localized: """
+                    Homebrew could not reach a required download host. \
+                    Check your network, VPN, proxy, and DNS settings, then try again.
+                    """
+                )
+            case .storageFull:
+                return String(
+                    localized: "There is not enough free storage to complete this operation. Free some space, then try again."
+                )
+            case .filesystemPermissionDenied:
+                return String(
+                    localized: """
+                    Homebrew could not write to one of its temporary or installation folders. \
+                    Run `brew doctor`, correct the permissions it reports, then try again.
+                    """
+                )
+            case .quarantineInvalid:
+                return String(
+                    localized: """
+                    The download is missing valid macOS quarantine metadata. \
+                    Remove the cached download and let Homebrew download it again; \
+                    do not bypass the security check.
+                    """
+                )
+            case .homebrewNotWritable:
                 return "Homebrew cannot write to one or more directories in its prefix. Run "
                     + "`brew doctor`, repair the ownership it reports, then try again."
-            case "brew-api-unavailable":
+            case .brewAPIUnavailable:
                 return "Homebrew could not obtain a valid package from its API. Wait a few "
                     + "minutes and try again; if it persists, update Homebrew."
-            case "platform-unsupported":
+            case .platformUnsupported:
                 return String(
                     localized: "This app is not available for this Mac's processor architecture or macOS version."
                 )
+            case .checksumMismatch:
+                return String(localized: .errorChecksumMismatch)
             default:
                 break
-            }
-            if trimmed.contains("reports different checksum") || trimmed.contains("SHA256 mismatch") {
-                return String(localized: .errorChecksumMismatch)
             }
             return trimmed.isEmpty
                 ? String(localized: "`\(cmd)` failed (exit \(code)).")
@@ -261,20 +279,4 @@ enum LocalHomebrewError: LocalizedError {
         }
     }
 
-    /// The App Management (TCC) permission gating modification of other apps' bundles.
-    static func isAppManagementDenial(stderr: String) -> Bool {
-        if stderr.contains("does not have App Management permissions") { return true }
-        return stderr.components(separatedBy: .newlines).contains { line in
-            line.contains("Operation not permitted")
-                && line.contains("/Applications/")
-                && line.contains(".app")
-        }
-    }
-
-    /// `brew install --adopt` refuses when the on-disk app differs from the cask's version.
-    static func isAdoptMismatch(args: [String], stderr: String) -> Bool {
-        args.contains("--adopt")
-            && (stderr.contains("different from the one being installed")
-                || stderr.contains("already an App at"))
-    }
 }

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewTypes.swift
@@ -277,6 +277,7 @@ nonisolated enum CaskAction: Equatable, Sendable {
     case installing
     case adopting
     case updating
+    case updatingHomebrew
     case uninstalling
     case repairing
     case queued
@@ -287,6 +288,7 @@ nonisolated enum CaskAction: Equatable, Sendable {
         case .installing: return String(localized: "Installing…")
         case .adopting: return String(localized: "Adopting…")
         case .updating: return String(localized: "Updating…")
+        case .updatingHomebrew: return String(localized: "Updating Homebrew…")
         case .uninstalling: return String(localized: "Uninstalling…")
         case .repairing: return String(localized: "Repairing…")
         case .queued: return String(localized: "Queued…")
@@ -301,6 +303,7 @@ nonisolated enum CaskAction: Equatable, Sendable {
         case .installing: return "installing"
         case .adopting: return "adopting"
         case .updating: return "updating"
+        case .updatingHomebrew: return "updating-homebrew"
         case .uninstalling: return "uninstalling"
         case .repairing: return "repairing"
         case .queued: return "queued"

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Intents.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Intents.swift
@@ -10,6 +10,7 @@ enum CaskIntent {
     case uninstall(token: String)
     case repair(token: String)
     case repairAndReinstall(token: String)
+    case updateHomebrew(token: String)
     case update(token: String)
     case updateAll(tokens: [String])
     case requestAdoption(Cask)
@@ -35,7 +36,8 @@ extension LocalHomebrewService {
         CaskActionPresentation(
             localState: suppliedState ?? localState(for: cask),
             homebrewInstallation: installationSnapshot.installedCasks[cask.token],
-            operationState: operationStore.state(for: cask.token)
+            operationState: operationStore.state(for: cask.token),
+            isHomebrewMutationBlocked: operationStore.isUpdatingHomebrew
         )
     }
 
@@ -59,6 +61,8 @@ extension LocalHomebrewService {
             Task { try? await repair(token: token) }
         case let .repairAndReinstall(token):
             Task { try? await repairReinstalling(token: token) }
+        case let .updateHomebrew(token):
+            Task { try? await updateHomebrew(for: token) }
         case let .update(token):
             Task { try? await upgrade(token: token) }
         case let .updateAll(tokens):

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Mutations.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Mutations.swift
@@ -45,18 +45,22 @@ extension LocalHomebrewService {
         _ action: CaskAction,
         token: String,
         steps: [HomebrewMutationStep],
-        origin: CaskActionOrigin
+        origin: CaskActionOrigin,
+        displayName: String? = nil
     ) async throws {
         try await mutationCoordinator.runSequence(
             HomebrewMutationSequenceRequest(
                 action: action,
                 token: token,
-                displayName: displayName(for: token),
+                displayName: displayName ?? self.displayName(for: token),
                 origin: origin,
                 steps: steps
             ),
             callbacks: HomebrewMutationCallbacks(
-                refresh: { [self] in await refresh() },
+                refresh: { [self] in
+                    if action == .updatingHomebrew { invalidateBrewVersion() }
+                    await refresh()
+                },
                 strandedCopyExists: { [self] in hasStrandedCopy(token: token) },
                 recoverIf: nil
             )

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
@@ -72,6 +72,25 @@ extension LocalHomebrewService {
         )
     }
 
+    /// Homebrew's troubleshooting checklist calls for two update passes: the
+    /// first can update brew itself while leaving the original command behind.
+    func updateHomebrew(for token: String) async throws {
+        let updateStep = HomebrewMutationStep(
+            arguments: ["update"],
+            environmentOverrides: [:],
+            cancellable: false,
+            recoverIf: nil,
+            recoveryBehavior: .continueSequence
+        )
+        try await runMutationSequence(
+            .updatingHomebrew,
+            token: token,
+            steps: [updateStep, updateStep],
+            origin: .repair,
+            displayName: String(localized: "Homebrew")
+        )
+    }
+
     /// Package artifacts cannot be adopted as metadata. For a downgrade (or a
     /// recovery after a vendor installer refuses an in-place install), fetch the
     /// payload first, ask Homebrew to run the cask's uninstall stanza even though
@@ -150,7 +169,10 @@ extension LocalHomebrewService {
     func updateAll(tokens: [String]) async {
         guard operationStore.beginUpdateAll() else { return }
         defer { operationStore.finishUpdateAll() }
-        for token in tokens where operationStore.canBeginOperation(for: token) {
+        for token in tokens where operationStore.canBeginOperation(
+            .updating,
+            for: token
+        ) {
             operationStore.send(.enqueue(.updating), for: token)
         }
         for (index, token) in tokens.enumerated() {

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService.swift
@@ -48,6 +48,10 @@ final class LocalHomebrewService {
         operationStore.isUpdatingAll
     }
 
+    var isUpdatingHomebrew: Bool {
+        operationStore.isUpdatingHomebrew
+    }
+
     var hasActiveOperations: Bool {
         operationStore.hasActiveOperations
     }
@@ -157,6 +161,10 @@ final class LocalHomebrewService {
         await refresh()
     }
 
+    func invalidateBrewVersion() {
+        brewVersion = nil
+    }
+
     // MARK: - Detection
 
     func refresh() async {
@@ -175,6 +183,7 @@ final class LocalHomebrewService {
                 "brew.path",
                 value: brewBinaryProvider()?.path ?? "not found"
             )
+            CrashReporter.tag("brew.version", value: brewVersion ?? "not found")
             CrashReporter.tag("brew.caskroom", value: request.caskroomURL?.path ?? "not found")
             return
         }

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewOutputDiagnostics.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewOutputDiagnostics.swift
@@ -62,8 +62,8 @@ nonisolated enum HomebrewOutputDiagnostics {
         if line.unicodeScalars.contains(where: { (0x2800...0x28FF).contains($0.value) }) {
             return true
         }
-        guard let range = line.range(of: "Downloading ") ?? line.range(of: "Extracting ")
-            ?? line.range(of: "Verified ") else { return false }
+        guard let range = line.range(of: "Downloading ") ?? line.range(of: "Downloaded ")
+            ?? line.range(of: "Extracting ") ?? line.range(of: "Verified ") else { return false }
         return line[range.upperBound...].contains("B/")
     }
 }

--- a/CaskHub/Services/Homebrew/Presentation/CaskActionPresentation.swift
+++ b/CaskHub/Services/Homebrew/Presentation/CaskActionPresentation.swift
@@ -31,6 +31,7 @@ nonisolated struct CaskActionPresentation: Equatable, Sendable {
     let localState: CaskLocalState
     let homebrewInstallation: LocalCaskInstallation?
     let operationState: CaskOperationState?
+    let isHomebrewMutationBlocked: Bool
 
     var activeAction: CaskAction? {
         operationState?.action
@@ -49,7 +50,7 @@ nonisolated struct CaskActionPresentation: Equatable, Sendable {
     }
 
     var isBusy: Bool {
-        activeAction != nil
+        activeAction != nil || isHomebrewMutationBlocked
     }
 
 }

--- a/CaskHub/Services/Telemetry/Analytics+Events.swift
+++ b/CaskHub/Services/Telemetry/Analytics+Events.swift
@@ -37,12 +37,15 @@ extension Analytics {
     static func caskActionFailed(
         _ action: CaskAction,
         token: String,
-        origin: CaskActionOrigin = .individual
+        origin: CaskActionOrigin = .individual,
+        failureKind: HomebrewFailureKind? = nil
     ) {
         guard let verb = action.analyticsVerb else { return }
-        send("Cask.actionFailed", parameters: actionParameters(
+        var parameters = actionParameters(
             verb: verb.base, token: token, origin: origin
-        ))
+        )
+        parameters["failureClass"] = failureKind?.rawValue
+        send("Cask.actionFailed", parameters: parameters)
     }
 
     static func caskActionRecovered(
@@ -161,7 +164,7 @@ private extension CaskAction {
         case .uninstalling: return ("uninstall", "uninstalled")
         case .updating: return ("update", "updated")
         case .repairing: return ("repair", "repaired")
-        case .opening, .queued: return nil
+        case .opening, .updatingHomebrew, .queued: return nil
         }
     }
 }

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -92,7 +92,13 @@ enum CrashReporter {
                .contains("Unexpected end of file") == true {
             return
         }
-        let signature = "\(type(of: error)):\(nsError.domain):\(nsError.code)"
+        let signature: String
+        if let localError = error as? LocalHomebrewError,
+           case let .brewCommandFailed(failure) = localError {
+            signature = failure.rateLimitSignature
+        } else {
+            signature = "\(type(of: error)):\(nsError.domain):\(nsError.code)"
+        }
         let count = captureCounts[signature, default: 0]
         guard count < captureLimit else { return }
         captureCounts[signature] = count + 1
@@ -173,6 +179,12 @@ final class SentryProvider: CrashReporterProvider {
             if let fingerprint = Self.fingerprint(for: error) {
                 scope.setFingerprint(fingerprint)
             }
+            guard let localError = error as? LocalHomebrewError,
+                  case let .brewCommandFailed(failure) = localError
+            else { return }
+            scope.setTag(value: failure.kind.rawValue, key: "brew.failure_class")
+            scope.setTag(value: failure.subcommand ?? "missing", key: "brew.subcommand")
+            scope.setTag(value: String(failure.exitCode), key: "brew.exit_code")
         }
     }
 
@@ -180,13 +192,10 @@ final class SentryProvider: CrashReporterProvider {
     /// domain+code — one issue per way brew fails, so a rare destructive failure
     /// can't hide inside a busy catch-all group.
     static func fingerprint(for error: Error) -> [String]? {
-        guard case let LocalHomebrewError.brewCommandFailed(args, exitCode, stderr) = error,
-              let subcommand = args.first else { return nil }
-        return [
-            "brewCommandFailed",
-            subcommand,
-            LocalHomebrewError.failureClass(stderr: stderr, exitCode: exitCode)
-        ]
+        guard case let LocalHomebrewError.brewCommandFailed(failure) = error else {
+            return nil
+        }
+        return failure.stableFingerprint
     }
 
     func setTag(_ key: String, value: String) {

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -166,6 +166,7 @@ struct ContentView: View {
                 : nil,
             updateAllCount: viewModel.updatesCount,
             isUpdatingAll: localHomebrew.isUpdatingAll,
+            isUpdatingHomebrew: localHomebrew.isUpdatingHomebrew,
             greedyUpdates: selectedSidebar == .library(.updates) ? localHomebrew.greedyUpdates : nil,
             onToggleGreedy: { enabled in
                 Analytics.greedyUpdatesChanged(enabled)

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -238,7 +238,7 @@ enum CaskActionAlertFactory {
         let alert = NSAlert()
         alert.messageText = failure.kind == .installationPreflight
             ? String(localized: .alertInstallConflictTitle(cask.displayName))
-            : "\(cask.displayName) Failed"
+            : failure.title ?? "\(cask.displayName) Failed"
         if failure.message.count <= 500 {
             alert.informativeText = failure.message
         } else {
@@ -256,7 +256,13 @@ enum CaskActionAlertFactory {
         }
         var actions: [() -> Void] = []
         for recovery in CaskRecoveryAction.allCases where failure.recoveries.contains(recovery) {
-            alert.addButton(withTitle: recovery.buttonTitle).keyEquivalent = ""
+            let canPerform = recovery.canPerform(cask: cask, service: service)
+            let button = alert.addButton(withTitle: recovery.buttonTitle)
+            button.keyEquivalent = ""
+            button.isEnabled = canPerform
+            button.toolTip = canPerform
+                ? nil
+                : String(localized: "Wait for the current action to finish.")
             actions.append { recovery.perform(cask: cask, service: service) }
         }
         alert.addButton(withTitle: "OK")
@@ -266,11 +272,27 @@ enum CaskActionAlertFactory {
 }
 
 private extension CaskRecoveryAction {
+    func canPerform(cask: Cask, service: LocalHomebrewService) -> Bool {
+        switch self {
+        case .openAppManagementSettings:
+            true
+        case .adoptExisting, .replaceWithHomebrew:
+            service.operationStore.canBeginOperation(.adopting, for: cask.token)
+        case .repairAndReinstall:
+            service.operationStore.canBeginOperation(.repairing, for: cask.token)
+        case .updateHomebrew:
+            service.operationStore.canBeginOperation(.updatingHomebrew, for: cask.token)
+        case .forceUninstall:
+            service.operationStore.canBeginOperation(.uninstalling, for: cask.token)
+        }
+    }
+
     var buttonTitle: String {
         switch self {
         case .adoptExisting: "Adopt Existing App"
         case .replaceWithHomebrew: "Replace with Homebrew Version"
         case .repairAndReinstall: "Repair & Reinstall"
+        case .updateHomebrew: String(localized: "Update Homebrew")
         case .forceUninstall: "Force Uninstall"
         case .openAppManagementSettings: "Open System Settings"
         }
@@ -285,6 +307,8 @@ private extension CaskRecoveryAction {
             service.send(.requestReplacementAdoption(cask))
         case .repairAndReinstall:
             service.send(.repairAndReinstall(token: cask.token))
+        case .updateHomebrew:
+            service.send(.updateHomebrew(token: cask.token))
         case .forceUninstall:
             service.send(.repair(token: cask.token))
         case .openAppManagementSettings:

--- a/CaskHubTests/Catalog/Projection/CaskMetadataProjectorTests.swift
+++ b/CaskHubTests/Catalog/Projection/CaskMetadataProjectorTests.swift
@@ -155,7 +155,8 @@ final class CaskMetadataProjectorTests: XCTestCase {
                     canOpen: false
                 ),
                 homebrewInstallation: nil,
-                operationState: nil
+                operationState: nil,
+                isHomebrewMutationBlocked: false
             ),
             externalVersion: nil,
             installationDates: nil
@@ -206,7 +207,8 @@ final class CaskMetadataProjectorTests: XCTestCase {
             actionPresentation: CaskActionPresentation(
                 localState: localState,
                 homebrewInstallation: installation,
-                operationState: nil
+                operationState: nil,
+                isHomebrewMutationBlocked: false
             ),
             externalVersion: externalVersion,
             installationDates: dates

--- a/CaskHubTests/Homebrew/Coordination/MutationRecoveryTests.swift
+++ b/CaskHubTests/Homebrew/Coordination/MutationRecoveryTests.swift
@@ -6,6 +6,7 @@
 //
 
 @testable import CaskHub
+import AppKit
 import XCTest
 
 @MainActor
@@ -31,7 +32,10 @@ final class MutationRecoveryTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    private func makeService(runner: StubBrewProcessRunner) -> LocalHomebrewService {
+    private func makeService(
+        runner: StubBrewProcessRunner,
+        brewVersionProvider: @escaping () async -> String? = { "test" }
+    ) -> LocalHomebrewService {
         LocalHomebrewService(defaults: defaults) {
             $0.fileManager = fileManager
             $0.applicationDirectories = [
@@ -41,7 +45,7 @@ final class MutationRecoveryTests: XCTestCase {
             $0.brewBinaryProvider = {
                 URL(fileURLWithPath: "/test/bin/brew")
             }
-            $0.brewVersionProvider = { "test" }
+            $0.brewVersionProvider = brewVersionProvider
         }
     }
 
@@ -128,6 +132,103 @@ final class MutationRecoveryTests: XCTestCase {
         XCTAssertEqual(failure.recoveries, [.replaceWithHomebrew])
     }
 
+    func test_update_homebrew_runs_two_update_passes() async throws {
+        let runner = StubBrewProcessRunner()
+        var versionLoads = 0
+        let service = makeService(runner: runner) {
+            versionLoads += 1
+            return versionLoads == 1 ? "old" : "new"
+        }
+
+        await service.refresh()
+        XCTAssertEqual(service.brewVersion, "old")
+        runner.onRequest = { request in
+            if request.arguments == ["update"], runner.requests.count == 2 {
+                XCTAssertEqual(
+                    service.operationStore.state(for: "gimp")?.progress?.phase,
+                    .performing
+                )
+            }
+        }
+
+        try await service.updateHomebrew(for: "gimp")
+
+        XCTAssertEqual(runner.requests.map(\.arguments), [
+            ["update"],
+            ["update"]
+        ])
+        XCTAssertEqual(service.brewVersion, "new")
+        XCTAssertEqual(versionLoads, 2)
+    }
+
+    func test_stale_homebrew_recovery_runs_through_alert_action() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [
+            BrewProcessResult(
+                exitCode: 1,
+                output: "Error: Cask 'gimp' definition is invalid: invalid "
+                    + "'command_wrapper' stanza: Unknown key: :executable"
+            ),
+            BrewProcessResult(exitCode: 0, output: "updated once"),
+            BrewProcessResult(exitCode: 0, output: "updated twice")
+        ]
+        let versionReloaded = expectation(description: "Homebrew version reloaded")
+        var versionLoads = 0
+        let service = makeService(runner: runner) {
+            versionLoads += 1
+            if versionLoads == 2 { versionReloaded.fulfill() }
+            return versionLoads == 1 ? "old" : "new"
+        }
+        await service.refresh()
+        let cask = makeCask("gimp")
+
+        do {
+            try await service.install(cask)
+            XCTFail("expected the stale Homebrew install to fail")
+        } catch {}
+
+        guard case let .failure(failure) = service.actionAlert(for: cask.token) else {
+            return XCTFail("expected a recoverable command failure")
+        }
+        XCTAssertEqual(failure.recoveries, [.updateHomebrew])
+        let (alert, actions) = CaskActionAlertFactory.errorAlert(
+            for: cask,
+            failure: failure,
+            service: service
+        )
+        XCTAssertEqual(alert.buttons.map(\.title), ["Update Homebrew", "OK"])
+
+        actions[0]()
+        await fulfillment(of: [versionReloaded], timeout: 1)
+
+        XCTAssertEqual(runner.requests.map(\.arguments), [
+            ["install", "--cask", "gimp"],
+            ["update"],
+            ["update"]
+        ])
+        XCTAssertEqual(service.brewVersion, "new")
+        XCTAssertNil(service.actionAlert(for: cask.token))
+    }
+
+    func test_failed_homebrew_update_keeps_a_homebrew_specific_title() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "Error: update failed"
+        )]
+        let service = makeService(runner: runner)
+
+        do {
+            try await service.updateHomebrew(for: "gimp")
+            XCTFail("expected update failure")
+        } catch {
+            XCTAssertEqual(
+                service.operationStore.state(for: "gimp")?.failure?.title,
+                String(localized: "Homebrew Update Failed")
+            )
+        }
+    }
+
     func test_failed_upgrade_for_uninstalled_cask_refreshes_stale_local_state() async {
         let runner = StubBrewProcessRunner()
         runner.queuedResults = [BrewProcessResult(
@@ -161,9 +262,9 @@ final class MutationRecoveryTests: XCTestCase {
         do {
             try await makeService(runner: runner).install(token: "zed")
             XCTFail("expected failure")
-        } catch let LocalHomebrewError.brewCommandFailed(_, _, stderr) {
-            XCTAssertTrue(stderr.contains("Error: the meaningful failure"))
-            XCTAssertTrue(stderr.contains("formula-30"))
+        } catch let LocalHomebrewError.brewCommandFailed(failure) {
+            XCTAssertTrue(failure.diagnostic.contains("Error: the meaningful failure"))
+            XCTAssertTrue(failure.diagnostic.contains("formula-30"))
         } catch {
             XCTFail("unexpected error: \(error)")
         }

--- a/CaskHubTests/Homebrew/Domain/CaskOperationProgressTests.swift
+++ b/CaskHubTests/Homebrew/Domain/CaskOperationProgressTests.swift
@@ -184,6 +184,25 @@ final class CaskOperationProgressTests: XCTestCase {
         XCTAssertFalse(service.operationStore.state(for: "firefox")?.canCancel == true)
     }
 
+    @MainActor
+    func test_homebrew_update_begins_with_its_visible_update_label() throws {
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("homebrew-update-progress")
+        )
+
+        service.mutationCoordinator.beginOperation(
+            .updatingHomebrew,
+            token: "gimp",
+            displayName: "Homebrew"
+        )
+
+        let progress = try XCTUnwrap(
+            service.operationStore.state(for: "gimp")?.progress
+        )
+        XCTAssertEqual(progress.phase, .performing)
+        XCTAssertEqual(progress.inlineLabel, String(localized: "Updating Homebrew…"))
+    }
+
     func test_operation_status_summarizes_multiple_operations() {
         let operations = [
             CaskOperationProgress(
@@ -199,15 +218,24 @@ final class CaskOperationProgressTests: XCTestCase {
                 displayName: "Firefox",
                 action: .updating,
                 phase: .performing
+            ),
+            CaskOperationProgress(
+                token: "gimp",
+                displayName: "Homebrew",
+                action: .updatingHomebrew,
+                phase: .performing
             )
         ]
 
-        let summary = String(localized: "\(2) operations in progress")
+        let summary = String(localized: "\(3) operations in progress")
         let downloading = CaskOperationPhase.downloading.label(for: .installing).lowercased()
         let updating = CaskOperationPhase.performing.label(for: .updating).lowercased()
+        let updatingHomebrew = CaskOperationPhase.performing
+            .label(for: .updatingHomebrew)
+            .lowercased()
         XCTAssertEqual(
             CaskOperationStatus.make(operations: operations, updateAll: nil)?.message,
-            "\(summary) · 1 \(downloading) · 1 \(updating)"
+            "\(summary) · 1 \(downloading) · 1 \(updating) · 1 \(updatingHomebrew)"
         )
     }
 

--- a/CaskHubTests/Homebrew/Domain/HomebrewCommandFailureTests.swift
+++ b/CaskHubTests/Homebrew/Domain/HomebrewCommandFailureTests.swift
@@ -1,0 +1,282 @@
+//
+//  HomebrewCommandFailureTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 12/08/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+final class HomebrewCommandFailureTests: XCTestCase {
+    private struct Fixture {
+        let name: String
+        let arguments: [String]
+        let diagnostic: String
+        let expectedKind: HomebrewFailureKind
+    }
+
+    func test_field_samples_map_to_typed_failure_kinds() {
+        XCTAssertEqual(fieldSamples.count, 14)
+
+        for fixture in fieldSamples {
+            let diagnostic = HomebrewOutputDiagnostics.make(from: fixture.diagnostic)
+            let failure = HomebrewCommandFailure(
+                arguments: fixture.arguments,
+                exitCode: 1,
+                diagnostic: diagnostic
+            )
+
+            XCTAssertEqual(failure.kind, fixture.expectedKind, fixture.name)
+        }
+    }
+
+    func test_terminal_privilege_failure_wins_over_incidental_signals() {
+        let diagnostic = """
+        Error: Failed to download ruby from https://ghcr.io/example
+        hdiutil: attach canceled
+        Sorry, user demo is not allowed to execute '/bin/cp' as root on this Mac.
+        """
+
+        XCTAssertEqual(
+            HomebrewCommandFailure.classify(
+                arguments: ["install", "--cask", "example"],
+                exitCode: 1,
+                diagnostic: diagnostic
+            ),
+            .sudoPolicyDenied
+        )
+    }
+
+    func test_unknown_fingerprint_is_bounded_without_private_context() throws {
+        let first = unknownFailure(
+            token: "cask-alpha",
+            diagnostic: """
+            Error: cask-alpha failed for /Users/alice at /private/tmp/homebrew-one/payload.dmg
+            Source https://one.example/cask-alpha/1.2.3/payload.dmg version 1.2.3 build 42
+            Hash aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            UUID 123e4567-e89b-12d3-a456-426614174000
+            """
+        )
+        let second = unknownFailure(
+            token: "cask-beta",
+            diagnostic: """
+            Error: cask-beta failed for /Users/bob at /private/tmp/homebrew-two/payload.dmg
+            Source https://two.example/cask-beta/9.8.7/payload.dmg version 9.8.7 build 99
+            Hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+            UUID 987e6543-e21b-43d3-b654-426614179999
+            """
+        )
+
+        XCTAssertEqual(first.kind, .unknown)
+        XCTAssertEqual(second.kind, .unknown)
+        let firstFingerprint = try XCTUnwrap(first.stableFingerprint)
+        let secondFingerprint = try XCTUnwrap(second.stableFingerprint)
+        XCTAssertEqual(firstFingerprint, secondFingerprint)
+        XCTAssertEqual(
+            firstFingerprint,
+            ["brewCommandFailed", "install", "unknown"]
+        )
+        XCTAssertFalse(first.rateLimitSignature.contains("alice"))
+        XCTAssertFalse(first.rateLimitSignature.contains("cask-alpha"))
+
+        let different = unknownFailure(
+            token: "cask-gamma",
+            diagnostic: "Error: renderer crashed before launch"
+        )
+        XCTAssertEqual(firstFingerprint, different.stableFingerprint)
+    }
+
+    func test_unknown_disk_image_output_keeps_a_reportable_mount_class() {
+        let failure = HomebrewCommandFailure(
+            arguments: ["install", "--cask", "example"],
+            exitCode: 1,
+            diagnostic: "Error: `/usr/bin/hdiutil attach example.dmg` exited with 1: erreur inconnue"
+        )
+
+        XCTAssertEqual(failure.kind, .dmgMountFailed)
+        XCTAssertTrue(failure.kind.shouldReport)
+    }
+
+    func test_runtime_incompatible_failure_offers_update_homebrew() {
+        let error = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "gimp"],
+            exitCode: 1,
+            stderr: """
+            Error: Cask 'gimp' definition is invalid: invalid 'command_wrapper' stanza: \
+            Unknown key: :executable. Valid keys are: :target, :content
+            """
+        )
+
+        XCTAssertEqual(error.commandFailure?.kind, .homebrewRuntimeIncompatible)
+        XCTAssertFalse(error.shouldReport)
+        XCTAssertEqual(
+            CaskOperationFailureFactory.make(
+                from: error,
+                strandedCopyExists: false
+            ).recoveries,
+            [.updateHomebrew]
+        )
+    }
+
+    func test_terminal_environment_failure_wins_over_download_wrapper() {
+        let failure = HomebrewCommandFailure(
+            arguments: ["install", "--cask", "example"],
+            exitCode: 1,
+            diagnostic: "Error: example: Download failed on Cask 'example' with message: "
+                + "No space left on device"
+        )
+
+        XCTAssertEqual(failure.kind, .storageFull)
+        XCTAssertFalse(failure.kind.shouldReport)
+    }
+
+    private func unknownFailure(
+        token: String,
+        diagnostic: String
+    ) -> HomebrewCommandFailure {
+        HomebrewCommandFailure(
+            arguments: ["install", "--cask", token],
+            exitCode: 1,
+            diagnostic: diagnostic
+        )
+    }
+
+    private var fieldSamples: [Fixture] {
+        [
+            Fixture(
+                name: "affinity lock cleanup race",
+                arguments: ["install", "--cask", "affinity"],
+                diagnostic: "✘ Cask affinity (3.2.3,4646)\n"
+                    + "Error: No such file or directory @ dir_s_rmdir - "
+                    + "/opt/homebrew/var/homebrew/locks/"
+                    + "5fec6af861f84cb794dbe427cd42eeb35b42018950e42a5e84ae4d9e1ec0edfe--"
+                    + "Affinity Affinity Store 4646.zip.incomplete.download.lock",
+                expectedKind: .brewLockCleanupRace
+            ),
+            Fixture(
+                name: "skim canceled disk image mount",
+                arguments: ["install", "--cask", "skim"],
+                diagnostic: "Error: Failure while executing; `/usr/bin/env hdiutil attach "
+                    + "-plist -nobrowse -readonly -mountrandom "
+                    + "/private/tmp/homebrew-dmg20260811-1901-g5sxas "
+                    + "/Users/justin/Library/Caches/Homebrew/downloads/skim.dmg` exited with 1.\n"
+                    + "There may be a problem with this disk image. "
+                    + "Are you sure you want to open it?\n"
+                    + "hdiutil: attach canceled",
+                expectedKind: .dmgMountCancelled
+            ),
+            Fixture(
+                name: "alt-tab portable ruby download",
+                arguments: ["install", "--cask", "alt-tab"],
+                diagnostic: "Warning: Failed to set filetime 1784072529 on\n"
+                    + "Warning: '/Users/aj/Library/Caches/Homebrew/portable-ruby-4.0.6."
+                    + "arm64_big_sur.bottle.tar.gz.incomplete': No such file or directory\n"
+                    + "Error: Failed to download ruby from the following locations:\n"
+                    + "- https://ghcr.io/v2/homebrew/core/portable-ruby/blobs/sha256:83a3ff85\n"
+                    + "Error: Failed to upgrade Homebrew Portable Ruby!",
+                expectedKind: .portableRubyUnavailable
+            ),
+            Fixture(
+                name: "daisydisk require-sha policy",
+                arguments: ["install", "--cask", "daisydisk", "--adopt"],
+                diagnostic: "✔︎ Cask daisydisk (4.34.2) Downloaded 5.4MB/5.4MB\n"
+                    + "Error: Cask 'daisydisk' does not have a sha256 checksum defined.\n"
+                    + "This means you have the --require-sha option set, perhaps in your "
+                    + "`$HOMEBREW_CASK_OPTS`.",
+                expectedKind: .requireSHAPolicy
+            ),
+            Fixture(
+                name: "libreoffice download lock",
+                arguments: ["install", "--cask", "libreoffice-language-pack"],
+                diagnostic: "Warning: Waiting for another Homebrew process to finish downloading "
+                    + "/Users/em/Library/Caches/Homebrew/downloads/libreoffice.dmg.incomplete...\n"
+                    + "Error: A `brew install --cask libreoffice-language-pack` process has "
+                    + "already locked /Users/em/Library/Caches/Homebrew/downloads/"
+                    + "libreoffice.dmg.incomplete.\n"
+                    + "Gave up after waiting 180 seconds. Terminate it to continue.",
+                expectedKind: .brewBusy
+            ),
+            Fixture(
+                name: "amazon music unsupported macOS",
+                arguments: ["install", "--cask", "amazon-music"],
+                diagnostic: "✔︎ Cask amazon-music (9.5.2) Downloaded 141.2MB/141.2MB\n"
+                    + "==> Running installer script\n"
+                    + "The current OS X version is not supported\n"
+                    + "Error: installer script exited with 1: "
+                    + "The current OS X version is not supported",
+                expectedKind: .platformUnsupported
+            ),
+            Fixture(
+                name: "google chrome sudo policy",
+                arguments: ["install", "--cask", "google-chrome"],
+                diagnostic: "Sorry, user u116558 is not allowed to execute "
+                    + "'/bin/cp -pR /opt/homebrew/Caskroom/google-chrome/151.0.7922.109/"
+                    + "Google Chrome.app /Applications/Google Chrome.app' as root on IX01877468.\n"
+                    + "Error: `/usr/bin/sudo -A -E -- /bin/cp -pR` exited with 1.",
+                expectedKind: .sudoPolicyDenied
+            ),
+            Fixture(
+                name: "anythingllm completed download only",
+                arguments: ["install", "--cask", "anythingllm", "--adopt"],
+                diagnostic: "✔︎ Cask anythingllm (1.15.0) Downloaded 504.5MB/504.5MB",
+                expectedKind: .noDiagnosticOutput
+            ),
+            Fixture(
+                name: "deepl Intel Homebrew on Apple silicon",
+                arguments: ["install", "--cask", "deepl", "--adopt"],
+                diagnostic: "/usr/local/Homebrew/Library/Homebrew/brew.sh: line 688: "
+                    + "/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/current/bin/ruby: "
+                    + "Bad CPU type in executable\n"
+                    + "/usr/local/Homebrew/Library/Homebrew/brew.sh: line 688: "
+                    + "Undefined error: 0",
+                expectedKind: .brewArchitectureMismatch
+            ),
+            Fixture(
+                name: "backdrop read-only disk image",
+                arguments: ["install", "--cask", "backdrop"],
+                diagnostic: "Error: Read-only file system @ apply2files - "
+                    + "/private/tmp/homebrew-dmg20260812-23432-84kktm/"
+                    + "dmg.S5Is7D/.DropDMGBackground/background.tiff",
+                expectedKind: .dmgReadOnly
+            ),
+            Fixture(
+                name: "docker sudo environment policy",
+                arguments: ["install", "--cask", "docker-desktop", "--adopt"],
+                diagnostic: "✔︎ Cask docker-desktop (4.86.0,236216) Downloaded 574.0MB/574.0MB\n"
+                    + "==> Using sudo to gain ownership of path "
+                    + "'/usr/local/bin/docker-credential-osxkeychain'\n"
+                    + "Error: `/usr/bin/sudo -A -E -- /bin/rm -f` exited with 1.\n"
+                    + "sudo: sorry, you are not allowed to preserve the environment",
+                expectedKind: .sudoPolicyDenied
+            ),
+            Fixture(
+                name: "musaicfm screen saver conflict",
+                arguments: ["install", "--cask", "musaicfm"],
+                diagnostic: "Error: It seems there is already a Screen Saver at "
+                    + "'/Users/beluga/Library/Screen Savers/MusaicFM.saver'.",
+                expectedKind: .artifactConflict
+            ),
+            Fixture(
+                name: "macfuse sudo environment policy",
+                arguments: ["install", "--cask", "macfuse"],
+                diagnostic: "Sorry, try again.\n"
+                    + "installer: Package name is macFUSE\n"
+                    + "installer: The install was successful.\n"
+                    + "Error: `/usr/bin/sudo -A -E -- rm "
+                    + "/usr/local/include/.homebrew-write-test` exited with 1.\n"
+                    + "sudo: sorry, you are not allowed to preserve the environment",
+                expectedKind: .sudoPolicyDenied
+            ),
+            Fixture(
+                name: "gimp incompatible cask definition",
+                arguments: ["install", "--cask", "gimp"],
+                diagnostic: "✔︎ JSON API packages.arm64_golden_gate.jws.json "
+                    + "Downloaded 15.8MB/15.8MB\n"
+                    + "Error: Cask 'gimp' definition is invalid: invalid 'command_wrapper' "
+                    + "stanza: Unknown key: :executable. Valid keys are: :target, :content",
+                expectedKind: .homebrewRuntimeIncompatible
+            )
+        ]
+    }
+}

--- a/CaskHubTests/Homebrew/Infrastructure/HomebrewCommandExecutorTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/HomebrewCommandExecutorTests.swift
@@ -72,6 +72,49 @@ final class HomebrewCommandExecutorTests: XCTestCase {
 
         XCTAssertNil(service.operationStore.state(for: "firefox"))
     }
+
+    func test_homebrew_update_blocks_other_tokens_until_both_passes_finish() async {
+        let executor = SuspendingHomebrewCommandExecutor()
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("global-homebrew-update")
+        ) {
+            $0.commandExecutor = executor
+            $0.softwareScanner = EmptyInstalledSoftwareScanner()
+            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
+            $0.brewVersionProvider = { "test" }
+        }
+
+        let update = Task { try? await service.updateHomebrew(for: "gimp") }
+        while executor.requests.count < 1 { await Task.yield() }
+
+        try? await service.install(token: "firefox")
+        await service.updateAll(tokens: ["zed", "zoom"])
+        XCTAssertEqual(executor.requests.map(\.arguments), [["update"]])
+        XCTAssertNil(service.operationStore.state(for: "zed"))
+        XCTAssertNil(service.operationStore.state(for: "zoom"))
+        XCTAssertFalse(service.isUpdatingAll)
+
+        executor.finish(BrewProcessResult(exitCode: 0, output: "first pass"))
+        while executor.requests.count < 2 { await Task.yield() }
+
+        try? await service.install(token: "firefox")
+        XCTAssertEqual(executor.requests.map(\.arguments), [["update"], ["update"]])
+
+        executor.finish(BrewProcessResult(exitCode: 0, output: "second pass"))
+        await update.value
+
+        let install = Task { try? await service.install(token: "firefox") }
+        while executor.requests.count < 3 { await Task.yield() }
+        XCTAssertEqual(executor.requests.last?.arguments, ["install", "--cask", "firefox"])
+        XCTAssertEqual(service.brewVersion, "test")
+
+        try? await service.updateHomebrew(for: "gimp")
+        XCTAssertEqual(service.brewVersion, "test")
+        XCTAssertEqual(executor.requests.count, 3)
+
+        executor.finish(BrewProcessResult(exitCode: 0, output: "installed"))
+        await install.value
+    }
 }
 
 @MainActor

--- a/CaskHubTests/Homebrew/Infrastructure/HomebrewOutputDiagnosticsTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/HomebrewOutputDiagnosticsTests.swift
@@ -32,6 +32,14 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
         XCTAssertEqual(result, "Error: Download failed")
     }
 
+    func test_completed_download_without_a_diagnostic_becomes_blank() {
+        let output = "✔︎ Cask anythingllm (1.15.0) Downloaded 504.5MB/504.5MB"
+        let result = HomebrewOutputDiagnostics.make(from: output)
+
+        XCTAssertTrue(result.isEmpty)
+        XCTAssertEqual(failureKind(result), .noDiagnosticOutput)
+    }
+
     func test_download_url_lines_are_kept() {
         let output = """
         ==> Downloading https://formulae.brew.sh/api/cask.jws.json
@@ -49,7 +57,7 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
         let output = (frames + ["curl: (28) Operation timed out after 30000 milliseconds"])
             .joined(separator: "\n")
         let cleaned = HomebrewOutputDiagnostics.make(from: output)
-        XCTAssertEqual(LocalHomebrewError.failureClass(stderr: cleaned), "network-failure")
+        XCTAssertEqual(failureKind(cleaned), .networkFailure)
     }
 
     func test_short_output_passes_through_unchanged() {
@@ -95,7 +103,7 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
         """
         let result = HomebrewOutputDiagnostics.make(from: output)
         XCTAssertFalse(result.contains("already an App at"))
-        XCTAssertNotEqual(LocalHomebrewError.failureClass(stderr: result), "app-conflict")
+        XCTAssertNotEqual(failureKind(result), .appConflict)
     }
 
     func test_long_payload_slices_near_the_last_error_line_keeping_context() {
@@ -119,8 +127,8 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
         let result = HomebrewOutputDiagnostics.make(from: output)
         XCTAssertTrue(result.contains("sudo: 3 incorrect password attempts"))
         XCTAssertEqual(
-            LocalHomebrewError.failureClass(stderr: result),
-            "sudo-wrong-password",
+            failureKind(result),
+            .sudoWrongPassword,
             "slicing must not strip the lines classification depends on"
         )
     }
@@ -151,5 +159,13 @@ final class HomebrewOutputDiagnosticsTests: XCTestCase {
             .joined(separator: "\n")
         let result = HomebrewOutputDiagnostics.make(from: output)
         XCTAssertEqual(result, "Error: installation failed for parallels")
+    }
+
+    private func failureKind(_ diagnostic: String) -> HomebrewFailureKind {
+        HomebrewCommandFailure.classify(
+            arguments: [],
+            exitCode: nil,
+            diagnostic: diagnostic
+        )
     }
 }

--- a/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
+++ b/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
@@ -261,18 +261,27 @@ final class CaskHubTests: XCTestCase {
     }
 
     func test_adopt_mismatch_detection() {
-        XCTAssertTrue(LocalHomebrewError.isAdoptMismatch(
-            args: ["install", "--cask", "x", "--adopt"],
-            stderr: "Error: It seems the existing App is different from the one being installed."
-        ))
-        XCTAssertFalse(LocalHomebrewError.isAdoptMismatch(
-            args: ["install", "--cask", "x"],
-            stderr: "It seems there is already an App at '/Applications/X.app'."
-        ))
-        XCTAssertFalse(LocalHomebrewError.isAdoptMismatch(
-            args: ["install", "--cask", "x", "--adopt"],
-            stderr: "curl: (6) Could not resolve host"
-        ))
+        XCTAssertEqual(
+            classify(
+                ["install", "--cask", "x", "--adopt"],
+                "Error: It seems the existing App is different from the one being installed."
+            ),
+            .adoptVersionMismatch
+        )
+        XCTAssertEqual(
+            classify(
+                ["install", "--cask", "x"],
+                "It seems there is already an App at '/Applications/X.app'."
+            ),
+            .appConflict
+        )
+        XCTAssertEqual(
+            classify(
+                ["install", "--cask", "x", "--adopt"],
+                "curl: (6) Could not resolve host"
+            ),
+            .networkFailure
+        )
     }
 
     @MainActor
@@ -329,7 +338,7 @@ final class CaskHubTests: XCTestCase {
 
     func test_app_management_denial_maps_to_permission_guidance() {
         let stderr = "xattr: [Errno 1] Operation not permitted: '/Applications/ChatGPT Classic.app'"
-        XCTAssertTrue(LocalHomebrewError.isAppManagementDenial(stderr: stderr))
+        XCTAssertEqual(classify(["install", "--cask", "chatgpt-classic"], stderr), .permissionDenied)
 
         let error = LocalHomebrewError.brewCommandFailed(
             args: ["install", "--cask", "chatgpt-classic", "--adopt"], exitCode: 1, stderr: stderr
@@ -339,19 +348,28 @@ final class CaskHubTests: XCTestCase {
         )
 
         let unrelated = "chmod: /opt/homebrew/bin/tool: Operation not permitted"
-        XCTAssertFalse(LocalHomebrewError.isAppManagementDenial(stderr: unrelated))
-        XCTAssertFalse(
-            LocalHomebrewError.isAppManagementDenial(
-                stderr: "Inspecting /Applications/Example.app\n\(unrelated)"
-            )
+        XCTAssertEqual(classify([], unrelated), .unknown)
+        XCTAssertEqual(
+            classify([], "Inspecting /Applications/Example.app\n\(unrelated)"),
+            .unknown
         )
-        XCTAssertEqual(LocalHomebrewError.failureClass(stderr: unrelated), "uncategorized")
         XCTAssertTrue(
             LocalHomebrewError.brewCommandFailed(
                 args: ["install", "--cask", "tool"], exitCode: 1, stderr: unrelated
             ).shouldReport
         )
-        XCTAssertFalse(LocalHomebrewError.isAppManagementDenial(stderr: "curl: (6) Could not resolve host"))
+        XCTAssertEqual(classify([], "curl: (6) Could not resolve host"), .networkFailure)
+    }
+
+    private func classify(
+        _ arguments: [String],
+        _ diagnostic: String
+    ) -> HomebrewFailureKind {
+        HomebrewCommandFailure.classify(
+            arguments: arguments,
+            exitCode: 1,
+            diagnostic: diagnostic
+        )
     }
 
     func test_output_collector_folds_pty_crlf_instead_of_doubling() {

--- a/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
@@ -30,6 +30,23 @@ final class CaskActionPresentationTests: XCTestCase {
         XCTAssertNil(service.actionAlert(for: cask.token))
     }
 
+    func test_homebrew_update_blocks_other_cask_mutations() {
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("presentation-global-update")
+        )
+        service.mutationCoordinator.beginOperation(
+            .updatingHomebrew,
+            token: "gimp",
+            displayName: "Homebrew"
+        )
+
+        let presentation = service.actionPresentation(for: makeCask("firefox"))
+
+        XCTAssertTrue(presentation.isHomebrewMutationBlocked)
+        XCTAssertTrue(presentation.isBusy)
+        XCTAssertNil(presentation.activeAction)
+    }
+
     func test_failure_presentation_carries_message_and_recovery_together() {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("presentation-failure"))
         let cask = makeCask("tabby")
@@ -230,6 +247,36 @@ final class AdoptionViewRenderTests: XCTestCase {
     }
 
     @MainActor
+    func test_update_homebrew_recovery_is_disabled_while_an_operation_runs() {
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("blocked-homebrew-recovery")
+        )
+        service.mutationCoordinator.beginOperation(
+            .installing,
+            token: "firefox",
+            displayName: "Firefox"
+        )
+        let failure = CaskOperationFailure(
+            kind: .brewCommand,
+            message: "Update Homebrew first",
+            recoveries: [.updateHomebrew]
+        )
+
+        let (alert, _) = CaskActionAlertFactory.errorAlert(
+            for: makeCask("gimp"),
+            failure: failure,
+            service: service
+        )
+
+        XCTAssertFalse(alert.buttons[0].isEnabled)
+        XCTAssertEqual(
+            alert.buttons[0].toolTip,
+            String(localized: "Wait for the current action to finish.")
+        )
+        XCTAssertTrue(alert.buttons[1].isEnabled)
+    }
+
+    @MainActor
     func test_installation_preflight_alert_does_not_call_the_conflict_a_failure() {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("install-conflict-alert"))
         let failure = CaskOperationFailure(
@@ -286,14 +333,15 @@ final class AdoptionViewRenderTests: XCTestCase {
             "Adopt Existing App",
             "Replace with Homebrew Version",
             "Repair & Reinstall",
+            "Update Homebrew",
             "Force Uninstall",
             "Open System Settings",
             "OK"
         ])
-        XCTAssertEqual(actions.count, 6)
+        XCTAssertEqual(actions.count, 7)
 
         // Every action except Open System Settings (launches the real app) and OK.
-        for action in actions[0...3] {
+        for action in actions[0...4] {
             action()
             try? await Task.sleep(for: .milliseconds(150))
         }

--- a/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
@@ -224,12 +224,12 @@ final class AdoptionSurfaceTests: XCTestCase {
             try await service.install(token: "firefox")
             XCTFail("expected the simulated brew failure")
         } catch let error as LocalHomebrewError {
-            guard case let .brewCommandFailed(args, exitCode, stderr) = error else {
+            guard case let .brewCommandFailed(failure) = error else {
                 return XCTFail("unexpected LocalHomebrewError: \(error)")
             }
-            XCTAssertEqual(args, ["install", "--cask", "firefox"])
-            XCTAssertEqual(exitCode, 7)
-            XCTAssertEqual(stderr, "simulated failure")
+            XCTAssertEqual(failure.arguments, ["install", "--cask", "firefox"])
+            XCTAssertEqual(failure.exitCode, 7)
+            XCTAssertEqual(failure.diagnostic, "simulated failure")
         } catch {
             XCTFail("unexpected error: \(error)")
         }

--- a/CaskHubTests/Telemetry/AnalyticsTests.swift
+++ b/CaskHubTests/Telemetry/AnalyticsTests.swift
@@ -114,7 +114,7 @@ final class AnalyticsTests: XCTestCase {
         XCTAssertTrue(spy.signals.isEmpty)
     }
 
-    func test_cask_action_failed_sends_base_verb_and_token() {
+    func test_cask_action_failed_omits_failure_class_when_unavailable() {
         Analytics.caskActionFailed(.updating, token: "iterm2")
         XCTAssertEqual(lastSignal?.name, "Cask.actionFailed")
         XCTAssertEqual(lastSignal?.parameters, [
@@ -122,6 +122,44 @@ final class AnalyticsTests: XCTestCase {
             "cask": "iterm2",
             "origin": "individual"
         ])
+    }
+
+    func test_cask_action_failed_includes_failure_class_when_provided() {
+        Analytics.caskActionFailed(
+            .installing,
+            token: "gimp",
+            failureKind: .homebrewRuntimeIncompatible
+        )
+
+        XCTAssertEqual(lastSignal?.parameters, [
+            "action": "install",
+            "cask": "gimp",
+            "failureClass": "homebrew-runtime-incompatible",
+            "origin": "individual"
+        ])
+    }
+
+    @MainActor
+    func test_failed_service_mutation_forwards_its_classification() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "Error: Cask 'gimp' definition is invalid: invalid "
+                + "'command_wrapper' stanza: Unknown key: :executable"
+        )]
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("classified-analytics")
+        ) {
+            $0.fileManager = NoFilesFileManager()
+            $0.processRunner = runner
+            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
+            $0.brewVersionProvider = { "test" }
+        }
+
+        try? await service.install(token: "gimp")
+
+        XCTAssertEqual(lastSignal?.name, "Cask.actionFailed")
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "homebrew-runtime-incompatible")
     }
 
     func test_cask_action_recovered_records_repair_postcondition() {

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -85,6 +85,23 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertEqual(spy.capturedErrors.count, 10)
     }
 
+    func test_brew_failure_classes_are_limited_independently() {
+        for _ in 1...6 {
+            CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
+                args: ["install", "--cask", "one"],
+                exitCode: 1,
+                stderr: "curl: (22) The requested URL returned error: 404"
+            ))
+            CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
+                args: ["install", "--cask", "two"],
+                exitCode: 1,
+                stderr: "Error: two: Download failed on Cask 'two' with message: mystery"
+            ))
+        }
+
+        XCTAssertEqual(spy.capturedErrors.count, 10)
+    }
+
     func test_task_cancellation_is_never_captured() {
         CrashReporter.capture(CancellationError())
         XCTAssertTrue(spy.capturedErrors.isEmpty)
@@ -236,7 +253,11 @@ final class CrashReporterTests: XCTestCase {
     }
 
     private func cls(_ stderr: String) -> String {
-        LocalHomebrewError.failureClass(stderr: stderr)
+        HomebrewCommandFailure.classify(
+            arguments: [],
+            exitCode: nil,
+            diagnostic: stderr
+        ).rawValue
     }
 
     func test_failure_classes_cover_observed_brew_errors() {
@@ -259,7 +280,7 @@ final class CrashReporterTests: XCTestCase {
             "sudo-declined",
             "a declined prompt is the terminal cause even with incidental conflict warnings"
         )
-        XCTAssertEqual(cls("something novel"), "uncategorized")
+        XCTAssertEqual(cls("something novel"), "unknown")
     }
 
     func test_failure_classes_cover_field_mined_brew_errors() {
@@ -365,11 +386,14 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_killed_process_with_silent_stderr_gets_its_own_class() {
-        XCTAssertEqual(LocalHomebrewError.failureClass(stderr: "", exitCode: 9), "process-killed")
-        XCTAssertEqual(LocalHomebrewError.failureClass(stderr: "", exitCode: 1), "uncategorized")
+        XCTAssertEqual(classify("", exitCode: 9), "process-killed")
         XCTAssertEqual(
-            LocalHomebrewError.failureClass(stderr: "Error: real failure", exitCode: 9),
-            "uncategorized",
+            classify("", exitCode: 1),
+            "no-diagnostic-output"
+        )
+        XCTAssertEqual(
+            classify("Error: real failure", exitCode: 9),
+            "unknown",
             "a kill with actual output classifies on the output"
         )
         let killed = LocalHomebrewError.brewCommandFailed(
@@ -380,6 +404,14 @@ final class CrashReporterTests: XCTestCase {
             ["brewCommandFailed", "install", "process-killed"]
         )
         XCTAssertTrue(killed.shouldReport, "watch volume before deciding to suppress")
+    }
+
+    private func classify(_ diagnostic: String, exitCode: Int32) -> String {
+        HomebrewCommandFailure.classify(
+            arguments: [],
+            exitCode: exitCode,
+            diagnostic: diagnostic
+        ).rawValue
     }
 
     func test_wrong_sudo_password_is_not_reported() {
@@ -416,6 +448,20 @@ final class CrashReporterTests: XCTestCase {
         UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
         CrashReporter.tag("brew.path", value: "/opt/homebrew/bin/brew")
         XCTAssertTrue(spy.tags.isEmpty)
+    }
+
+    @MainActor
+    func test_homebrew_refresh_tags_the_selected_path_and_version() async {
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("brew-tags")) {
+            $0.softwareScanner = EmptyInstalledSoftwareScanner()
+            $0.brewBinaryProvider = { URL(fileURLWithPath: "/opt/homebrew/bin/brew") }
+            $0.brewVersionProvider = { "6.0.0" }
+        }
+
+        await service.refresh()
+
+        XCTAssertEqual(spy.tags["brew.path"], "/opt/homebrew/bin/brew")
+        XCTAssertEqual(spy.tags["brew.version"], "6.0.0")
     }
 
     // MARK: - Breadcrumbs
@@ -474,5 +520,32 @@ final class CrashReporterTests: XCTestCase {
         let provider = SentryProvider()
         provider.pauseHangTracking()
         provider.resumeHangTracking()
+    }
+}
+
+extension CrashReporterTests {
+    func test_unknown_brew_diagnostics_share_one_bounded_fingerprint_and_rate_limit() {
+        let first = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "one"],
+            exitCode: 1,
+            stderr: "Error: renderer crashed before launch"
+        )
+        let second = LocalHomebrewError.brewCommandFailed(
+            args: ["install", "--cask", "two"],
+            exitCode: 1,
+            stderr: "Error: helper returned an impossible state"
+        )
+        XCTAssertEqual(
+            SentryProvider.fingerprint(for: first),
+            SentryProvider.fingerprint(for: second)
+        )
+
+        for _ in 1...6 {
+            CrashReporter.capture(first)
+            CrashReporter.capture(second)
+        }
+
+        XCTAssertEqual(spy.capturedErrors.count, 5)
+        XCTAssertEqual(CrashReporter.captureCounts.count, 1)
     }
 }

--- a/CaskHubTests/Views/ContentViewTests.swift
+++ b/CaskHubTests/Views/ContentViewTests.swift
@@ -234,6 +234,7 @@ final class SidebarViewTests: XCTestCase {
 final class TopBarViewTests: XCTestCase {
     private struct TopBarHarness: View {
         let isUpdatingAll: Bool
+        let isUpdatingHomebrew: Bool
         var greedyUpdates: Bool?
         let onAppear: () -> Void
         @FocusState private var searchFocused: Bool
@@ -248,6 +249,7 @@ final class TopBarViewTests: XCTestCase {
                 searchFocus: $searchFocused,
                 onUpdateAll: {},
                 isUpdatingAll: isUpdatingAll,
+                isUpdatingHomebrew: isUpdatingHomebrew,
                 greedyUpdates: greedyUpdates,
                 onToggleGreedy: { _ in }
             )
@@ -261,7 +263,11 @@ final class TopBarViewTests: XCTestCase {
     }
 
     @MainActor
-    private func renderTopBar(isUpdatingAll: Bool, greedyUpdates: Bool? = nil) {
+    private func renderTopBar(
+        isUpdatingAll: Bool,
+        isUpdatingHomebrew: Bool,
+        greedyUpdates: Bool? = nil
+    ) {
         let probe = RenderProbe()
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 900, height: 80),
@@ -271,7 +277,11 @@ final class TopBarViewTests: XCTestCase {
         )
         window.isReleasedWhenClosed = false
         window.contentView = NSHostingView(
-            rootView: TopBarHarness(isUpdatingAll: isUpdatingAll, greedyUpdates: greedyUpdates) { probe.appeared = true }
+            rootView: TopBarHarness(
+                isUpdatingAll: isUpdatingAll,
+                isUpdatingHomebrew: isUpdatingHomebrew,
+                greedyUpdates: greedyUpdates
+            ) { probe.appeared = true }
         )
         window.orderFrontRegardless()
 
@@ -287,18 +297,19 @@ final class TopBarViewTests: XCTestCase {
 
     @MainActor
     func test_update_all_chip_renders_idle_state() {
-        renderTopBar(isUpdatingAll: false)
+        renderTopBar(isUpdatingAll: false, isUpdatingHomebrew: false)
     }
 
     @MainActor
     func test_update_all_chip_renders_updating_state() {
-        renderTopBar(isUpdatingAll: true)
+        renderTopBar(isUpdatingAll: true, isUpdatingHomebrew: false)
+        renderTopBar(isUpdatingAll: false, isUpdatingHomebrew: true)
     }
 
     @MainActor
     func test_greedy_chip_renders_on_and_off_states() {
-        renderTopBar(isUpdatingAll: false, greedyUpdates: true)
-        renderTopBar(isUpdatingAll: false, greedyUpdates: false)
+        renderTopBar(isUpdatingAll: false, isUpdatingHomebrew: false, greedyUpdates: true)
+        renderTopBar(isUpdatingAll: false, isUpdatingHomebrew: false, greedyUpdates: false)
     }
 
     /// Production-boundary check for the reveal sentinel: the browse landing


### PR DESCRIPTION
## Summary

CASKHUB-C grouped many unrelated Homebrew command failures because failure
classification was duplicated across reporting, recovery, presentation, and
telemetry. Unmatched diagnostics also collapsed into the same uncategorized
fingerprint.

- Introduce one typed Homebrew failure classifier and reuse it for user-facing
  guidance, recovery actions, reportability, analytics, state reconciliation,
  and Sentry tags/fingerprints.
- Keep Sentry grouping bounded by command and failure kind. Expected user and
  environment failures remain measurable through analytics without being sent
  as app defects.
- Offer an explicit two-pass Update Homebrew recovery when the installed
  runtime cannot read a current cask definition, then reload the detected
  Homebrew version.
- Serialize that global repair against cask mutations and disable conflicting
  row and Update All controls while it runs.
- Add English and Simplified Chinese recovery strings plus production-boundary
  coverage for classification, telemetry, two-pass recovery, and concurrency.

Related Sentry issue: `CASKHUB-C`

## Verification

- `swiftlint lint --strict`
- Full macOS arm64 test suite
- Signed Debug build
- App-launch smoke check
- `git diff --check develop...HEAD`

## Checklist

- [x] Base branch is `develop` (not `master`)
- [x] Title uses a conventional prefix + Sentence-case subject
- [x] Tests added or updated (Codecov patch target: 80%)
- [x] SwiftLint build phase passes locally
- [x] No changes to `CaskHub/Resources/*.json` or `CHANGELOG.md`
- [x] Sentry issue identified for this non-trivial change (`CASKHUB-C`)
