### PR TITLE
fix: Improve AppHang reporting

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		41AD10122F68B00300BEABB8 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 41AD10112F68B00200BEABB8 /* Sentry */; };
 		41AD10142F68B00500BEABB8 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AD10132F68B00400BEABB8 /* CrashReporter.swift */; };
 		41AD10162F68B00700BEABB8 /* CrashReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */; };
+		41EA00023005200100C45A51 /* AppHangReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EA00013005200100C45A51 /* AppHangReportingTests.swift */; };
 		41AD10222F68C00300BEABB8 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 41AD10212F68C00200BEABB8 /* Sparkle */; };
 		41AD10312F68D00200BEABB8 /* UpdaterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AD10302F68D00100BEABB8 /* UpdaterService.swift */; };
 		41DF1BB73027E71B004C0E14 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 41DF1BB63027E71B004C0E14 /* AppIcon.icon */; };
@@ -158,6 +159,7 @@
 		41AD10042F68A00400BEABB8 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = Configs/Shared.xcconfig; sourceTree = "<group>"; };
 		41AD10132F68B00400BEABB8 /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporterTests.swift; sourceTree = "<group>"; };
+		41EA00013005200100C45A51 /* AppHangReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangReportingTests.swift; sourceTree = "<group>"; };
 		41AD10302F68D00100BEABB8 /* UpdaterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterService.swift; sourceTree = "<group>"; };
 		41DF1BB63027E71B004C0E14 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		41DFD44E30028F7D00608C7A /* Askpass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Askpass.swift; sourceTree = "<group>"; };
@@ -711,6 +713,7 @@
 			isa = PBXGroup;
 			children = (
 				41DFD4B030028F9F00608C7A /* AnalyticsTests.swift */,
+				41EA00013005200100C45A51 /* AppHangReportingTests.swift */,
 				41AD10152F68B00600BEABB8 /* CrashReporterTests.swift */,
 			);
 			path = Telemetry;
@@ -1071,6 +1074,7 @@
 				B09000000000000000000002 /* ApplicationMenuTests.swift in Sources */,
 				A29000000000000000000004 /* ApplicationTerminationCoordinatorTests.swift in Sources */,
 				41DFD4B330028F9F00608C7A /* AnalyticsTests.swift in Sources */,
+				41EA00023005200100C45A51 /* AppHangReportingTests.swift in Sources */,
 				A29100000000000000000004 /* CaskMetadataProjectorTests.swift in Sources */,
 				41AD10162F68B00700BEABB8 /* CrashReporterTests.swift in Sources */,
 				41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */,

--- a/CaskHub/App/ApplicationTerminationCoordinator.swift
+++ b/CaskHub/App/ApplicationTerminationCoordinator.swift
@@ -57,6 +57,14 @@ final class ApplicationTerminationCoordinator: NSObject, NSApplicationDelegate {
         requestApplicationTermination()
     }
 
+    func applicationDidBecomeActive(_ notification: Notification) {
+        CrashReporter.setApplicationActive(true)
+    }
+
+    func applicationWillResignActive(_ notification: Notification) {
+        CrashReporter.setApplicationActive(false)
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard hasActiveOperations() else {
             return .terminateNow

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -72,9 +72,10 @@ struct CaskHubApp: App {
                 ContentView(viewModel: catalog)
                     .frame(minWidth: 1380, minHeight: 640)
                     .background {
-                        WindowCloseButtonConfigurator {
-                            terminationCoordinator.requestTermination()
-                        }
+                        WindowCloseButtonConfigurator(
+                            onClose: { terminationCoordinator.requestTermination() },
+                            onBecomeKey: { updaterService.start() }
+                        )
                     }
                     .background {
                         CaskHubHelpSearchRegistration(selection: $helpTopic)
@@ -129,12 +130,13 @@ struct CaskHubApp: App {
 
 @MainActor
 struct WindowCloseButtonConfigurator: NSViewRepresentable {
-    typealias CloseAction = @MainActor @Sendable () -> Void
+    typealias WindowAction = @MainActor @Sendable () -> Void
 
-    let onClose: CloseAction
+    let onClose: WindowAction
+    let onBecomeKey: WindowAction
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onClose: onClose)
+        Coordinator(onClose: onClose, onBecomeKey: onBecomeKey)
     }
 
     func makeNSView(context: Context) -> WindowObservationView {
@@ -146,6 +148,7 @@ struct WindowCloseButtonConfigurator: NSViewRepresentable {
     func updateNSView(_ view: WindowObservationView, context: Context) {
         view.coordinator = context.coordinator
         context.coordinator.onClose = onClose
+        context.coordinator.onBecomeKey = onBecomeKey
         if let window = view.window {
             context.coordinator.attach(to: window)
         }
@@ -170,30 +173,53 @@ struct WindowCloseButtonConfigurator: NSViewRepresentable {
 
     @MainActor
     final class Coordinator: NSObject {
-        var onClose: CloseAction
+        var onClose: WindowAction
+        var onBecomeKey: WindowAction
 
+        private weak var observedWindow: NSWindow?
         private weak var closeButton: NSButton?
         private weak var originalTarget: AnyObject?
         private var originalAction: Selector?
 
-        init(onClose: @escaping CloseAction) {
+        init(onClose: @escaping WindowAction, onBecomeKey: @escaping WindowAction) {
             self.onClose = onClose
+            self.onBecomeKey = onBecomeKey
         }
 
         func detach() {
-            guard let closeButton, closeButton.target === self else { return }
-            closeButton.target = originalTarget
-            closeButton.action = originalAction
+            if let closeButton, closeButton.target === self {
+                closeButton.target = originalTarget
+                closeButton.action = originalAction
+            }
+            if let observedWindow {
+                NotificationCenter.default.removeObserver(
+                    self,
+                    name: NSWindow.didBecomeKeyNotification,
+                    object: observedWindow
+                )
+            }
+            observedWindow = nil
             self.closeButton = nil
             originalTarget = nil
             originalAction = nil
         }
 
         func attach(to window: NSWindow) {
-            guard let button = window.standardWindowButton(.closeButton) else { return }
-            guard closeButton !== button || button.target !== self else { return }
+            guard observedWindow !== window else { return }
 
             detach()
+            observedWindow = window
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(windowDidBecomeKey),
+                name: NSWindow.didBecomeKeyNotification,
+                object: window
+            )
+            if window.isKeyWindow {
+                onBecomeKey()
+            }
+
+            guard let button = window.standardWindowButton(.closeButton) else { return }
             closeButton = button
             originalTarget = button.target
             originalAction = button.action
@@ -204,6 +230,11 @@ struct WindowCloseButtonConfigurator: NSViewRepresentable {
         @objc
         private func closeButtonPressed() {
             onClose()
+        }
+
+        @objc
+        private func windowDidBecomeKey() {
+            onBecomeKey()
         }
     }
 }

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -189,6 +189,9 @@ nonisolated enum AppHangFamily: String, Sendable {
 }
 
 nonisolated final class AppHangEventProcessor: Sendable {
+    private static let swiftUIFrameworks = ["swiftui", "attributegraph"]
+    private static let graphicsFrameworks = ["coregraphics", "metal", "renderbox"]
+
     func process(_ event: Event) -> Event? {
         guard let exception = event.exceptions?.first(where: {
             $0.mechanism?.type == "AppHang"
@@ -220,28 +223,21 @@ nonisolated final class AppHangEventProcessor: Sendable {
             guard let package = frame.package.map({
                 URL(fileURLWithPath: $0).lastPathComponent.lowercased()
             }) else { continue }
-            if package.contains("sentry") {
-                return .sentry
-            }
-            if package.contains("sparkle") {
-                return .sparkle
-            }
-            if package.contains("swiftui") || package.contains("attributegraph") {
-                return .swiftUI
-            }
-            if package == "skylight" {
-                return .windowServer
-            }
-            if package.contains("coregraphics")
-                || package.contains("metal")
-                || package.contains("renderbox") {
-                return .graphics
-            }
-            if package == "appkit" {
-                return .appKit
+            if let family = family(forPackage: package) {
+                return family
             }
         }
         return .system
+    }
+
+    private static func family(forPackage package: String) -> AppHangFamily? {
+        if package.contains("sentry") { return .sentry }
+        if package.contains("sparkle") { return .sparkle }
+        if swiftUIFrameworks.contains(where: package.contains) { return .swiftUI }
+        if package == "skylight" { return .windowServer }
+        if graphicsFrameworks.contains(where: package.contains) { return .graphics }
+        if package == "appkit" { return .appKit }
+        return nil
     }
 }
 

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -33,8 +33,11 @@ enum CrashReporter {
     static let enabledKey = "crashReportingEnabled"
 
     static var provider: CrashReporterProvider = SentryProvider()
+    static var defaults = UserDefaults.standard
 
     static var captureCounts: [String: Int] = [:]
+    static var isApplicationActive = false
+    static var hangTrackingPauseDepth = 0
     private static let captureLimit = 5
     private static let ignoredURLErrorCodes: Set<Int> = [
         URLError.cancelled.rawValue,
@@ -52,17 +55,19 @@ enum CrashReporter {
     static var isRunningTests = detectsTestRun
 
     static var isEnabled: Bool {
-        UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+        defaults.object(forKey: enabledKey) as? Bool ?? true
     }
 
     static func start() {
         guard !isRunningTests else { return }
         provider.start(enabled: isEnabled)
+        if isEnabled { synchronizeHangTracking() }
     }
 
     static func refresh() {
         guard !isRunningTests else { return }
         provider.setEnabled(isEnabled)
+        if isEnabled { synchronizeHangTracking() }
     }
 
     static func capture(_ error: Error) {
@@ -120,21 +125,48 @@ enum CrashReporter {
         return provider.startSpan(name: name, operation: operation)
     }
 
-    // Hang detection pings the main queue in the default run-loop mode; app-modal
-    // panels spin NSModalPanelRunLoopMode, so any dialog open >2s reports as a
-    // fake hang. Pause around every runModal-style nested run loop.
+    // Sentry's macOS tracker does not understand app activity or nested pauses.
+    // Keep it enabled only while CaskHub is active and outside modal run loops.
+    static func setApplicationActive(_ isActive: Bool) {
+        let wasTracking = shouldTrackHangs
+        isApplicationActive = isActive
+        updateHangTracking(ifChangedFrom: wasTracking)
+    }
+
     static func pauseHangTracking() {
-        provider.pauseHangTracking()
+        let wasTracking = shouldTrackHangs
+        hangTrackingPauseDepth += 1
+        updateHangTracking(ifChangedFrom: wasTracking)
     }
 
     static func resumeHangTracking() {
-        provider.resumeHangTracking()
+        guard hangTrackingPauseDepth > 0 else { return }
+        let wasTracking = shouldTrackHangs
+        hangTrackingPauseDepth -= 1
+        updateHangTracking(ifChangedFrom: wasTracking)
     }
 
     static func withHangTrackingPaused<T>(_ body: () throws -> T) rethrows -> T {
         pauseHangTracking()
         defer { resumeHangTracking() }
         return try body()
+    }
+
+    private static var shouldTrackHangs: Bool {
+        isApplicationActive && hangTrackingPauseDepth == 0
+    }
+
+    private static func updateHangTracking(ifChangedFrom wasTracking: Bool) {
+        guard shouldTrackHangs != wasTracking else { return }
+        synchronizeHangTracking()
+    }
+
+    private static func synchronizeHangTracking() {
+        if shouldTrackHangs {
+            provider.resumeHangTracking()
+        } else {
+            provider.pauseHangTracking()
+        }
     }
 }
 
@@ -145,6 +177,74 @@ struct NoOpCrashSpan: CrashSpan {
 
 // MARK: - Sentry
 
+nonisolated enum AppHangFamily: String, Sendable {
+    case appCode = "app-code"
+    case sentry
+    case sparkle
+    case swiftUI = "swift-ui"
+    case windowServer = "window-server"
+    case graphics
+    case appKit = "app-kit"
+    case system
+}
+
+nonisolated final class AppHangEventProcessor: Sendable {
+    func process(_ event: Event) -> Event? {
+        guard let exception = event.exceptions?.first(where: {
+            $0.mechanism?.type == "AppHang"
+        }) else {
+            return event
+        }
+
+        let family = Self.family(
+            for: exception.stacktrace?.frames
+                ?? event.threads?.first(where: { $0.isMain?.boolValue == true })?
+                    .stacktrace?.frames
+                ?? []
+        )
+        var tags = event.tags ?? [:]
+        tags["app_hang.family"] = family.rawValue
+        event.tags = tags
+        event.fingerprint = (event.fingerprint ?? ["{{ default }}"])
+            + ["app-hang", family.rawValue]
+        return event
+    }
+
+    private static func family(for frames: [Frame]) -> AppHangFamily {
+        // Sentry stores native frames oldest-to-youngest. The youngest useful
+        // frame describes the work that was actually blocking the main thread.
+        for frame in frames.reversed() {
+            if frame.inApp?.boolValue == true {
+                return .appCode
+            }
+            guard let package = frame.package.map({
+                URL(fileURLWithPath: $0).lastPathComponent.lowercased()
+            }) else { continue }
+            if package.contains("sentry") {
+                return .sentry
+            }
+            if package.contains("sparkle") {
+                return .sparkle
+            }
+            if package.contains("swiftui") || package.contains("attributegraph") {
+                return .swiftUI
+            }
+            if package == "skylight" {
+                return .windowServer
+            }
+            if package.contains("coregraphics")
+                || package.contains("metal")
+                || package.contains("renderbox") {
+                return .graphics
+            }
+            if package == "appkit" {
+                return .appKit
+            }
+        }
+        return .system
+    }
+}
+
 final class SentryProvider: CrashReporterProvider {
     private static var dsn: String? {
         let value = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String
@@ -152,12 +252,15 @@ final class SentryProvider: CrashReporterProvider {
     }
 
     private var started = false
+    private let appHangProcessor = AppHangEventProcessor()
 
     func start(enabled: Bool) {
         guard enabled, let dsn = Self.dsn else { return }
+        let appHangProcessor = appHangProcessor
         SentrySDK.start { options in
             options.dsn = dsn
             options.tracesSampleRate = 1.0
+            options.beforeSend = appHangProcessor.process
             #if DEBUG
             options.environment = "debug"
             #endif

--- a/CaskHub/Services/Updates/UpdaterService.swift
+++ b/CaskHub/Services/Updates/UpdaterService.swift
@@ -36,6 +36,17 @@ struct StagedUpdateGate {
     }
 }
 
+struct UpdaterStartGate {
+    private(set) var started = false
+
+    mutating func run(start: () -> Void, check: () -> Void) {
+        guard !started else { return }
+        started = true
+        start()
+        check()
+    }
+}
+
 @Observable
 final class UpdaterService: NSObject, SPUUpdaterDelegate {
     private var controller: SPUStandardUpdaterController!
@@ -44,16 +55,15 @@ final class UpdaterService: NSObject, SPUUpdaterDelegate {
     private(set) var lastUpdateCheckDate: Date?
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
     @ObservationIgnored private var stagedUpdate = StagedUpdateGate()
+    @ObservationIgnored private var startGate = UpdaterStartGate()
 
     override init() {
         super.init()
         controller = SPUStandardUpdaterController(
-            startingUpdater: true,
+            startingUpdater: false,
             updaterDelegate: self,
             userDriverDelegate: self
         )
-        // Sparkle allows a forced launch check here, before its scheduled cycle starts.
-        Self.checkForUpdatesOnLaunch(using: controller.updater)
         controller.updater.publisher(for: \.canCheckForUpdates)
             .sink { [weak self] canCheck in
                 guard let self else { return }
@@ -71,6 +81,16 @@ final class UpdaterService: NSObject, SPUUpdaterDelegate {
                 self?.lastUpdateCheckDate = date
             }
             .store(in: &cancellables)
+    }
+
+    func start() {
+        startGate.run(
+            start: { controller.startUpdater() },
+            check: {
+                // Sparkle allows a forced launch check after the updater starts.
+                Self.checkForUpdatesOnLaunch(using: controller.updater)
+            }
+        )
     }
 
     static func checkForUpdatesOnLaunch(using updater: some BackgroundUpdateChecking) {

--- a/CaskHubTests/Telemetry/AnalyticsTests.swift
+++ b/CaskHubTests/Telemetry/AnalyticsTests.swift
@@ -23,18 +23,24 @@ private final class SpyAnalyticsProvider: AnalyticsProvider {
 final class AnalyticsTests: XCTestCase {
     private var spy: SpyAnalyticsProvider!
     private var originalProvider: AnalyticsProvider!
+    private var originalCrashDefaults: UserDefaults!
 
     override func setUp() {
         super.setUp()
         spy = SpyAnalyticsProvider()
         originalProvider = Analytics.provider
+        originalCrashDefaults = CrashReporter.defaults
         Analytics.provider = spy
+        CrashReporter.defaults = makeScratchDefaults(
+            "analytics-crash-\(ProcessInfo.processInfo.processIdentifier)"
+        )
         Analytics.openedPages.removeAll()
         UserDefaults.standard.removeObject(forKey: Analytics.enabledKey)
     }
 
     override func tearDown() {
         Analytics.provider = originalProvider
+        CrashReporter.defaults = originalCrashDefaults
         UserDefaults.standard.removeObject(forKey: Analytics.enabledKey)
         super.tearDown()
     }
@@ -308,9 +314,9 @@ final class AnalyticsTests: XCTestCase {
         CrashReporter.provider = crashSpy
         defer {
             CrashReporter.provider = originalCrash
-            UserDefaults.standard.removeObject(forKey: CrashReporter.enabledKey)
+            CrashReporter.defaults.removeObject(forKey: CrashReporter.enabledKey)
         }
-        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
 
         Analytics.send("Page.opened")
 

--- a/CaskHubTests/Telemetry/AppHangReportingTests.swift
+++ b/CaskHubTests/Telemetry/AppHangReportingTests.swift
@@ -1,0 +1,196 @@
+//
+//  AppHangReportingTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 13/08/2026.
+//
+
+@testable import CaskHub
+import AppKit
+import Sentry
+import XCTest
+
+extension CrashReporterTests {
+    func test_paused_scope_brackets_the_body() {
+        activateHangTracking()
+
+        let value = CrashReporter.withHangTrackingPaused { 7 }
+
+        XCTAssertEqual(value, 7)
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
+    }
+
+    func test_paused_scope_resumes_when_the_body_throws() {
+        activateHangTracking()
+
+        XCTAssertThrowsError(
+            try CrashReporter.withHangTrackingPaused { throw URLError(.badURL) }
+        )
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
+    }
+
+    func test_nested_pauses_resume_only_after_the_final_scope() {
+        activateHangTracking()
+
+        CrashReporter.pauseHangTracking()
+        CrashReporter.pauseHangTracking()
+        CrashReporter.resumeHangTracking()
+
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause"])
+
+        CrashReporter.resumeHangTracking()
+
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
+    }
+
+    @MainActor
+    func test_modal_closing_while_inactive_waits_for_activation_to_resume() {
+        let coordinator = ApplicationTerminationCoordinator()
+        coordinator.applicationDidBecomeActive(Notification(
+            name: NSApplication.didBecomeActiveNotification
+        ))
+        spy.hangTrackingEvents.removeAll()
+
+        CrashReporter.pauseHangTracking()
+        coordinator.applicationWillResignActive(Notification(
+            name: NSApplication.willResignActiveNotification
+        ))
+        CrashReporter.resumeHangTracking()
+
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause"])
+
+        coordinator.applicationDidBecomeActive(Notification(
+            name: NSApplication.didBecomeActiveNotification
+        ))
+
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
+    }
+
+    @MainActor
+    func test_activation_during_a_modal_waits_for_the_modal_to_close() {
+        CrashReporter.start()
+        spy.hangTrackingEvents.removeAll()
+        let coordinator = ApplicationTerminationCoordinator()
+
+        CrashReporter.pauseHangTracking()
+        coordinator.applicationDidBecomeActive(Notification(
+            name: NSApplication.didBecomeActiveNotification
+        ))
+
+        XCTAssertTrue(spy.hangTrackingEvents.isEmpty)
+
+        CrashReporter.resumeHangTracking()
+
+        XCTAssertEqual(spy.hangTrackingEvents, ["resume"])
+    }
+
+    func test_start_and_reenable_synchronize_inactive_hang_tracking() {
+        CrashReporter.start()
+
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause"])
+
+        spy.hangTrackingEvents.removeAll()
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.refresh()
+        CrashReporter.defaults.set(true, forKey: CrashReporter.enabledKey)
+        CrashReporter.refresh()
+
+        XCTAssertEqual(spy.hangTrackingEvents, ["pause"])
+    }
+
+    private func activateHangTracking() {
+        CrashReporter.setApplicationActive(true)
+        spy.hangTrackingEvents.removeAll()
+    }
+}
+
+final class AppHangEventProcessorTests: XCTestCase {
+    func test_non_app_hang_event_is_unchanged() {
+        let processor = AppHangEventProcessor()
+        let event = Event(level: .error)
+
+        let processed = processor.process(event)
+
+        XCTAssertTrue(processed === event)
+        XCTAssertNil(event.fingerprint)
+        XCTAssertNil(event.tags?["app_hang.family"])
+    }
+
+    func test_app_hangs_are_split_by_presymbolicated_framework_family() {
+        let processor = AppHangEventProcessor()
+        let windowServer = makeAppHangEvent(packages: [
+            "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+            "/System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight"
+        ])
+        let swiftUI = makeAppHangEvent(packages: [
+            "/System/Library/Frameworks/SwiftUI.framework/Versions/A/SwiftUI"
+        ])
+
+        XCTAssertNotNil(processor.process(windowServer))
+        XCTAssertNotNil(processor.process(swiftUI))
+        XCTAssertEqual(windowServer.tags?["app_hang.family"], "window-server")
+        XCTAssertEqual(swiftUI.tags?["app_hang.family"], "swift-ui")
+        XCTAssertEqual(
+            windowServer.fingerprint,
+            ["{{ default }}", "app-hang", "window-server"]
+        )
+        XCTAssertEqual(
+            swiftUI.fingerprint,
+            ["{{ default }}", "app-hang", "swift-ui"]
+        )
+    }
+
+    func test_youngest_app_frame_wins_over_swiftui_ancestor() {
+        let processor = AppHangEventProcessor()
+        let event = makeAppHangEvent(frames: [
+            ("/System/Library/Frameworks/SwiftUI.framework/Versions/A/SwiftUI", false),
+            ("/Applications/CaskHub.app/Contents/MacOS/CaskHub", true)
+        ])
+
+        XCTAssertNotNil(processor.process(event))
+        XCTAssertEqual(event.tags?["app_hang.family"], "app-code")
+    }
+
+    func test_sentry_queue_ping_does_not_merge_with_appkit_hangs() {
+        let processor = AppHangEventProcessor()
+        let event = makeAppHangEvent(packages: [
+            "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+            "/Applications/CaskHub.app/Contents/Frameworks/Sentry.framework/Sentry"
+        ])
+
+        XCTAssertNotNil(processor.process(event))
+        XCTAssertEqual(event.tags?["app_hang.family"], "sentry")
+    }
+
+    func test_core_graphics_without_skylight_is_graphics() {
+        let processor = AppHangEventProcessor()
+        let event = makeAppHangEvent(packages: [
+            "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+            "/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics"
+        ])
+
+        XCTAssertNotNil(processor.process(event))
+        XCTAssertEqual(event.tags?["app_hang.family"], "graphics")
+    }
+
+    private func makeAppHangEvent(packages: [String]) -> Event {
+        makeAppHangEvent(frames: packages.map { ($0, false) })
+    }
+
+    private func makeAppHangEvent(frames: [(package: String, inApp: Bool)]) -> Event {
+        let event = Event(level: .error)
+        let exception = Exception(value: "App hanging", type: "App Hanging")
+        exception.mechanism = Mechanism(type: "AppHang")
+        exception.stacktrace = SentryStacktrace(
+            frames: frames.map { package, inApp in
+                let frame = Frame()
+                frame.package = package
+                frame.inApp = NSNumber(value: inApp)
+                return frame
+            },
+            registers: [:]
+        )
+        event.exceptions = [exception]
+        return event
+    }
+}

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -8,25 +8,47 @@
 @testable import CaskHub
 import XCTest
 
+private struct CrashReporterTestState {
+    let provider: CrashReporterProvider
+    let defaults: UserDefaults
+    let captureCounts: [String: Int]
+    let applicationActive: Bool
+    let pauseDepth: Int
+    let isRunningTests: Bool
+}
+
 final class CrashReporterTests: XCTestCase {
-    private var spy: SpyCrashReporterProvider!
-    private var originalProvider: CrashReporterProvider!
+    var spy: SpyCrashReporterProvider!
+    private var originalState: CrashReporterTestState!
 
     override func setUp() {
         super.setUp()
         spy = SpyCrashReporterProvider()
-        originalProvider = CrashReporter.provider
+        originalState = CrashReporterTestState(
+            provider: CrashReporter.provider,
+            defaults: CrashReporter.defaults,
+            captureCounts: CrashReporter.captureCounts,
+            applicationActive: CrashReporter.isApplicationActive,
+            pauseDepth: CrashReporter.hangTrackingPauseDepth,
+            isRunningTests: CrashReporter.isRunningTests
+        )
         CrashReporter.provider = spy
+        CrashReporter.defaults = makeScratchDefaults(
+            "crash-reporter-\(ProcessInfo.processInfo.processIdentifier)"
+        )
         CrashReporter.captureCounts = [:]
+        CrashReporter.isApplicationActive = false
+        CrashReporter.hangTrackingPauseDepth = 0
         CrashReporter.isRunningTests = false
-        UserDefaults.standard.removeObject(forKey: CrashReporter.enabledKey)
     }
 
     override func tearDown() {
-        CrashReporter.provider = originalProvider
-        CrashReporter.captureCounts = [:]
-        CrashReporter.isRunningTests = CrashReporter.detectsTestRun
-        UserDefaults.standard.removeObject(forKey: CrashReporter.enabledKey)
+        CrashReporter.provider = originalState.provider
+        CrashReporter.defaults = originalState.defaults
+        CrashReporter.captureCounts = originalState.captureCounts
+        CrashReporter.isApplicationActive = originalState.applicationActive
+        CrashReporter.hangTrackingPauseDepth = originalState.pauseDepth
+        CrashReporter.isRunningTests = originalState.isRunningTests
         super.tearDown()
     }
 
@@ -37,20 +59,20 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_is_enabled_reflects_stored_opt_out() {
-        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
         XCTAssertFalse(CrashReporter.isEnabled)
     }
 
     func test_start_passes_stored_setting_to_provider() {
-        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
         CrashReporter.start()
         XCTAssertEqual(spy.startedWith, [false])
     }
 
     func test_refresh_forwards_current_setting_to_provider() {
-        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
         CrashReporter.refresh()
-        UserDefaults.standard.set(true, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(true, forKey: CrashReporter.enabledKey)
         CrashReporter.refresh()
         XCTAssertEqual(spy.enabledChanges, [false, true])
     }
@@ -63,7 +85,7 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_capture_is_suppressed_when_opted_out() {
-        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
         CrashReporter.capture(URLError(.badServerResponse))
         XCTAssertTrue(spy.capturedErrors.isEmpty)
     }
@@ -267,7 +289,10 @@ final class CrashReporterTests: XCTestCase {
             cls("chmod: /Applications/Example.app: Unable to change file mode: Operation not permitted"),
             "permission-denied"
         )
-        XCTAssertEqual(cls("It seems the existing App is different from the one being installed."), "adopt-version-mismatch")
+        XCTAssertEqual(
+            cls("It seems the existing App is different from the one being installed."),
+            "adopt-version-mismatch"
+        )
         XCTAssertEqual(cls("SHA256 mismatch"), "checksum-mismatch")
         XCTAssertEqual(cls("curl: (6) Could not resolve host: example.com"), "network-failure")
         XCTAssertEqual(cls("It seems there is already a Binary at '/opt/homebrew/bin/x'."), "binary-conflict")
@@ -445,7 +470,7 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_tag_is_suppressed_when_opted_out() {
-        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
         CrashReporter.tag("brew.path", value: "/opt/homebrew/bin/brew")
         XCTAssertTrue(spy.tags.isEmpty)
     }
@@ -473,7 +498,7 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_breadcrumb_is_suppressed_when_opted_out() {
-        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
         CrashReporter.breadcrumb("Cask.installed")
         XCTAssertTrue(spy.breadcrumbs.isEmpty)
     }
@@ -495,26 +520,13 @@ final class CrashReporterTests: XCTestCase {
     }
 
     func test_span_is_inert_when_opted_out() {
-        UserDefaults.standard.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
         let span = CrashReporter.span(name: "install", operation: "brew")
         span.finish()
         XCTAssertTrue(spy.spans.isEmpty)
     }
 
     // MARK: - Hang tracking pause
-
-    func test_with_hang_tracking_paused_brackets_the_body() {
-        let value = CrashReporter.withHangTrackingPaused { 7 }
-        XCTAssertEqual(value, 7)
-        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
-    }
-
-    func test_hang_tracking_resumes_when_body_throws() {
-        XCTAssertThrowsError(
-            try CrashReporter.withHangTrackingPaused { throw URLError(.badURL) }
-        )
-        XCTAssertEqual(spy.hangTrackingEvents, ["pause", "resume"])
-    }
 
     func test_sentry_provider_pause_resume_are_safe_without_started_sdk() {
         let provider = SentryProvider()

--- a/CaskHubTests/Views/ContentViewTests.swift
+++ b/CaskHubTests/Views/ContentViewTests.swift
@@ -151,9 +151,10 @@ final class ContentViewTests: XCTestCase {
             defer: false
         )
         window.isReleasedWhenClosed = false
-        window.contentView = NSHostingView(rootView: WindowCloseButtonConfigurator {
-            terminationCoordinator.requestTermination()
-        })
+        window.contentView = NSHostingView(rootView: WindowCloseButtonConfigurator(
+            onClose: { terminationCoordinator.requestTermination() },
+            onBecomeKey: {}
+        ))
         window.orderFrontRegardless()
 
         let closeButton = try XCTUnwrap(window.standardWindowButton(.closeButton))
@@ -170,6 +171,39 @@ final class ContentViewTests: XCTestCase {
         XCTAssertEqual(probe.terminationReply, .terminateCancel)
         window.contentView = NSView()
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        window.close()
+    }
+
+    @MainActor
+    func test_window_configurator_reports_when_its_window_becomes_key() {
+        var keyCount = 0
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: WindowCloseButtonConfigurator(
+            onClose: {},
+            onBecomeKey: { keyCount += 1 }
+        ))
+        window.orderFrontRegardless()
+
+        let closeButton = window.standardWindowButton(.closeButton)
+        let deadline = Date().addingTimeInterval(2)
+        while !(closeButton?.target is WindowCloseButtonConfigurator.Coordinator),
+              Date() < deadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        }
+        keyCount = 0
+        NotificationCenter.default.post(
+            name: NSWindow.didBecomeKeyNotification,
+            object: window
+        )
+
+        XCTAssertEqual(keyCount, 1)
+        window.contentView = NSView()
         window.close()
     }
 

--- a/CaskHubTests/Views/SettingsViewTests.swift
+++ b/CaskHubTests/Views/SettingsViewTests.swift
@@ -159,6 +159,23 @@ final class SettingsViewTests: XCTestCase {
     }
 
     @MainActor
+    func test_updater_start_gate_runs_start_and_check_once_in_order() {
+        var gate = UpdaterStartGate()
+        var actions: [String] = []
+
+        gate.run(
+            start: { actions.append("start") },
+            check: { actions.append("check") }
+        )
+        gate.run(
+            start: { actions.append("start") },
+            check: { actions.append("check") }
+        )
+
+        XCTAssertEqual(actions, ["start", "check"])
+    }
+
+    @MainActor
     func test_staged_update_not_pending_when_automatic_checks_disabled() {
         var gate = StagedUpdateGate()
         gate.updateStaged(automaticChecksEnabled: false)

--- a/CaskHubTests/Views/UpdateSettingsViewTests.swift
+++ b/CaskHubTests/Views/UpdateSettingsViewTests.swift
@@ -23,8 +23,16 @@ final class UpdateSettingsViewTests: XCTestCase {
     func test_sparkle_modal_alert_hooks_pause_and_resume_hang_tracking() {
         let spy = SpyCrashReporterProvider()
         let original = CrashReporter.provider
-        defer { CrashReporter.provider = original }
+        let wasActive = CrashReporter.isApplicationActive
+        let pauseDepth = CrashReporter.hangTrackingPauseDepth
+        defer {
+            CrashReporter.provider = original
+            CrashReporter.isApplicationActive = wasActive
+            CrashReporter.hangTrackingPauseDepth = pauseDepth
+        }
         CrashReporter.provider = spy
+        CrashReporter.isApplicationActive = true
+        CrashReporter.hangTrackingPauseDepth = 0
 
         let updater = UpdaterService()
         updater.standardUserDriverWillShowModalAlert()


### PR DESCRIPTION
## Summary

- pause Sentry AppHang tracking while CaskHub is inactive or inside nested modal run loops
- split the mixed CASKHUB-M group into stable semantic families while preserving Sentry default stack grouping
- identify app-code, Sentry, Sparkle, SwiftUI, WindowServer, graphics, AppKit, and system hangs without dropping distinct events client-side
- start Sparkle only after the main window becomes key, then perform the existing automatic launch check once
- isolate telemetry preferences in tests and cover lifecycle interleavings, pre-symbolication classification, and the real NSWindow presentation boundary

Sentry: [CASKHUB-M](https://caskhub.sentry.io/issues/CASKHUB-M)

This removes inactive/modal false positives and prevents unrelated hangs from collapsing into one issue. Genuine active AppKit, SwiftUI, graphics, or system stalls remain reportable as separate issues for targeted follow-up.

## Verification

- strict SwiftLint: passed on all changed Swift files
- full macOS test suite: passed
- signed Debug arm64 build: passed
- app launch smoke check: passed
- `git diff --check`: passed
- Xcode project plist validation: passed

Signing note: the app contains an embedded Hardened Runtime signature for team `USYCM7BRK3`; local strict trust verification reports `CSSMERR_TP_NOT_TRUSTED` because this machine has no trusted signing identity.

## Checklist

- [x] Base branch is `develop` (not `master`)
- [x] Title uses a conventional prefix + Sentence-case subject (`fix: Handle empty search results`)
- [x] Tests added or updated (Codecov patch target: 80%)
- [x] SwiftLint build phase passes locally
- [x] No changes to `CaskHub/Resources/*.json` or `CHANGELOG.md`
- [x] Issue linked for non-trivial changes (see [CONTRIBUTING.md](https://github.com/alielsokary/CaskHub/blob/develop/CONTRIBUTING.md))