### PR TITLE
pref: Clear search text on sidebar navigation

### DIFF
--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -109,6 +109,7 @@ final class CaskCatalogViewModel {
     var selectedSidebar: SidebarSelection = .discover(.browse) {
         didSet {
             guard oldValue != selectedSidebar else { return }
+            searchText = ""
             resetReveal()
             switch selectedSidebar {
             case .library(.installed):

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -156,6 +156,16 @@ final class CaskCatalogViewModelTests: XCTestCase {
         XCTAssertEqual(vm.displayedCasks.count, chunk)
     }
 
+    @MainActor
+    func test_sidebar_change_clears_search_text() async {
+        let (vm, _) = await makeSUT(casks: [makeCask("firefox")])
+
+        vm.searchText = "fire"
+        vm.selectedSidebar = .library(.installed)
+
+        XCTAssertEqual(vm.searchText, "")
+    }
+
     // MARK: Sidebar filters
 
     @MainActor


### PR DESCRIPTION
## Summary
Search field kept its text when navigating between pages from the sidebar, so the previous query silently filtered the new page. Clear it on every sidebar change.

## Changes
- `CaskCatalogViewModel.selectedSidebar` didSet clears `searchText` — covers all navigation paths (sidebar clicks, deep links, category taps, browse sections) since every write routes through the view model.
- Clearing cascades through existing plumbing: empty text applies instantly (debounce skipped) and `ContentView` hides the results header and drops search focus.

## Tests
- New `test_sidebar_change_clears_search_text`
- CaskCatalogViewModelTests (20), CaskCatalogSortTests + ContentViewTests (16) all pass