### PR TITLE
refactor: Move usage metrics to Sentry

### DIFF
--- a/CaskHub/Resources/Localizable.xcstrings
+++ b/CaskHub/Resources/Localizable.xcstrings
@@ -2662,7 +2662,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sends anonymized usage signals through TelemetryDeck. No personal information is collected."
+            "value" : "Sends anonymous usage metrics through Sentry. TelemetryDeck receives only anonymous session and new-install signals."
           }
         }
       }

--- a/CaskHub/Services/Telemetry/Analytics+Events.swift
+++ b/CaskHub/Services/Telemetry/Analytics+Events.swift
@@ -95,11 +95,8 @@ extension Analytics {
 
     // MARK: - Search
 
-    static func searchPerformed(query: String, results: Int) {
-        send("Search.performed", parameters: [
-            "query": query.trimmingCharacters(in: .whitespaces).lowercased(),
-            "results": "\(results)"
-        ])
+    static func searchPerformed(results: Int) {
+        send("Search.performed", parameters: ["results": "\(results)"])
     }
 
     // MARK: - Filters & view options

--- a/CaskHub/Services/Telemetry/Analytics.swift
+++ b/CaskHub/Services/Telemetry/Analytics.swift
@@ -6,21 +6,24 @@
 //
 
 import Foundation
+import Sentry
 import TelemetryDeck
 
 protocol AnalyticsProvider {
     func start(enabled: Bool)
     func setEnabled(_ enabled: Bool)
-    func send(_ signalName: String, parameters: [String: String])
 }
 
 enum Analytics {
     static let enabledKey = "analyticsEnabled"
+    static let metricKey = "caskhub.analytics.event"
 
     static var provider: AnalyticsProvider = TelemetryDeckProvider()
+    static var metrics: SentryMetricsApiProtocol = SentrySDK.metrics
+    static var defaults = UserDefaults.standard
 
     static var isEnabled: Bool {
-        UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+        defaults.object(forKey: enabledKey) as? Bool ?? true
     }
 
     static func start() {
@@ -29,11 +32,21 @@ enum Analytics {
 
     static func refresh() {
         provider.setEnabled(isEnabled)
+        CrashReporter.refresh()
     }
 
     static func send(_ signalName: String, parameters: [String: String] = [:]) {
         CrashReporter.breadcrumb(signalName, data: parameters)
-        provider.send(signalName, parameters: parameters)
+        guard isEnabled else { return }
+
+        var attributes: [String: SentryAttributeValue] = [
+            "event.name": signalName,
+            "schema.version": 1
+        ]
+        for (key, value) in parameters {
+            attributes["event.\(key)"] = value
+        }
+        metrics.count(key: metricKey, value: 1, attributes: attributes)
     }
 }
 
@@ -41,27 +54,34 @@ enum Analytics {
 
 /// Session signals (launches, active users) are sent by the SDK automatically.
 final class TelemetryDeckProvider: AnalyticsProvider {
-    private static var appID: String? {
-        let value = Bundle.main.object(forInfoDictionaryKey: "TelemetryDeckAppID") as? String
-        return value?.isEmpty == false ? value : nil
-    }
-
+    private let appID: () -> String?
+    private let initialize: (TelemetryDeck.Config) -> Void
     private var config: TelemetryDeck.Config?
 
+    init(
+        appID: @escaping () -> String? = {
+            let value = Bundle.main.object(
+                forInfoDictionaryKey: "TelemetryDeckAppID"
+            ) as? String
+            return value?.isEmpty == false ? value : nil
+        },
+        initialize: @escaping (TelemetryDeck.Config) -> Void = {
+            TelemetryDeck.initialize(config: $0)
+        }
+    ) {
+        self.appID = appID
+        self.initialize = initialize
+    }
+
     func start(enabled: Bool) {
-        guard let appID = Self.appID else { return }
+        guard let appID = appID() else { return }
         let config = TelemetryDeck.Config(appID: appID)
         config.analyticsDisabled = !enabled
-        TelemetryDeck.initialize(config: config)
+        initialize(config)
         self.config = config
     }
 
     func setEnabled(_ enabled: Bool) {
         config?.analyticsDisabled = !enabled
-    }
-
-    func send(_ signalName: String, parameters: [String: String]) {
-        guard config != nil else { return }
-        TelemetryDeck.signal(signalName, parameters: parameters)
     }
 }

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -14,8 +14,8 @@ protocol CrashSpan {
 }
 
 protocol CrashReporterProvider {
-    func start(enabled: Bool)
-    func setEnabled(_ enabled: Bool)
+    func start(consent: SentryConsent)
+    func setConsent(_ consent: SentryConsent)
     func capture(_ error: Error)
     func addBreadcrumb(_ message: String, data: [String: String])
     func setTag(_ key: String, value: String)
@@ -27,6 +27,13 @@ protocol CrashReporterProvider {
 extension CrashReporterProvider {
     func pauseHangTracking() {}
     func resumeHangTracking() {}
+}
+
+nonisolated struct SentryConsent: Equatable, Sendable {
+    let crashReporting: Bool
+    let analytics: Bool
+
+    var isEmpty: Bool { !crashReporting && !analytics }
 }
 
 enum CrashReporter {
@@ -60,14 +67,18 @@ enum CrashReporter {
 
     static func start() {
         guard !isRunningTests else { return }
-        provider.start(enabled: isEnabled)
+        provider.start(consent: consent)
         if isEnabled { synchronizeHangTracking() }
     }
 
     static func refresh() {
         guard !isRunningTests else { return }
-        provider.setEnabled(isEnabled)
+        provider.setConsent(consent)
         if isEnabled { synchronizeHangTracking() }
+    }
+
+    private static var consent: SentryConsent {
+        SentryConsent(crashReporting: isEnabled, analytics: Analytics.isEnabled)
     }
 
     static func capture(_ error: Error) {
@@ -242,21 +253,62 @@ nonisolated final class AppHangEventProcessor: Sendable {
 }
 
 final class SentryProvider: CrashReporterProvider {
-    private static var dsn: String? {
-        let value = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String
-        return value?.isEmpty == false ? value : nil
-    }
-
+    private let dsn: () -> String?
+    private let startSDK: (@escaping (Options) -> Void) -> Void
+    private let closeSDK: () -> Void
+    private var consent: SentryConsent?
     private var started = false
     private let appHangProcessor = AppHangEventProcessor()
+    init(
+        dsn: @escaping () -> String? = {
+            let value = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String
+            return value?.isEmpty == false ? value : nil
+        },
+        startSDK: @escaping (@escaping (Options) -> Void) -> Void = {
+            SentrySDK.start(configureOptions: $0)
+        },
+        closeSDK: @escaping () -> Void = SentrySDK.close
+    ) {
+        self.dsn = dsn
+        self.startSDK = startSDK
+        self.closeSDK = closeSDK
+    }
+    func start(consent: SentryConsent) { configure(for: consent) }
+    func setConsent(_ consent: SentryConsent) { configure(for: consent) }
 
-    func start(enabled: Bool) {
-        guard enabled, let dsn = Self.dsn else { return }
+    private func configure(for consent: SentryConsent) {
+        let previousConsent = self.consent
+        guard consent != previousConsent else { return }
+        self.consent = consent
+
+        if let previousConsent,
+           previousConsent.crashReporting == consent.crashReporting {
+            if consent.isEmpty {
+                stop()
+            } else if !started {
+                start(for: consent)
+            }
+            return
+        }
+
+        stop()
+        start(for: consent)
+    }
+
+    private func start(for consent: SentryConsent) {
+        guard !consent.isEmpty, let dsn = dsn() else { return }
+
         let appHangProcessor = appHangProcessor
-        SentrySDK.start { options in
+        startSDK { options in
             options.dsn = dsn
-            options.tracesSampleRate = 1.0
-            options.beforeSend = appHangProcessor.process
+            options.shutdownTimeInterval = 0
+            Self.configure(
+                options,
+                consent: consent,
+                appHangProcessor: appHangProcessor,
+                isCrashReportingEnabled: { CrashReporter.isEnabled },
+                isAnalyticsEnabled: { Analytics.isEnabled }
+            )
             #if DEBUG
             options.environment = "debug"
             #endif
@@ -264,12 +316,57 @@ final class SentryProvider: CrashReporterProvider {
         started = true
     }
 
-    func setEnabled(_ enabled: Bool) {
-        if enabled {
-            start(enabled: true)
-        } else {
-            SentrySDK.close()
-            started = false
+    private func stop() {
+        guard started else { return }
+        closeSDK()
+        started = false
+    }
+
+    static func configure(
+        _ options: Options,
+        consent: SentryConsent,
+        appHangProcessor: AppHangEventProcessor,
+        isCrashReportingEnabled: @escaping () -> Bool = { CrashReporter.isEnabled },
+        isAnalyticsEnabled: @escaping () -> Bool = { Analytics.isEnabled }
+    ) {
+        options.enableMetrics = true
+        options.beforeSendMetric = { metric in
+            guard isAnalyticsEnabled() else { return nil }
+            var metric = metric
+            metric.attributes.removeValue(forKey: "user.id")
+            metric.attributes.removeValue(forKey: "user.name")
+            metric.attributes.removeValue(forKey: "user.email")
+            return metric
+        }
+
+        guard consent.crashReporting else {
+            options.sampleRate = 0
+            options.tracesSampleRate = 0
+            options.enableCrashHandler = false
+            options.enableAutoSessionTracking = false
+            options.enableWatchdogTerminationTracking = false
+            options.enableAppHangTracking = false
+            options.enableAutoPerformanceTracing = false
+            options.enableNetworkTracking = false
+            options.enableFileIOTracing = false
+            options.enableCoreDataTracing = false
+            options.enableCaptureFailedRequests = false
+            options.enableAutoBreadcrumbTracking = false
+            options.enableNetworkBreadcrumbs = false
+            options.enableSwizzling = false
+            options.sendClientReports = false
+            options.beforeSend = { _ in nil }
+            options.beforeSendSpan = { _ in nil }
+            return
+        }
+
+        options.tracesSampleRate = 1.0
+        options.beforeSend = {
+            guard isCrashReportingEnabled() else { return nil }
+            return appHangProcessor.process($0)
+        }
+        options.beforeSendSpan = {
+            isCrashReportingEnabled() ? $0 : nil
         }
     }
 

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -116,10 +116,7 @@ struct ContentView: View {
                 searchSignalTask = Task {
                     try? await Task.sleep(for: .seconds(2))
                     guard !Task.isCancelled else { return }
-                    Analytics.searchPerformed(
-                        query: newValue,
-                        results: viewModel.filteredCasks.count
-                    )
+                    Analytics.searchPerformed(results: viewModel.filteredCasks.count)
                 }
             }
             if newValue.isEmpty {

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -366,8 +366,8 @@ final class SpyCrashReporterProvider: CrashReporterProvider {
         let span: SpyCrashSpan
     }
 
-    var startedWith: [Bool] = []
-    var enabledChanges: [Bool] = []
+    var startedWith: [SentryConsent] = []
+    var consentChanges: [SentryConsent] = []
     var capturedErrors: [Error] = []
     var breadcrumbs: [(message: String, data: [String: String])] = []
     var tags: [String: String] = [:]
@@ -382,12 +382,12 @@ final class SpyCrashReporterProvider: CrashReporterProvider {
         hangTrackingEvents.append("resume")
     }
 
-    func start(enabled: Bool) {
-        startedWith.append(enabled)
+    func start(consent: SentryConsent) {
+        startedWith.append(consent)
     }
 
-    func setEnabled(_ enabled: Bool) {
-        enabledChanges.append(enabled)
+    func setConsent(_ consent: SentryConsent) {
+        consentChanges.append(consent)
     }
 
     func capture(_ error: Error) {

--- a/CaskHubTests/Telemetry/AnalyticsTests.swift
+++ b/CaskHubTests/Telemetry/AnalyticsTests.swift
@@ -6,42 +6,86 @@
 //
 
 @testable import CaskHub
+import Sentry
+import TelemetryDeck
 import XCTest
 
-private final class SpyAnalyticsProvider: AnalyticsProvider {
+private final class SpyAnalyticsProvider: AnalyticsProvider, SentryMetricsApiProtocol {
     var startedWith: [Bool] = []
     var enabledChanges: [Bool] = []
     var signals: [(name: String, parameters: [String: String])] = []
+    var metricKeys: [String] = []
+    var metricValues: [UInt] = []
+    var metricAttributes: [[String: SentryAttributeContent]] = []
 
     func start(enabled: Bool) { startedWith.append(enabled) }
     func setEnabled(_ enabled: Bool) { enabledChanges.append(enabled) }
-    func send(_ signalName: String, parameters: [String: String]) {
-        signals.append((signalName, parameters))
+
+    func count(
+        key: String,
+        value: UInt,
+        attributes: [String: SentryAttributeValue]
+    ) {
+        let attributes = attributes.mapValues { $0.asSentryAttributeContent }
+        metricKeys.append(key)
+        metricValues.append(value)
+        metricAttributes.append(attributes)
+
+        guard case let .string(name)? = attributes["event.name"] else { return }
+        let parameters = attributes.reduce(into: [String: String]()) { result, attribute in
+            guard attribute.key.hasPrefix("event."), attribute.key != "event.name",
+                  case let .string(value) = attribute.value
+            else { return }
+            result[String(attribute.key.dropFirst("event.".count))] = value
+        }
+        signals.append((name, parameters))
     }
+
+    func distribution(
+        key _: String,
+        value _: Double,
+        unit _: SentryUnit?,
+        attributes _: [String: SentryAttributeValue]
+    ) {}
+
+    func gauge(
+        key _: String,
+        value _: Double,
+        unit _: SentryUnit?,
+        attributes _: [String: SentryAttributeValue]
+    ) {}
 }
 
 final class AnalyticsTests: XCTestCase {
     private var spy: SpyAnalyticsProvider!
     private var originalProvider: AnalyticsProvider!
+    private var originalMetrics: SentryMetricsApiProtocol!
+    private var originalAnalyticsDefaults: UserDefaults!
     private var originalCrashDefaults: UserDefaults!
 
     override func setUp() {
         super.setUp()
         spy = SpyAnalyticsProvider()
         originalProvider = Analytics.provider
+        originalMetrics = Analytics.metrics
+        originalAnalyticsDefaults = Analytics.defaults
         originalCrashDefaults = CrashReporter.defaults
         Analytics.provider = spy
+        Analytics.metrics = spy
+        Analytics.defaults = makeScratchDefaults(
+            "analytics-\(ProcessInfo.processInfo.processIdentifier)"
+        )
         CrashReporter.defaults = makeScratchDefaults(
             "analytics-crash-\(ProcessInfo.processInfo.processIdentifier)"
         )
         Analytics.openedPages.removeAll()
-        UserDefaults.standard.removeObject(forKey: Analytics.enabledKey)
     }
 
     override func tearDown() {
         Analytics.provider = originalProvider
+        Analytics.metrics = originalMetrics
+        Analytics.defaults = originalAnalyticsDefaults
         CrashReporter.defaults = originalCrashDefaults
-        UserDefaults.standard.removeObject(forKey: Analytics.enabledKey)
         super.tearDown()
     }
 
@@ -56,22 +100,32 @@ final class AnalyticsTests: XCTestCase {
     }
 
     func test_is_enabled_reflects_stored_opt_out() {
-        UserDefaults.standard.set(false, forKey: Analytics.enabledKey)
+        Analytics.defaults.set(false, forKey: Analytics.enabledKey)
         XCTAssertFalse(Analytics.isEnabled)
     }
 
     func test_start_passes_stored_setting_to_provider() {
-        UserDefaults.standard.set(false, forKey: Analytics.enabledKey)
+        Analytics.defaults.set(false, forKey: Analytics.enabledKey)
         Analytics.start()
         XCTAssertEqual(spy.startedWith, [false])
     }
 
     func test_refresh_forwards_current_setting_to_provider() {
-        UserDefaults.standard.set(false, forKey: Analytics.enabledKey)
+        Analytics.defaults.set(false, forKey: Analytics.enabledKey)
         Analytics.refresh()
-        UserDefaults.standard.set(true, forKey: Analytics.enabledKey)
+        Analytics.defaults.set(true, forKey: Analytics.enabledKey)
         Analytics.refresh()
         XCTAssertEqual(spy.enabledChanges, [false, true])
+    }
+
+    func test_custom_event_routes_to_one_sentry_counter() {
+        Analytics.viewModeChanged(.list)
+
+        XCTAssertEqual(spy.metricKeys, [Analytics.metricKey])
+        XCTAssertEqual(spy.metricValues, [1])
+        XCTAssertEqual(spy.metricAttributes.first?["event.name"], .string("View.modeChanged"))
+        XCTAssertEqual(spy.metricAttributes.first?["schema.version"], .integer(1))
+        XCTAssertTrue(spy.startedWith.isEmpty)
     }
 
     // MARK: - Cask action events
@@ -197,8 +251,22 @@ final class AnalyticsTests: XCTestCase {
         XCTAssertEqual(lastSignal?.parameters, ["count": "3"])
     }
 
-    func test_uninitialized_telemetry_provider_drops_signals() {
-        TelemetryDeckProvider().send("Test.signal", parameters: [:])
+    func test_telemetry_provider_keeps_automatic_lifecycle_and_honors_consent() {
+        var config: TelemetryDeck.Config?
+        let provider = TelemetryDeckProvider(
+            appID: { "test-app-id" },
+            initialize: { config = $0 }
+        )
+
+        provider.start(enabled: false)
+
+        XCTAssertTrue(config?.analyticsDisabled == true)
+        XCTAssertTrue(config?.sendNewSessionBeganSignal == true)
+        XCTAssertTrue(config?.sessionStatsEnabled == true)
+
+        provider.setEnabled(true)
+
+        XCTAssertTrue(config?.analyticsDisabled == false)
     }
 
     // MARK: - Navigation events
@@ -259,10 +327,10 @@ final class AnalyticsTests: XCTestCase {
 
     // MARK: - Search
 
-    func test_search_performed_normalizes_query_and_counts_results() {
-        Analytics.searchPerformed(query: "  FireFox ", results: 3)
+    func test_search_performed_counts_results_without_search_text() {
+        Analytics.searchPerformed(results: 3)
         XCTAssertEqual(lastSignal?.name, "Search.performed")
-        XCTAssertEqual(lastSignal?.parameters, ["query": "firefox", "results": "3"])
+        XCTAssertEqual(lastSignal?.parameters, ["results": "3"])
     }
 
     // MARK: - Filters, view mode & settings
@@ -300,10 +368,11 @@ final class AnalyticsTests: XCTestCase {
         let originalCrash = CrashReporter.provider
         CrashReporter.provider = crashSpy
         defer { CrashReporter.provider = originalCrash }
-        UserDefaults.standard.set(false, forKey: Analytics.enabledKey)
+        Analytics.defaults.set(false, forKey: Analytics.enabledKey)
 
         Analytics.send("Page.opened", parameters: ["page": "installed"])
 
+        XCTAssertTrue(spy.signals.isEmpty)
         XCTAssertEqual(crashSpy.breadcrumbs.last?.message, "Page.opened")
         XCTAssertEqual(crashSpy.breadcrumbs.last?.data, ["page": "installed"])
     }

--- a/CaskHubTests/Telemetry/AppHangReportingTests.swift
+++ b/CaskHubTests/Telemetry/AppHangReportingTests.swift
@@ -7,10 +7,183 @@
 
 @testable import CaskHub
 import AppKit
-import Sentry
+@_spi(Private) import Sentry
 import XCTest
 
 extension CrashReporterTests {
+    func test_start_passes_crash_and_analytics_consent_to_provider() {
+        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
+        CrashReporter.start()
+        XCTAssertEqual(spy.startedWith, [SentryConsent(
+            crashReporting: false,
+            analytics: true
+        )])
+    }
+
+    func test_refresh_covers_all_consent_combinations() {
+        let consents = [
+            SentryConsent(crashReporting: true, analytics: true),
+            SentryConsent(crashReporting: true, analytics: false),
+            SentryConsent(crashReporting: false, analytics: true),
+            SentryConsent(crashReporting: false, analytics: false)
+        ]
+
+        for consent in consents {
+            CrashReporter.defaults.set(
+                consent.crashReporting,
+                forKey: CrashReporter.enabledKey
+            )
+            Analytics.defaults.set(consent.analytics, forKey: Analytics.enabledKey)
+            CrashReporter.refresh()
+        }
+
+        XCTAssertEqual(spy.consentChanges, consents)
+    }
+
+    func test_sentry_options_support_metrics_without_crash_reporting() {
+        let options = Options()
+
+        SentryProvider.configure(
+            options,
+            consent: SentryConsent(crashReporting: false, analytics: true),
+            appHangProcessor: AppHangEventProcessor()
+        )
+
+        XCTAssertTrue(options.enableMetrics)
+        XCTAssertNotNil(options.beforeSendMetric)
+        XCTAssertEqual(options.sampleRate?.doubleValue, 0)
+        XCTAssertEqual(options.tracesSampleRate?.doubleValue, 0)
+        XCTAssertFalse(options.enableCrashHandler)
+        XCTAssertFalse(options.enableAutoSessionTracking)
+        XCTAssertFalse(options.enableWatchdogTerminationTracking)
+        XCTAssertFalse(options.enableAppHangTracking)
+        XCTAssertFalse(options.enableAutoPerformanceTracing)
+        XCTAssertFalse(options.enableCaptureFailedRequests)
+        XCTAssertFalse(options.enableAutoBreadcrumbTracking)
+        XCTAssertFalse(options.enableNetworkBreadcrumbs)
+        XCTAssertFalse(options.enableSwizzling)
+        XCTAssertFalse(options.sendClientReports)
+    }
+
+    func test_sentry_options_keep_metrics_ready_without_analytics_consent() {
+        let options = Options()
+
+        SentryProvider.configure(
+            options,
+            consent: SentryConsent(crashReporting: true, analytics: false),
+            appHangProcessor: AppHangEventProcessor()
+        )
+
+        XCTAssertTrue(options.enableMetrics)
+        XCTAssertTrue(options.enableCrashHandler)
+        XCTAssertTrue(options.enableAutoSessionTracking)
+        XCTAssertTrue(options.enableAppHangTracking)
+        XCTAssertEqual(options.tracesSampleRate?.doubleValue, 1)
+        XCTAssertNotNil(options.beforeSend)
+    }
+
+    func test_metric_filter_strips_user_identifiers_and_honors_current_consent() throws {
+        var analyticsEnabled = true
+        let options = Options()
+        SentryProvider.configure(
+            options,
+            consent: SentryConsent(crashReporting: false, analytics: true),
+            appHangProcessor: AppHangEventProcessor(),
+            isAnalyticsEnabled: { analyticsEnabled }
+        )
+        let metric = SentryMetric(
+            timestamp: Date(),
+            traceId: SentryId(),
+            name: Analytics.metricKey,
+            value: .counter(1),
+            unit: nil,
+            attributes: [
+                "event.name": .string("View.modeChanged"),
+                "user.id": .string("installation-id"),
+                "user.name": .string("account-name"),
+                "user.email": .string("ali@example.com")
+            ]
+        )
+
+        let filtered = try XCTUnwrap(options.beforeSendMetric?(metric))
+        XCTAssertEqual(filtered.attributes["event.name"], .string("View.modeChanged"))
+        XCTAssertNil(filtered.attributes["user.id"])
+        XCTAssertNil(filtered.attributes["user.name"])
+        XCTAssertNil(filtered.attributes["user.email"])
+
+        analyticsEnabled = false
+        XCTAssertNil(options.beforeSendMetric?(metric))
+    }
+
+    func test_analytics_consent_changes_do_not_restart_sentry() {
+        var options: [Options] = []
+        var closeCount = 0
+        let provider = SentryProvider(
+            dsn: { "https://public@example.com/1" },
+            startSDK: {
+                let configured = Options()
+                $0(configured)
+                options.append(configured)
+            },
+            closeSDK: { closeCount += 1 }
+        )
+
+        provider.start(consent: SentryConsent(crashReporting: true, analytics: true))
+        provider.setConsent(SentryConsent(crashReporting: true, analytics: false))
+        provider.setConsent(SentryConsent(crashReporting: true, analytics: true))
+
+        XCTAssertEqual(options.count, 1)
+        XCTAssertEqual(closeCount, 0)
+        XCTAssertTrue(options[0].enableMetrics)
+        XCTAssertEqual(options[0].shutdownTimeInterval, 0)
+    }
+
+    func test_crash_consent_change_restarts_sentry_without_blocking() {
+        var options: [Options] = []
+        var lifecycle: [String] = []
+        let provider = SentryProvider(
+            dsn: { "https://public@example.com/1" },
+            startSDK: {
+                lifecycle.append("start")
+                let configured = Options()
+                $0(configured)
+                options.append(configured)
+            },
+            closeSDK: { lifecycle.append("close") }
+        )
+
+        provider.start(consent: SentryConsent(crashReporting: true, analytics: true))
+        provider.setConsent(SentryConsent(crashReporting: false, analytics: true))
+
+        XCTAssertEqual(options.count, 2)
+        XCTAssertEqual(lifecycle, ["start", "close", "start"])
+        XCTAssertTrue(options[0].enableCrashHandler)
+        XCTAssertFalse(options[1].enableCrashHandler)
+        XCTAssertEqual(options.map(\.shutdownTimeInterval), [0, 0])
+    }
+
+    func test_metrics_only_opt_out_closes_before_reenable() {
+        var options: [Options] = []
+        var lifecycle: [String] = []
+        let provider = SentryProvider(
+            dsn: { "https://public@example.com/1" },
+            startSDK: {
+                lifecycle.append("start")
+                let configured = Options()
+                $0(configured)
+                options.append(configured)
+            },
+            closeSDK: { lifecycle.append("close") }
+        )
+
+        provider.start(consent: SentryConsent(crashReporting: false, analytics: true))
+        provider.setConsent(SentryConsent(crashReporting: false, analytics: false))
+        provider.setConsent(SentryConsent(crashReporting: false, analytics: true))
+
+        XCTAssertEqual(options.count, 2)
+        XCTAssertEqual(lifecycle, ["start", "close", "start"])
+    }
+
     func test_paused_scope_brackets_the_body() {
         activateHangTracking()
 

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -11,6 +11,7 @@ import XCTest
 private struct CrashReporterTestState {
     let provider: CrashReporterProvider
     let defaults: UserDefaults
+    let analyticsDefaults: UserDefaults
     let captureCounts: [String: Int]
     let applicationActive: Bool
     let pauseDepth: Int
@@ -27,6 +28,7 @@ final class CrashReporterTests: XCTestCase {
         originalState = CrashReporterTestState(
             provider: CrashReporter.provider,
             defaults: CrashReporter.defaults,
+            analyticsDefaults: Analytics.defaults,
             captureCounts: CrashReporter.captureCounts,
             applicationActive: CrashReporter.isApplicationActive,
             pauseDepth: CrashReporter.hangTrackingPauseDepth,
@@ -35,6 +37,9 @@ final class CrashReporterTests: XCTestCase {
         CrashReporter.provider = spy
         CrashReporter.defaults = makeScratchDefaults(
             "crash-reporter-\(ProcessInfo.processInfo.processIdentifier)"
+        )
+        Analytics.defaults = makeScratchDefaults(
+            "crash-reporter-analytics-\(ProcessInfo.processInfo.processIdentifier)"
         )
         CrashReporter.captureCounts = [:]
         CrashReporter.isApplicationActive = false
@@ -45,6 +50,7 @@ final class CrashReporterTests: XCTestCase {
     override func tearDown() {
         CrashReporter.provider = originalState.provider
         CrashReporter.defaults = originalState.defaults
+        Analytics.defaults = originalState.analyticsDefaults
         CrashReporter.captureCounts = originalState.captureCounts
         CrashReporter.isApplicationActive = originalState.applicationActive
         CrashReporter.hangTrackingPauseDepth = originalState.pauseDepth
@@ -61,20 +67,6 @@ final class CrashReporterTests: XCTestCase {
     func test_is_enabled_reflects_stored_opt_out() {
         CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
         XCTAssertFalse(CrashReporter.isEnabled)
-    }
-
-    func test_start_passes_stored_setting_to_provider() {
-        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
-        CrashReporter.start()
-        XCTAssertEqual(spy.startedWith, [false])
-    }
-
-    func test_refresh_forwards_current_setting_to_provider() {
-        CrashReporter.defaults.set(false, forKey: CrashReporter.enabledKey)
-        CrashReporter.refresh()
-        CrashReporter.defaults.set(true, forKey: CrashReporter.enabledKey)
-        CrashReporter.refresh()
-        XCTAssertEqual(spy.enabledChanges, [false, true])
     }
 
     // MARK: - Capture + consent
@@ -162,7 +154,7 @@ final class CrashReporterTests: XCTestCase {
         CrashReporter.start()
         CrashReporter.refresh()
         XCTAssertTrue(spy.startedWith.isEmpty)
-        XCTAssertTrue(spy.enabledChanges.isEmpty)
+        XCTAssertTrue(spy.consentChanges.isEmpty)
     }
 
     func test_environmental_errors_are_never_captured() {

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Select the **CaskHub** scheme and run (⌘R). Xcode resolves the Swift package d
 - **SwiftUI + MVVM** with `@Observable` view models and `@MainActor` isolation
 - **Protocol-based networking layer** for testability (`BrewAPIClientProtocol`, `NetworkServiceProtocol`) with dependency injection throughout
 - **Two-tier icon caching** (memory + disk) and HTTP-header-based download-size resolution
-- **Minimal dependencies** - three focused packages: [Sparkle](https://sparkle-project.org) for app updates, [Sentry](https://sentry.io) for crash reporting, and [TelemetryDeck](https://telemetrydeck.com) for analytics
+- **Minimal dependencies** - three focused packages: [Sparkle](https://sparkle-project.org) for app updates, [Sentry](https://sentry.io) for crash reporting and usage metrics, and [TelemetryDeck](https://telemetrydeck.com) for session and acquisition analytics
 
 ## Testing & CI
 
@@ -97,11 +97,11 @@ xcodebuild test -project CaskHub.xcodeproj -scheme CaskHub -destination 'platfor
 
 ## Privacy & Analytics
 
-CaskHub collects anonymous usage analytics through [TelemetryDeck](https://telemetrydeck.com), a privacy-first analytics service. No personal data or identifiers ever leave your Mac: user IDs are salted and hashed on-device, and there is no tracking across apps or websites.
+CaskHub sends anonymous usage metrics through [Sentry](https://sentry.io). [TelemetryDeck](https://telemetrydeck.com) receives only anonymous session and new-install signals used for acquisition and retention reporting.
 
-CaskHub also sends anonymous crash reports through [Sentry](https://sentry.io) to help diagnose and fix stability issues.
+CaskHub also sends crash reports and technical diagnostics through [Sentry](https://sentry.io) to help diagnose and fix stability issues.
 
-You can opt out of both at any time in **Settings → Privacy**.
+You can opt out of everything at any time in **Settings → Privacy**.
 
 ## Localization
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -473,7 +473,7 @@
       <div class="card">
         <span class="icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-3.5 8-10V5l-8-3-8 3v7c0 6.5 8 10 8 10Z"/></svg></span>
         <h3>Private by default</h3>
-        <p>Anonymous, privacy-first analytics with IDs salted and hashed on-device. No personal data ever leaves your Mac, and you can opt out of everything in Settings → Privacy.</p>
+        <p>Anonymous usage metrics, with TelemetryDeck limited to anonymous session and new-install reporting. You can opt out of everything in Settings → Privacy.</p>
       </div>
       <div class="card">
         <span class="icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 8-4 4 4 4"/><path d="m15 8 4 4-4 4"/></svg></span>


### PR DESCRIPTION
## Summary

- Route custom usage events to the Sentry counter caskhub.analytics.event.
- Keep TelemetryDeck limited to automatic session and new-install signals.
- Support independent usage-analytics and crash-reporting consent, including metrics-only Sentry operation.
- Strip user identifiers from metrics and omit search text from analytics.
- Update in-app, README, and website privacy disclosures.

## Verification

- [x] swiftlint lint --strict --quiet
- [x] Full macOS xcodebuild test suite
- [x] Signed Debug build
- [x] App launch and process smoke check
- [x] Debug View.modeChanged metric confirmed in Sentry before release

## Checklist

- [x] Base branch is develop
- [x] Conventional, sentence-case title
- [x] Tests added or updated
- [x] SwiftLint build phase passes locally
- [x] No changes to CaskHub/Resources/*.json or CHANGELOG.md