### PR TITLE
feat: Brewfile export and import in Shelf Setup

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -64,6 +64,9 @@
 		7FFA89946C514C00BF5496DB /* BrewOutputCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5317A6659E48459EB3FFB7EB /* BrewOutputCollector.swift */; };
 		A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000001 /* LocalHomebrewTypes.swift */; };
 		A12000000000000000000005 /* CaskAdoptionPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000005 /* CaskAdoptionPlan.swift */; };
+		AF11E0000000000000000001 /* Brewfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF11E0000000000000000001 /* Brewfile.swift */; };
+		AF11E0000000000000000003 /* BrewfileImportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF11E0000000000000000003 /* BrewfileImportSheet.swift */; };
+		AF11E0000000000000000002 /* BrewfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF11E0000000000000000002 /* BrewfileTests.swift */; };
 		A12000000000000000000007 /* CaskAdoptionPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000006 /* CaskAdoptionPlanTests.swift */; };
 		A12000000000000000000009 /* CaskAdoptionWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000008 /* CaskAdoptionWorkflowTests.swift */; };
 		B0E000000000000000000002 /* LocalHomebrewError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E000000000000000000001 /* LocalHomebrewError.swift */; };
@@ -237,6 +240,9 @@
 		B0C000000000000000000004 /* ShelfSetupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelfSetupViewTests.swift; sourceTree = "<group>"; };
 		B12000000000000000000001 /* LocalHomebrewTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewTypes.swift; sourceTree = "<group>"; };
 		B12000000000000000000005 /* CaskAdoptionPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskAdoptionPlan.swift; sourceTree = "<group>"; };
+		BF11E0000000000000000001 /* Brewfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Brewfile.swift; sourceTree = "<group>"; };
+		BF11E0000000000000000003 /* BrewfileImportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewfileImportSheet.swift; sourceTree = "<group>"; };
+		BF11E0000000000000000002 /* BrewfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewfileTests.swift; sourceTree = "<group>"; };
 		B12000000000000000000006 /* CaskAdoptionPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskAdoptionPlanTests.swift; sourceTree = "<group>"; };
 		B12000000000000000000008 /* CaskAdoptionWorkflowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskAdoptionWorkflowTests.swift; sourceTree = "<group>"; };
 		B0E000000000000000000001 /* LocalHomebrewError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHomebrewError.swift; sourceTree = "<group>"; };
@@ -539,6 +545,7 @@
 		B0C000000000000000000003 /* Manage */ = {
 			isa = PBXGroup;
 			children = (
+				BF11E0000000000000000003 /* BrewfileImportSheet.swift */,
 				B0C000000000000000000001 /* ShelfSetupView.swift */,
 			);
 			path = Manage;
@@ -627,6 +634,7 @@
 		F32000000000000000000018 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				BF11E0000000000000000001 /* Brewfile.swift */,
 				B12000000000000000000005 /* CaskAdoptionPlan.swift */,
 				E24000000000000000000001 /* CaskOperationProgress.swift */,
 				E29000000000000000000001 /* CaskOperationState.swift */,
@@ -766,6 +774,7 @@
 		F32000000000000000000026 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				BF11E0000000000000000002 /* BrewfileTests.swift */,
 				B12000000000000000000006 /* CaskAdoptionPlanTests.swift */,
 				E24000000000000000000003 /* CaskOperationProgressTests.swift */,
 				E29000000000000000000003 /* CaskOperationStateTests.swift */,
@@ -1017,6 +1026,8 @@
 				C15000000000000000000002 /* InstallationCatalogBuilder.swift in Sources */,
 				A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */,
 				A12000000000000000000005 /* CaskAdoptionPlan.swift in Sources */,
+				AF11E0000000000000000001 /* Brewfile.swift in Sources */,
+				AF11E0000000000000000003 /* BrewfileImportSheet.swift in Sources */,
 				B0F000000000000000000002 /* HomebrewCommandFailure.swift in Sources */,
 				B0E000000000000000000002 /* LocalHomebrewError.swift in Sources */,
 				F24000000000000000000001 /* CaskOperationProgress.swift in Sources */,
@@ -1091,6 +1102,7 @@
 				FC77AC4ED839460894E8ED53 /* AdoptionTests.swift in Sources */,
 				A12000000000000000000009 /* CaskAdoptionWorkflowTests.swift in Sources */,
 				A12000000000000000000007 /* CaskAdoptionPlanTests.swift in Sources */,
+				AF11E0000000000000000002 /* BrewfileTests.swift in Sources */,
 				F26000000000000000000001 /* CaskListActionTests.swift in Sources */,
 				F24000000000000000000003 /* CaskOperationProgressTests.swift in Sources */,
 				F29000000000000000000003 /* CaskOperationStateTests.swift in Sources */,

--- a/CaskHub/Resources/Localizable.xcstrings
+++ b/CaskHub/Resources/Localizable.xcstrings
@@ -1254,6 +1254,16 @@
         }
       }
     },
+    "Currently selected brew path is invalid" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前选择的 brew 路径无效"
+          }
+        }
+      }
+    },
     "Custom brew path" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1861,6 +1871,56 @@
     "Homebrew" : {
       "shouldTranslate" : false
     },
+    "Homebrew could not extract this disk image because its layout is read-only. Try again once; if it repeats, the cask needs to be corrected upstream." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 无法提取此磁盘映像，因为其布局为只读。请重试一次；如果问题再次出现，则需要由上游修正该 Cask。"
+          }
+        }
+      }
+    },
+    "Homebrew could not prepare its Portable Ruby runtime. Check access to GitHub and GHCR, then update Homebrew and try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 无法准备 Portable Ruby 运行环境。请检查能否访问 GitHub 和 GHCR，然后更新 Homebrew 并重试。"
+          }
+        }
+      }
+    },
+    "Homebrew could not reach a required download host. Check your network, VPN, proxy, and DNS settings, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 无法访问所需的下载主机。请检查网络、VPN、代理和 DNS 设置，然后重试。"
+          }
+        }
+      }
+    },
+    "Homebrew could not write to one of its temporary or installation folders. Run `brew doctor`, correct the permissions it reports, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 无法写入其临时目录或安装目录。请运行 `brew doctor`，修正它报告的权限问题，然后重试。"
+          }
+        }
+      }
+    },
+    "Homebrew found an existing item at the destination. Remove or move that item manually, then try again.\n\n%@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 在目标位置发现了现有项目。请手动移除或移动该项目，然后重试。\n\n%@"
+          }
+        }
+      }
+    },
     "Homebrew is available: %@" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1905,12 +1965,42 @@
         }
       }
     },
+    "Homebrew tried to run code for the wrong processor architecture. Select the compatible Homebrew path in Settings, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 尝试为错误的处理器架构运行代码。请在设置中选择兼容的 Homebrew 路径，然后重试。"
+          }
+        }
+      }
+    },
+    "Homebrew Update Failed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homebrew 更新失败"
+          }
+        }
+      }
+    },
     "Homebrew was not found on this Mac." : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "此 Mac 上未找到 Homebrew。"
+          }
+        }
+      }
+    },
+    "Homebrew's temporary download state changed while the operation was finishing. Try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作即将完成时，Homebrew 的临时下载状态发生了变化。请重试。"
           }
         }
       }
@@ -2142,6 +2232,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加载中…"
+          }
+        }
+      }
+    },
+    "macOS canceled opening the disk image. Try again and approve the disk image if macOS asks for confirmation." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS 取消了打开磁盘映像。请重试；如果 macOS 要求确认，请允许打开该磁盘映像。"
           }
         }
       }
@@ -2721,6 +2821,366 @@
         }
       }
     },
+    "shelfSetup.brewfile.export.button" : {
+      "comment" : "Button that saves the shelf as a Brewfile",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出…"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.export.description" : {
+      "comment" : "Explains Brewfile export; count of managed casks",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Write the %lld casks CaskHub manages to a Brewfile. Your setup, portable."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "把 CaskHub 管理的 %lld 个 cask 写入 Brewfile。你的配置，随身携带。"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.export.failed" : {
+      "comment" : "Shown under the export row when writing the file fails",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't save the Brewfile."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法保存 Brewfile。"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.export.saved" : {
+      "comment" : "Shown under the export row after saving; path then cask count",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saved to %1$@ · %2$lld casks"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存到 %1$@ · %2$lld 个 cask"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.export.title" : {
+      "comment" : "Title of the Brewfile export row",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export your shelf"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出你的酒架"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.import.button" : {
+      "comment" : "Button that opens the Brewfile picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose file…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择文件…"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.import.description" : {
+      "comment" : "Explains Brewfile import",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pour every cask a Brewfile lists. Perfect for a new Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "装入 Brewfile 列出的每个 cask，新 Mac 的完美起点。"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.import.empty" : {
+      "comment" : "Shown under the import row when the chosen file lists no casks",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No casks found in that Brewfile."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该 Brewfile 中未找到 cask。"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.import.title" : {
+      "comment" : "Title of the Brewfile import row",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import a Brewfile"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入 Brewfile"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.deselectAll" : {
+      "comment" : "Header checkbox label when every listed cask is selected",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deselect All"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消全选"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.done" : {
+      "comment" : "Import sheet success message; count of casks installed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All %lld poured. Your shelf matches the Brewfile."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部 %lld 个已装入。你的酒架与 Brewfile 一致。"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.doneWithFailures" : {
+      "comment" : "Import sheet completion when some installs failed: succeeded, total, failed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld poured, %3$lld failed."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lld 个中已装入 %1$lld 个，%3$lld 个失败。"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.installButton" : {
+      "comment" : "Import sheet confirm button; count of casks not yet on the shelf",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Install %lld new"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安装 %lld 个新应用"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.nothingNew" : {
+      "comment" : "Import sheet message when every listed cask is already present",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing new to pour. Everything listed is already on this Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有新内容，列出的应用都已安装在这台 Mac 上。"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.pouring" : {
+      "comment" : "Import progress: cask name, current index, total",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pouring %1$@… (%2$lld of %3$lld)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在装入 %1$@…（%2$lld/%3$lld）"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.selectAll" : {
+      "comment" : "Header checkbox label when some listed casks are deselected",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select All"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全选"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.skipped" : {
+      "comment" : "Import sheet section header; count of casks already installed on this Mac (brew, App Store, or external)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld already on your machine, skipped"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个已安装在这台 Mac 上，已跳过"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.subtitle" : {
+      "comment" : "Import sheet subtitle: file path, cask count",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$lld casks listed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · 共列出 %2$lld 个 cask"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.sheet.title" : {
+      "comment" : "Title of the Brewfile import sheet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import Casks"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入 Cask"
+          }
+        }
+      }
+    },
+    "shelfSetup.brewfile.title" : {
+      "comment" : "Section title of the Brewfile card on Shelf Setup",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brewfile"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brewfile"
+          }
+        }
+      }
+    },
     "shelfSetup.ignore.addButton" : {
       "comment" : "Button opening the picker of adoptable apps to ignore",
       "extractionState" : "manual",
@@ -3075,6 +3535,26 @@
         }
       }
     },
+    "The disk image is already in use. Eject any mounted copy of it, then try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此磁盘映像正在使用中。请推出已挂载的副本，然后重试。"
+          }
+        }
+      }
+    },
+    "The download is missing valid macOS quarantine metadata. Remove the cached download and let Homebrew download it again; do not bypass the security check." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载内容缺少有效的 macOS 隔离属性。请删除缓存的下载内容，让 Homebrew 重新下载；不要绕过此安全检查。"
+          }
+        }
+      }
+    },
     "The installer for “%@” requires your login password." : {
       "localizations" : {
         "zh-Hans" : {
@@ -3085,12 +3565,12 @@
         }
       }
     },
-    "Currently selected brew path is invalid" : {
+    "There is not enough free storage to complete this operation. Free some space, then try again." : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当前选择的 brew 路径无效"
+            "value" : "可用存储空间不足，无法完成此操作。请释放一些空间，然后重试。"
           }
         }
       }
@@ -3101,6 +3581,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此应用不支持这台 Mac 的处理器架构或 macOS 版本。"
+          }
+        }
+      }
+    },
+    "This Homebrew installation cannot read the current cask definition. Update Homebrew, then try again. If it still fails, run `brew doctor` in Terminal." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 Homebrew 安装无法读取当前的 Cask 定义。请更新 Homebrew 后重试。如果仍然失败，请在“终端”中运行 `brew doctor`。"
           }
         }
       }
@@ -3225,6 +3715,16 @@
         }
       }
     },
+    "Update Homebrew" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新 Homebrew"
+          }
+        }
+      }
+    },
     "Updates" : {
       "localizations" : {
         "zh-Hans" : {
@@ -3251,6 +3751,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在更新 %lld/%lld"
+          }
+        }
+      }
+    },
+    "Updating Homebrew…" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在更新 Homebrew…"
           }
         }
       }
@@ -3376,152 +3886,22 @@
         }
       }
     },
-    "Homebrew could not extract this disk image because its layout is read-only. Try again once; if it repeats, the cask needs to be corrected upstream." : {
+    "Year" : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Homebrew 无法提取此磁盘映像，因为其布局为只读。请重试一次；如果问题再次出现，则需要由上游修正该 Cask。"
+            "value" : "一年"
           }
         }
       }
     },
-    "Homebrew could not prepare its Portable Ruby runtime. Check access to GitHub and GHCR, then update Homebrew and try again." : {
+    "Yes" : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Homebrew 无法准备 Portable Ruby 运行环境。请检查能否访问 GitHub 和 GHCR，然后更新 Homebrew 并重试。"
-          }
-        }
-      }
-    },
-    "Homebrew could not reach a required download host. Check your network, VPN, proxy, and DNS settings, then try again." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Homebrew 无法访问所需的下载主机。请检查网络、VPN、代理和 DNS 设置，然后重试。"
-          }
-        }
-      }
-    },
-    "Homebrew could not write to one of its temporary or installation folders. Run `brew doctor`, correct the permissions it reports, then try again." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Homebrew 无法写入其临时目录或安装目录。请运行 `brew doctor`，修正它报告的权限问题，然后重试。"
-          }
-        }
-      }
-    },
-    "Homebrew found an existing item at the destination. Remove or move that item manually, then try again.\n\n%@" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Homebrew 在目标位置发现了现有项目。请手动移除或移动该项目，然后重试。\n\n%@"
-          }
-        }
-      }
-    },
-    "Homebrew Update Failed" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Homebrew 更新失败"
-          }
-        }
-      }
-    },
-    "Homebrew tried to run code for the wrong processor architecture. Select the compatible Homebrew path in Settings, then try again." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Homebrew 尝试为错误的处理器架构运行代码。请在设置中选择兼容的 Homebrew 路径，然后重试。"
-          }
-        }
-      }
-    },
-    "Homebrew's temporary download state changed while the operation was finishing. Try again." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作即将完成时，Homebrew 的临时下载状态发生了变化。请重试。"
-          }
-        }
-      }
-    },
-    "macOS canceled opening the disk image. Try again and approve the disk image if macOS asks for confirmation." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macOS 取消了打开磁盘映像。请重试；如果 macOS 要求确认，请允许打开该磁盘映像。"
-          }
-        }
-      }
-    },
-    "The disk image is already in use. Eject any mounted copy of it, then try again." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此磁盘映像正在使用中。请推出已挂载的副本，然后重试。"
-          }
-        }
-      }
-    },
-    "The download is missing valid macOS quarantine metadata. Remove the cached download and let Homebrew download it again; do not bypass the security check." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载内容缺少有效的 macOS 隔离属性。请删除缓存的下载内容，让 Homebrew 重新下载；不要绕过此安全检查。"
-          }
-        }
-      }
-    },
-    "There is not enough free storage to complete this operation. Free some space, then try again." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可用存储空间不足，无法完成此操作。请释放一些空间，然后重试。"
-          }
-        }
-      }
-    },
-    "This Homebrew installation cannot read the current cask definition. Update Homebrew, then try again. If it still fails, run `brew doctor` in Terminal." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此 Homebrew 安装无法读取当前的 Cask 定义。请更新 Homebrew 后重试。如果仍然失败，请在“终端”中运行 `brew doctor`。"
-          }
-        }
-      }
-    },
-    "Update Homebrew" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新 Homebrew"
-          }
-        }
-      }
-    },
-    "Updating Homebrew…" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在更新 Homebrew…"
+            "value" : "是"
           }
         }
       }
@@ -3542,26 +3922,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你的 Homebrew 设置要求校验和，但此 Cask 使用不带校验和的未版本化下载。请从 `HOMEBREW_CASK_OPTS` 中移除 `--require-sha` 以安装它。"
-          }
-        }
-      }
-    },
-    "Year" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一年"
-          }
-        }
-      }
-    },
-    "Yes" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "是"
           }
         }
       }

--- a/CaskHub/Services/Homebrew/Domain/Brewfile.swift
+++ b/CaskHub/Services/Homebrew/Domain/Brewfile.swift
@@ -1,0 +1,27 @@
+//
+//  Brewfile.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 15/08/2026.
+//
+
+import Foundation
+
+/// Reads and writes the `cask` entries of a `brew bundle` Brewfile.
+/// Other entry kinds (`tap`, `brew`, `mas`, comments) are left alone.
+nonisolated enum Brewfile {
+    static func caskTokens(in contents: String) -> [String] {
+        var seen: Set<String> = []
+        return contents.split(whereSeparator: \.isNewline).compactMap { line in
+            guard let match = line.firstMatch(
+                of: /^\s*cask\s+["']([^"']+)["']/
+            ) else { return nil }
+            let token = String(match.1)
+            return seen.insert(token).inserted ? token : nil
+        }
+    }
+
+    static func contents(forCaskTokens tokens: [String]) -> String {
+        tokens.sorted().map { "cask \"\($0)\"\n" }.joined()
+    }
+}

--- a/CaskHub/Views/Manage/BrewfileImportSheet.swift
+++ b/CaskHub/Views/Manage/BrewfileImportSheet.swift
@@ -25,9 +25,10 @@ nonisolated struct BrewfileImportPlan: Identifiable {
 
     let id = UUID()
     let fileName: String
-    let listedCount: Int
     let skippedEntries: [Entry]
     let newEntries: [Entry]
+
+    var listedCount: Int { skippedEntries.count + newEntries.count }
 }
 
 nonisolated enum BrewfileImportPhase: Equatable {
@@ -102,7 +103,7 @@ struct BrewfileImportSheet: View {
                     if !plan.skippedEntries.isEmpty {
                         skippedHeader
                         ForEach(plan.skippedEntries) { entry in
-                            BrewfileInstalledRow(entry: entry)
+                            BrewfileEntryRow(entry: entry)
                         }
                     }
                 }
@@ -111,24 +112,15 @@ struct BrewfileImportSheet: View {
         }
         HStack(spacing: 8) {
             Spacer()
-            if plan.newEntries.isEmpty {
-                PillButton(
-                    title: String(localized: "Done"),
-                    background: .chSurfaceField,
-                    border: .chHairlineStrong,
-                    foreground: .chTextNav
-                ) {
-                    dismiss()
-                }
-            } else {
-                PillButton(
-                    title: String(localized: "Cancel"),
-                    background: .chSurfaceField,
-                    border: .chHairlineStrong,
-                    foreground: .chTextNav
-                ) {
-                    dismiss()
-                }
+            PillButton(
+                title: String(localized: plan.newEntries.isEmpty ? "Done" : "Cancel"),
+                background: .chSurfaceField,
+                border: .chHairlineStrong,
+                foreground: .chTextNav
+            ) {
+                dismiss()
+            }
+            if !plan.newEntries.isEmpty {
                 PillButton(
                     title: String(localized: .shelfSetupBrewfileSheetInstallButton(
                         selectedEntries.count
@@ -195,7 +187,9 @@ struct BrewfileImportSheet: View {
             GeometryReader { geo in
                 Capsule()
                     .fill(Color.chTerracotta)
-                    .frame(width: geo.size.width * fraction(index: index))
+                    .frame(
+                        width: geo.size.width * CGFloat(index) / CGFloat(selectedEntries.count)
+                    )
             }
             .frame(height: 8)
             .background(Capsule().fill(Color.chSurfaceField))
@@ -210,11 +204,6 @@ struct BrewfileImportSheet: View {
             .foregroundStyle(Color.chTextMuted)
         }
         .padding(.vertical, 8)
-    }
-
-    private func fraction(index: Int) -> CGFloat {
-        guard !selectedEntries.isEmpty else { return 0 }
-        return CGFloat(index) / CGFloat(selectedEntries.count)
     }
 
     @ViewBuilder private func summary(failedCount: Int) -> some View {
@@ -266,42 +255,24 @@ struct BrewfileImportSheet: View {
 
 // MARK: - Rows
 
+/// Checkbox row when `isSelected` is bound; dimmed installed row when nil.
 private struct BrewfileEntryRow: View {
     let entry: BrewfileImportPlan.Entry
-    @Binding var isSelected: Bool
+    var isSelected: Binding<Bool>?
 
     var body: some View {
         HStack(spacing: 10) {
-            Toggle(isOn: $isSelected) {
-                Text(entry.displayName)
-            }
-            .toggleStyle(.checkbox)
-            .labelsHidden()
-            .frame(width: 16)
-            BrewfileEntryIcon(entry: entry)
-            Text(entry.displayName)
-                .font(CHType.cardTitle)
-                .foregroundStyle(Color.chTextTitle)
-                .lineLimit(1)
-            Spacer(minLength: 10)
-            if let cask = entry.cask {
-                Text(verbatim: "v\(cask.displayVersion)")
-                    .font(CHType.statusMono)
-                    .foregroundStyle(Color.chTextFaint)
-            }
-        }
-        .padding(.vertical, 7)
-        .overlay(alignment: .top) { Color.chHairline.frame(height: 1) }
-    }
-}
-
-private struct BrewfileInstalledRow: View {
-    let entry: BrewfileImportPlan.Entry
-
-    var body: some View {
-        HStack(spacing: 10) {
-            BrewfileDoneMark(size: 14)
+            if let isSelected {
+                Toggle(isOn: isSelected) {
+                    Text(entry.displayName)
+                }
+                .toggleStyle(.checkbox)
+                .labelsHidden()
                 .frame(width: 16)
+            } else {
+                BrewfileDoneMark(size: 14)
+                    .frame(width: 16)
+            }
             BrewfileEntryIcon(entry: entry)
             Text(entry.displayName)
                 .font(CHType.cardTitle)
@@ -315,7 +286,7 @@ private struct BrewfileInstalledRow: View {
             }
         }
         .padding(.vertical, 7)
-        .opacity(0.55)
+        .opacity(isSelected == nil ? 0.55 : 1)
         .overlay(alignment: .top) { Color.chHairline.frame(height: 1) }
     }
 }

--- a/CaskHub/Views/Manage/BrewfileImportSheet.swift
+++ b/CaskHub/Views/Manage/BrewfileImportSheet.swift
@@ -41,11 +41,12 @@ struct BrewfileImportSheet: View {
     let plan: BrewfileImportPlan
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @Environment(\.dismiss) private var dismiss
-    @State private var phase: BrewfileImportPhase = .preview
+    @State private var phase: BrewfileImportPhase
     @State private var selectedTokens: Set<String>
 
-    init(plan: BrewfileImportPlan) {
+    init(plan: BrewfileImportPlan, phase: BrewfileImportPhase = .preview) {
         self.plan = plan
+        _phase = State(initialValue: phase)
         _selectedTokens = State(initialValue: Set(plan.newEntries.map(\.token)))
     }
 

--- a/CaskHub/Views/Manage/BrewfileImportSheet.swift
+++ b/CaskHub/Views/Manage/BrewfileImportSheet.swift
@@ -1,0 +1,354 @@
+//
+//  BrewfileImportSheet.swift
+//  CaskHub
+//
+//  Created by Ali Elsokary on 15/08/2026.
+//
+
+import SwiftUI
+
+// MARK: - Brewfile Import
+
+nonisolated struct BrewfileNote {
+    let message: String
+    let isFailure: Bool
+}
+
+nonisolated struct BrewfileImportPlan: Identifiable {
+    nonisolated struct Entry: Identifiable {
+        let token: String
+        let cask: Cask?
+
+        var id: String { token }
+        var displayName: String { cask?.displayName ?? token }
+    }
+
+    let id = UUID()
+    let fileName: String
+    let listedCount: Int
+    let skippedEntries: [Entry]
+    let newEntries: [Entry]
+}
+
+nonisolated enum BrewfileImportPhase: Equatable {
+    case preview
+    case running(index: Int)
+    case done(failedCount: Int)
+}
+
+struct BrewfileImportSheet: View {
+    let plan: BrewfileImportPlan
+    @Environment(LocalHomebrewService.self) private var localHomebrew
+    @Environment(\.dismiss) private var dismiss
+    @State private var phase: BrewfileImportPhase = .preview
+    @State private var selectedTokens: Set<String>
+
+    init(plan: BrewfileImportPlan) {
+        self.plan = plan
+        _selectedTokens = State(initialValue: Set(plan.newEntries.map(\.token)))
+    }
+
+    private var selectedEntries: [BrewfileImportPlan.Entry] {
+        plan.newEntries.filter { selectedTokens.contains($0.token) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(String(localized: .shelfSetupBrewfileSheetTitle))
+                .font(CHType.section)
+                .foregroundStyle(Color.chTextTitle)
+            Text(String(localized: .shelfSetupBrewfileSheetSubtitle(
+                plan.fileName, plan.listedCount
+            )))
+            .font(CHType.statusMono)
+            .foregroundStyle(Color.chTextMuted)
+
+            switch phase {
+            case .preview:
+                preview
+            case let .running(index):
+                progress(index: index)
+            case let .done(failedCount):
+                summary(failedCount: failedCount)
+            }
+        }
+        .padding(22)
+        .frame(width: 420)
+        .background(Color.chSurfaceHero)
+        .interactiveDismissDisabled(isRunning)
+    }
+
+    private var isRunning: Bool {
+        if case .running = phase { return true }
+        return false
+    }
+
+    @ViewBuilder private var preview: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if plan.newEntries.isEmpty {
+                Text(String(localized: .shelfSetupBrewfileSheetNothingNew))
+                    .font(CHType.bodySm)
+                    .foregroundStyle(Color.chTextMuted)
+                    .padding(.vertical, 10)
+                    .overlay(alignment: .top) { Color.chHairline.frame(height: 1) }
+            } else {
+                selectAllRow
+            }
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(plan.newEntries) { entry in
+                        BrewfileEntryRow(entry: entry, isSelected: selectionBinding(entry))
+                    }
+                    if !plan.skippedEntries.isEmpty {
+                        skippedHeader
+                        ForEach(plan.skippedEntries) { entry in
+                            BrewfileInstalledRow(entry: entry)
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: 300)
+        }
+        HStack(spacing: 8) {
+            Spacer()
+            if plan.newEntries.isEmpty {
+                PillButton(
+                    title: String(localized: "Done"),
+                    background: .chSurfaceField,
+                    border: .chHairlineStrong,
+                    foreground: .chTextNav
+                ) {
+                    dismiss()
+                }
+            } else {
+                PillButton(
+                    title: String(localized: "Cancel"),
+                    background: .chSurfaceField,
+                    border: .chHairlineStrong,
+                    foreground: .chTextNav
+                ) {
+                    dismiss()
+                }
+                PillButton(
+                    title: String(localized: .shelfSetupBrewfileSheetInstallButton(
+                        selectedEntries.count
+                    )),
+                    background: .chActionInstallBg,
+                    border: .chActionInstallBorder,
+                    foreground: .chActionInstallFg,
+                    action: runImport
+                )
+                .disabled(selectedEntries.isEmpty)
+                .opacity(selectedEntries.isEmpty ? 0.5 : 1)
+            }
+        }
+        .padding(.top, 6)
+    }
+
+    private func selectionBinding(_ entry: BrewfileImportPlan.Entry) -> Binding<Bool> {
+        Binding(
+            get: { selectedTokens.contains(entry.token) },
+            set: { selected in
+                if selected {
+                    selectedTokens.insert(entry.token)
+                } else {
+                    selectedTokens.remove(entry.token)
+                }
+            }
+        )
+    }
+
+    private var selectAllRow: some View {
+        let allSelected = selectedTokens.count == plan.newEntries.count
+        return Toggle(isOn: Binding(
+            get: { allSelected },
+            set: { selectAll in
+                selectedTokens = selectAll ? Set(plan.newEntries.map(\.token)) : []
+            }
+        )) {
+            Text(String(localized: allSelected
+                ? .shelfSetupBrewfileSheetDeselectAll
+                : .shelfSetupBrewfileSheetSelectAll))
+                .font(CHType.cardTitle)
+                .foregroundStyle(Color.chTextTitle)
+        }
+        .toggleStyle(.checkbox)
+        .padding(.vertical, 7)
+        .overlay(alignment: .top) { Color.chHairline.frame(height: 1) }
+    }
+
+    private var skippedHeader: some View {
+        HStack(spacing: 8) {
+            BrewfileDoneMark(size: 16)
+            Text(String(localized: .shelfSetupBrewfileSheetSkipped(
+                plan.skippedEntries.count
+            )))
+            .font(CHType.bodySm)
+            .foregroundStyle(Color.chTextBody)
+        }
+        .padding(.vertical, 8)
+        .overlay(alignment: .top) { Color.chHairline.frame(height: 1) }
+    }
+
+    private func progress(index: Int) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            GeometryReader { geo in
+                Capsule()
+                    .fill(Color.chTerracotta)
+                    .frame(width: geo.size.width * fraction(index: index))
+            }
+            .frame(height: 8)
+            .background(Capsule().fill(Color.chSurfaceField))
+            .overlay(Capsule().strokeBorder(Color.chHairline, lineWidth: 1))
+            .animation(.linear(duration: 0.15), value: index)
+            Text(String(localized: .shelfSetupBrewfileSheetPouring(
+                selectedEntries[index].displayName,
+                index + 1,
+                selectedEntries.count
+            )))
+            .font(CHType.statusMono)
+            .foregroundStyle(Color.chTextMuted)
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func fraction(index: Int) -> CGFloat {
+        guard !selectedEntries.isEmpty else { return 0 }
+        return CGFloat(index) / CGFloat(selectedEntries.count)
+    }
+
+    @ViewBuilder private func summary(failedCount: Int) -> some View {
+        HStack(spacing: 10) {
+            BrewfileDoneMark(size: 20)
+            Text(
+                failedCount == 0
+                    ? String(localized: .shelfSetupBrewfileSheetDone(selectedEntries.count))
+                    : String(localized: .shelfSetupBrewfileSheetDoneWithFailures(
+                        selectedEntries.count - failedCount,
+                        selectedEntries.count,
+                        failedCount
+                    ))
+            )
+            .font(CHType.bodySm)
+            .foregroundStyle(Color.chTextBody)
+        }
+        .padding(.vertical, 6)
+        HStack {
+            Spacer()
+            PillButton(
+                title: String(localized: "Done"),
+                background: .chActionDoneBg,
+                border: .chActionDoneBorder,
+                foreground: .chActionDoneFg
+            ) {
+                dismiss()
+            }
+        }
+    }
+
+    private func runImport() {
+        guard case .preview = phase, !selectedEntries.isEmpty else { return }
+        phase = .running(index: 0)
+        Task {
+            var failedCount = 0
+            for (index, entry) in selectedEntries.enumerated() {
+                phase = .running(index: index)
+                do {
+                    try await localHomebrew.install(token: entry.token)
+                } catch {
+                    failedCount += 1
+                }
+            }
+            phase = .done(failedCount: failedCount)
+        }
+    }
+}
+
+// MARK: - Rows
+
+private struct BrewfileEntryRow: View {
+    let entry: BrewfileImportPlan.Entry
+    @Binding var isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Toggle(isOn: $isSelected) {
+                Text(entry.displayName)
+            }
+            .toggleStyle(.checkbox)
+            .labelsHidden()
+            .frame(width: 16)
+            BrewfileEntryIcon(entry: entry)
+            Text(entry.displayName)
+                .font(CHType.cardTitle)
+                .foregroundStyle(Color.chTextTitle)
+                .lineLimit(1)
+            Spacer(minLength: 10)
+            if let cask = entry.cask {
+                Text(verbatim: "v\(cask.displayVersion)")
+                    .font(CHType.statusMono)
+                    .foregroundStyle(Color.chTextFaint)
+            }
+        }
+        .padding(.vertical, 7)
+        .overlay(alignment: .top) { Color.chHairline.frame(height: 1) }
+    }
+}
+
+private struct BrewfileInstalledRow: View {
+    let entry: BrewfileImportPlan.Entry
+
+    var body: some View {
+        HStack(spacing: 10) {
+            BrewfileDoneMark(size: 14)
+                .frame(width: 16)
+            BrewfileEntryIcon(entry: entry)
+            Text(entry.displayName)
+                .font(CHType.cardTitle)
+                .foregroundStyle(Color.chTextTitle)
+                .lineLimit(1)
+            Spacer(minLength: 10)
+            if let cask = entry.cask {
+                Text(verbatim: "v\(cask.displayVersion)")
+                    .font(CHType.statusMono)
+                    .foregroundStyle(Color.chTextFaint)
+            }
+        }
+        .padding(.vertical, 7)
+        .opacity(0.55)
+        .overlay(alignment: .top) { Color.chHairline.frame(height: 1) }
+    }
+}
+
+private struct BrewfileEntryIcon: View {
+    let entry: BrewfileImportPlan.Entry
+
+    var body: some View {
+        if let cask = entry.cask {
+            CaskIconView(cask: cask, size: 26)
+        } else {
+            RoundedRectangle(cornerRadius: 7)
+                .fill(Color.chSurfaceField)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7)
+                        .strokeBorder(Color.chHairline, lineWidth: 1)
+                )
+                .overlay(
+                    Text(entry.token.prefix(1).uppercased())
+                        .font(CHType.cardTitle)
+                        .foregroundStyle(Color.chTextFaint)
+                )
+                .frame(width: 26, height: 26)
+        }
+    }
+}
+
+private struct BrewfileDoneMark: View {
+    let size: CGFloat
+
+    var body: some View {
+        Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: size, weight: .semibold))
+            .foregroundStyle(Color.chActionDoneFg)
+    }
+}

--- a/CaskHub/Views/Manage/ShelfSetupView.swift
+++ b/CaskHub/Views/Manage/ShelfSetupView.swift
@@ -11,19 +11,175 @@ struct ShelfSetupView: View {
     let viewModel: CaskCatalogViewModel
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @State private var showsIgnorePicker = false
+    @State private var exportNote: BrewfileNote?
+    @State private var importNote: BrewfileNote?
+    @State private var importPlan: BrewfileImportPlan?
 
     var body: some View {
         ScrollView {
-            ignoreCard
-                .frame(maxWidth: 680, alignment: .leading)
-                .frame(width: CHSize.contentWidth, alignment: .leading)
-                .frame(maxWidth: .infinity)
+            VStack(alignment: .leading, spacing: 16) {
+                brewfileCard
+                ignoreCard
+            }
+            .frame(maxWidth: 680, alignment: .leading)
+            .frame(width: CHSize.contentWidth, alignment: .leading)
+            .frame(maxWidth: .infinity)
         }
         .contentMargins(.bottom, 44, for: .scrollContent)
         .scrollContentBackground(.hidden)
         .sheet(isPresented: $showsIgnorePicker) {
             AdoptIgnorePickerSheet(viewModel: viewModel)
         }
+        .sheet(item: $importPlan) { plan in
+            BrewfileImportSheet(plan: plan)
+        }
+    }
+
+    // MARK: - Brewfile
+
+    private var brewfileCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(String(localized: .shelfSetupBrewfileTitle))
+                .font(CHType.section)
+                .foregroundStyle(Color.chTextTitle)
+                .padding(.bottom, 10)
+            brewfileRow(
+                title: String(localized: .shelfSetupBrewfileExportTitle),
+                description: String(
+                    localized: .shelfSetupBrewfileExportDescription(viewModel.installedCount)
+                ),
+                note: exportNote
+            ) {
+                PillButton(
+                    title: String(localized: .shelfSetupBrewfileExportButton),
+                    background: .chActionInstallBg,
+                    border: .chActionInstallBorder,
+                    foreground: .chActionInstallFg,
+                    action: exportBrewfile
+                )
+            }
+            brewfileRow(
+                title: String(localized: .shelfSetupBrewfileImportTitle),
+                description: String(localized: .shelfSetupBrewfileImportDescription),
+                note: importNote
+            ) {
+                PillButton(
+                    title: String(localized: .shelfSetupBrewfileImportButton),
+                    background: .chSurfaceField,
+                    border: .chHairlineStrong,
+                    foreground: .chTextNav,
+                    action: chooseImportFile
+                )
+            }
+        }
+        .padding(EdgeInsets(top: 18, leading: 20, bottom: 8, trailing: 20))
+        .glassPanel()
+    }
+
+    private func brewfileRow(
+        title: String,
+        description: String,
+        note: BrewfileNote?,
+        @ViewBuilder button: () -> some View
+    ) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(CHType.cardTitle)
+                    .foregroundStyle(Color.chTextTitle)
+                Text(description)
+                    .font(CHType.bodySm)
+                    .foregroundStyle(Color.chTextBody)
+                if let note {
+                    Text(note.message)
+                        .font(CHType.bodySm)
+                        .foregroundStyle(
+                            note.isFailure ? Color.chActionUpdateFg : Color.chActionDoneFg
+                        )
+                }
+            }
+            Spacer(minLength: 10)
+            button()
+        }
+        .padding(.vertical, 11)
+        .overlay(alignment: .top) { Color.chHairline.frame(height: 1) }
+    }
+
+    private func exportBrewfile() {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "Brewfile"
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        panel.showsHiddenFiles = true
+        let response = CrashReporter.withHangTrackingPaused { panel.runModal() }
+        guard response == .OK, let url = panel.url else { return }
+        let tokens = viewModel.installedCasks.map(\.token)
+        do {
+            try Brewfile.contents(forCaskTokens: tokens)
+                .write(to: url, atomically: true, encoding: .utf8)
+            exportNote = BrewfileNote(
+                message: String(localized: .shelfSetupBrewfileExportSaved(
+                    (url.path as NSString).abbreviatingWithTildeInPath,
+                    tokens.count
+                )),
+                isFailure: false
+            )
+        } catch {
+            exportNote = BrewfileNote(
+                message: String(localized: .shelfSetupBrewfileExportFailed),
+                isFailure: true
+            )
+        }
+    }
+
+    private func chooseImportFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        let response = CrashReporter.withHangTrackingPaused { panel.runModal() }
+        guard response == .OK, let url = panel.url else { return }
+        let contents = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        let tokens = Brewfile.caskTokens(in: contents)
+        guard !tokens.isEmpty else {
+            importNote = BrewfileNote(
+                message: String(localized: .shelfSetupBrewfileImportEmpty),
+                isFailure: true
+            )
+            return
+        }
+        importNote = nil
+        importPlan = makeImportPlan(
+            fileName: (url.path as NSString).abbreviatingWithTildeInPath,
+            tokens: tokens
+        )
+    }
+
+    private func makeImportPlan(
+        fileName: String,
+        tokens: [String]
+    ) -> BrewfileImportPlan {
+        let byToken = Dictionary(viewModel.casks.map { ($0.token, $0) }) { first, _ in first }
+        var skippedEntries: [BrewfileImportPlan.Entry] = []
+        var newEntries: [BrewfileImportPlan.Entry] = []
+        for token in tokens {
+            // Brewfiles may tap-qualify tokens; the catalog keys bare ones.
+            let bare = token.split(separator: "/").last.map(String.init) ?? token
+            let cask = byToken[bare]
+            let entry = BrewfileImportPlan.Entry(token: token, cask: cask)
+            if let cask, viewModel.localState(for: cask).isPresent {
+                skippedEntries.append(entry)
+            } else {
+                newEntries.append(entry)
+            }
+        }
+        return BrewfileImportPlan(
+            fileName: fileName,
+            listedCount: tokens.count,
+            skippedEntries: skippedEntries,
+            newEntries: newEntries
+        )
     }
 
     // MARK: - Ignore List
@@ -217,7 +373,7 @@ struct AdoptIgnorePickerSheet: View {
 
 // MARK: - Shared Bits
 
-private struct PillButton: View {
+struct PillButton: View {
     let title: String
     let background: Color
     let border: Color

--- a/CaskHub/Views/Manage/ShelfSetupView.swift
+++ b/CaskHub/Views/Manage/ShelfSetupView.swift
@@ -176,7 +176,6 @@ struct ShelfSetupView: View {
         }
         return BrewfileImportPlan(
             fileName: fileName,
-            listedCount: tokens.count,
             skippedEntries: skippedEntries,
             newEntries: newEntries
         )

--- a/CaskHub/Views/Manage/ShelfSetupView.swift
+++ b/CaskHub/Views/Manage/ShelfSetupView.swift
@@ -156,7 +156,7 @@ struct ShelfSetupView: View {
         )
     }
 
-    private func makeImportPlan(
+    func makeImportPlan(
         fileName: String,
         tokens: [String]
     ) -> BrewfileImportPlan {

--- a/CaskHubTests/Homebrew/Domain/BrewfileTests.swift
+++ b/CaskHubTests/Homebrew/Domain/BrewfileTests.swift
@@ -1,0 +1,61 @@
+//
+//  BrewfileTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 15/08/2026.
+//
+
+@testable import CaskHub
+import XCTest
+
+final class BrewfileTests: XCTestCase {
+    func test_parsing_extracts_only_cask_entries() {
+        let contents = """
+        # my machine
+        tap "mongodb/brew"
+        brew "wget"
+        cask "google-chrome"
+          cask 'figma'
+        cask "raycast", args: { appdir: "~/Applications" }
+        mas "Keynote", id: 409183694
+        casket "not-a-cask"
+        """
+        XCTAssertEqual(
+            Brewfile.caskTokens(in: contents),
+            ["google-chrome", "figma", "raycast"]
+        )
+    }
+
+    func test_parsing_keeps_tap_qualified_tokens_and_dedupes() {
+        let contents = """
+        cask "homebrew/cask-versions/firefox-beta"
+        cask "figma"
+        cask "figma"
+        """
+        XCTAssertEqual(
+            Brewfile.caskTokens(in: contents),
+            ["homebrew/cask-versions/firefox-beta", "figma"]
+        )
+    }
+
+    func test_parsing_empty_or_caskless_contents_returns_nothing() {
+        XCTAssertEqual(Brewfile.caskTokens(in: ""), [])
+        XCTAssertEqual(Brewfile.caskTokens(in: "brew \"wget\"\n# cask \"x\" y"), [])
+    }
+
+    func test_serializing_sorts_tokens_into_cask_lines() {
+        XCTAssertEqual(
+            Brewfile.contents(forCaskTokens: ["raycast", "figma"]),
+            "cask \"figma\"\ncask \"raycast\"\n"
+        )
+        XCTAssertEqual(Brewfile.contents(forCaskTokens: []), "")
+    }
+
+    func test_roundtrip_preserves_tokens() {
+        let tokens = ["figma", "google-chrome", "raycast"]
+        XCTAssertEqual(
+            Brewfile.caskTokens(in: Brewfile.contents(forCaskTokens: tokens)),
+            tokens
+        )
+    }
+}

--- a/CaskHubTests/Views/ShelfSetupViewTests.swift
+++ b/CaskHubTests/Views/ShelfSetupViewTests.swift
@@ -124,6 +124,67 @@ final class ShelfSetupViewTests: XCTestCase {
     }
 
     @MainActor
+    func test_make_import_plan_splits_installed_new_and_unknown_tokens() async {
+        let homebrew = makeHomebrew(
+            defaults: makeScratchDefaults("brewfile-plan"),
+            externalApps: ["google-chrome": "Google Chrome.app"]
+        )
+        let (vm, _) = await makeSUT(
+            casks: [
+                makeCask("google-chrome", appNames: ["Google Chrome.app"]),
+                makeCask("raycast", appNames: ["Raycast.app"])
+            ],
+            localHomebrew: homebrew
+        )
+
+        let plan = ShelfSetupView(viewModel: vm).makeImportPlan(
+            fileName: "~/Brewfile",
+            tokens: ["homebrew/cask/google-chrome", "raycast", "mystery-app"]
+        )
+
+        XCTAssertEqual(
+            plan.skippedEntries.map(\.token), ["homebrew/cask/google-chrome"],
+            "externally installed app counts as present, even tap-qualified"
+        )
+        XCTAssertEqual(plan.newEntries.map(\.token), ["raycast", "mystery-app"])
+        XCTAssertEqual(plan.listedCount, 3)
+        XCTAssertEqual(plan.newEntries.first?.cask?.token, "raycast")
+        XCTAssertNil(plan.newEntries.last?.cask, "unknown token keeps nil cask")
+    }
+
+    @MainActor
+    func test_brewfile_import_sheet_renders_every_phase() {
+        let homebrew = makeHomebrew(
+            defaults: makeScratchDefaults("brewfile-render"),
+            externalApps: [:]
+        )
+        let plan = BrewfileImportPlan(
+            fileName: "~/Brewfile",
+            skippedEntries: [.init(token: "google-chrome", cask: makeCask("google-chrome"))],
+            newEntries: [
+                .init(token: "raycast", cask: makeCask("raycast")),
+                .init(token: "mystery-app", cask: nil)
+            ]
+        )
+        let phases: [BrewfileImportPhase] = [
+            .preview, .running(index: 0), .done(failedCount: 0), .done(failedCount: 1)
+        ]
+        for phase in phases {
+            render(BrewfileImportSheet(plan: plan, phase: phase)
+                .environment(homebrew)
+                .environment(ImageCacheService()))
+        }
+        let nothingNew = BrewfileImportPlan(
+            fileName: "~/Brewfile",
+            skippedEntries: plan.skippedEntries,
+            newEntries: []
+        )
+        render(BrewfileImportSheet(plan: nothingNew)
+            .environment(homebrew)
+            .environment(ImageCacheService()))
+    }
+
+    @MainActor
     func test_ignore_picker_sheet_renders_adoptable_and_empty_states() async {
         let homebrew = makeHomebrew(
             defaults: makeScratchDefaults("adopt-picker-render"),


### PR DESCRIPTION
## Summary

- **Export your shelf**: new Brewfile card on Shelf Setup writes every brew-managed cask to a Brewfile (save panel, sorted `cask "token"` lines), with an inline saved/failed note.
- **Import casks**: choose a Brewfile, preview it in a sheet:
  - selectable new casks on top (checkbox per row, Select All / Deselect All header, install button tracks selection and disables at zero)
  - already-installed casks listed below a "N already on your machine, skipped" section, dimmed with a checkmark.circle.fill instead of a checkbox (covers brew, App Store and external installs via `CaskLocalState.isPresent`)
  - sequential install of the selected set through the existing `install(token:)` pipeline with a progress bar ("Pouring X… (i of N)") and a completion summary including failures
- Parsing handles tap-qualified tokens, `args:` lines and quoting styles; `tap`/`brew`/`mas` entries are ignored. Tokens dedupe preserving order; export sorts alphabetically.
- 18 new string catalog keys, English + Simplified Chinese, no em-dashes.

## Implementation notes

- `Brewfile` is a pure domain type in `Services/Homebrew/Domain` with unit tests.
- Import sheet split into `BrewfileImportSheet.swift`; row views extracted to stay under lint caps.
- Version label uses `Text(verbatim:)` so compiler string extraction doesn't add a `v%@` catalog key.

## Testing

- `swiftlint --strict` clean.
- Full suite: 394 tests passed, 0 failed (`xcodebuild test`, macOS destination); `BrewfileTests` verified running.
- Manual pass over export panel, import preview, selection, install progress and done states.