### PR TITLE
refactor: Code cleanup

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B130028F9F00608C7A /* CaskHubTests.swift */; };
 		41DFD4B630028F9F00608C7A /* CaskCatalogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */; };
 		41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */; };
+		AA1000000000000000000017 /* TestFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000000000000000000016 /* TestFactories.swift */; };
 		41DFD4E230028F7D00608C7A /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DFD4E130028F7D00608C7A /* AppearanceSettingsView.swift */; };
 		7FFA89946C514C00BF5496DB /* BrewOutputCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5317A6659E48459EB3FFB7EB /* BrewOutputCollector.swift */; };
 		A12000000000000000000001 /* LocalHomebrewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12000000000000000000001 /* LocalHomebrewTypes.swift */; };
@@ -220,6 +221,7 @@
 		41DFD4B130028F9F00608C7A /* CaskHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubTests.swift; sourceTree = "<group>"; };
 		41DFD4B530028F9F00608C7A /* CaskCatalogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCatalogViewModelTests.swift; sourceTree = "<group>"; };
 		41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
+		AA1000000000000000000016 /* TestFactories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFactories.swift; sourceTree = "<group>"; };
 		41DFD4E130028F7D00608C7A /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		41E09E37CC8344C699ACADDB /* AppManagementPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppManagementPermission.swift; sourceTree = "<group>"; };
 		41EBDCE12F37FD8B00BEABB8 /* CaskHub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaskHub.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -747,6 +749,7 @@
 			isa = PBXGroup;
 			children = (
 				41DFD4B730028F9F00608C7A /* SharedTestHelpers.swift */,
+				AA1000000000000000000016 /* TestFactories.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1167,6 +1170,7 @@
 				C13000000000000000000002 /* MutationRecoveryTests.swift in Sources */,
 				A12000000000000000000004 /* ZombieDetectionTests.swift in Sources */,
 				41DFD4B830028F9F00608C7A /* SharedTestHelpers.swift in Sources */,
+				AA1000000000000000000017 /* TestFactories.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
+++ b/CaskHub/DesignSystem/Components/CaskOperationCapsule.swift
@@ -41,7 +41,8 @@ struct CaskOperationCapsule: View {
                     .foregroundStyle(Color.chTextBody)
                     .lineLimit(1)
             } else {
-                operationLabel
+                Text(label)
+                    .font(CHType.bodySm)
                     .foregroundStyle(Color.chTextBody)
                     .lineLimit(1)
             }
@@ -86,17 +87,6 @@ struct CaskOperationCapsule: View {
         .accessibilityLabel(label.replacingOccurrences(of: " · ", with: ", "))
     }
 
-    @ViewBuilder
-    private var operationLabel: some View {
-        if isCanceling {
-            Text("Canceling…")
-                .font(CHType.bodySm)
-        } else {
-            Text(progress?.inlineLabel ?? action.inProgressLabel)
-                .font(CHType.bodySm)
-        }
-    }
-
     private var downloadByteProgress: CaskByteProgress? {
         guard !isCanceling, progress?.phase.showsByteProgress == true else { return nil }
         return progress?.byteProgress
@@ -104,7 +94,7 @@ struct CaskOperationCapsule: View {
 
     private var label: String {
         if isCanceling {
-            return "Canceling…"
+            return String(localized: "Canceling…")
         }
         return progress?.inlineLabel ?? action.inProgressLabel
     }

--- a/CaskHub/DesignSystem/Components/Controls.swift
+++ b/CaskHub/DesignSystem/Components/Controls.swift
@@ -138,28 +138,18 @@ struct Keycap: View {
     let symbol: String
 
     var body: some View {
-        content
-            .foregroundStyle(Color.chTextTitle)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 1.5)
-            .background(RoundedRectangle(cornerRadius: CHRadius.keycap).fill(Color.chSurfaceKeycap))
-            .overlay(RoundedRectangle(cornerRadius: CHRadius.keycap).strokeBorder(Color.chHairlineStrong, lineWidth: 1))
-            .shadow(color: Color.chShadowCard, radius: 2, y: 1)
-    }
-
-    @ViewBuilder
-    private var content: some View {
-        if symbol.hasPrefix("⌘") {
-            HStack(spacing: 1) {
-                Image(systemName: "command")
-                    .font(.system(size: 8.5, weight: .bold))
-                Text(symbol.dropFirst())
-                    .font(CHType.keycap)
-            }
-        } else {
-            Text(symbol)
+        HStack(spacing: 1) {
+            Image(systemName: "command")
+                .font(.system(size: 8.5, weight: .bold))
+            Text(symbol.dropFirst())
                 .font(CHType.keycap)
         }
+        .foregroundStyle(Color.chTextTitle)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 1.5)
+        .background(RoundedRectangle(cornerRadius: CHRadius.keycap).fill(Color.chSurfaceKeycap))
+        .overlay(RoundedRectangle(cornerRadius: CHRadius.keycap).strokeBorder(Color.chHairlineStrong, lineWidth: 1))
+        .shadow(color: Color.chShadowCard, radius: 2, y: 1)
     }
 }
 

--- a/CaskHub/DesignSystem/Components/TopBarView.swift
+++ b/CaskHub/DesignSystem/Components/TopBarView.swift
@@ -287,41 +287,13 @@ private extension TopBarView {
                 ? String(localized: "Wait for the current action to finish.")
                 : String(localized: "Update All")
         )
-        .updateAllConfirmation(
-            $showUpdateAllConfirmation,
-            count: updateAllCount,
-            onConfirm: onUpdateAll
-        )
-    }
-}
-
-private struct UpdateAllConfirmationModifier: ViewModifier {
-    @Binding var isPresented: Bool
-    let count: Int
-    let onConfirm: (() -> Void)?
-
-    func body(content: Content) -> some View {
-        content.alert("Update All Apps?", isPresented: $isPresented) {
+        .alert("Update All Apps?", isPresented: $showUpdateAllConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Update All") {
-                onConfirm?()
+                onUpdateAll?()
             }
         } message: {
-            Text(.alertUpdateAllConfirmation(count))
+            Text(.alertUpdateAllConfirmation(updateAllCount))
         }
-    }
-}
-
-private extension View {
-    func updateAllConfirmation(
-        _ isPresented: Binding<Bool>,
-        count: Int,
-        onConfirm: (() -> Void)?
-    ) -> some View {
-        modifier(UpdateAllConfirmationModifier(
-            isPresented: isPresented,
-            count: count,
-            onConfirm: onConfirm
-        ))
     }
 }

--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -15,10 +15,6 @@ nonisolated struct ArtifactStanza: Decodable, Hashable, Sendable {
     let deletedAppNames: [String]
     let applicationBundleIdentifiers: [String]
 
-    /// Raw source paths of `binary` entries (e.g. a path inside the .app bundle).
-    /// Needed to verify a bundle actually contains what the cask declares.
-    let binarySourcePaths: [String]
-
     /// Source paths for every linked artifact that may resolve inside an adopted
     /// app bundle (binaries, shell completions, and manpages).
     let adoptionSourcePaths: [String]
@@ -27,7 +23,6 @@ nonisolated struct ArtifactStanza: Decodable, Hashable, Sendable {
         keys: Set<String>,
         appNames: [String] = [],
         binaryNames: [String] = [],
-        binarySourcePaths: [String] = [],
         adoptionSourcePaths: [String] = [],
         packageIdentifiers: [String] = [],
         deletedAppNames: [String] = [],
@@ -36,7 +31,6 @@ nonisolated struct ArtifactStanza: Decodable, Hashable, Sendable {
         self.keys = keys
         self.appNames = appNames
         self.binaryNames = binaryNames
-        self.binarySourcePaths = binarySourcePaths
         self.adoptionSourcePaths = adoptionSourcePaths
         self.packageIdentifiers = packageIdentifiers
         self.deletedAppNames = deletedAppNames
@@ -109,7 +103,6 @@ nonisolated struct ArtifactStanza: Decodable, Hashable, Sendable {
             keys = []
             appNames = []
             binaryNames = []
-            binarySourcePaths = []
             adoptionSourcePaths = []
             packageIdentifiers = []
             deletedAppNames = []
@@ -119,10 +112,6 @@ nonisolated struct ArtifactStanza: Decodable, Hashable, Sendable {
         keys = Set(container.allKeys.map(\.stringValue))
         appNames = Self.artifactNames(in: container, key: "app")
         binaryNames = Self.artifactNames(in: container, key: "binary")
-        binarySourcePaths = (AnyKey(stringValue: "binary")
-            .flatMap { try? container.decode([AppEntry].self, forKey: $0) } ?? [])
-            .compactMap(\.name)
-            .filter { $0.contains("/") }
         adoptionSourcePaths = Self.adoptionLinkKeys.flatMap { key in
             AnyKey(stringValue: key)
                 .flatMap { try? container.decode([AppEntry].self, forKey: $0) }
@@ -204,11 +193,6 @@ nonisolated struct Cask: Decodable, Identifiable, Hashable, Sendable {
     /// Executable names this cask links into the brew prefix (e.g. "claude").
     var binaryArtifactNames: [String] {
         artifacts?.flatMap(\.binaryNames) ?? []
-    }
-
-    /// Raw source paths of declared `binary` artifacts.
-    var binarySourcePaths: [String] {
-        artifacts?.flatMap(\.binarySourcePaths) ?? []
     }
 
     /// All bundle-relative artifact sources Homebrew links after moving an

--- a/CaskHub/Services/Catalog/CategoryService.swift
+++ b/CaskHub/Services/Catalog/CategoryService.swift
@@ -60,16 +60,6 @@ final class CategoryService {
             .map { (id: $0.key, definition: $0.value) }
     }
 
-    func loadCategories() {
-        guard let url = Bundle.main.url(forResource: "categories", withExtension: "json"),
-              let data = try? Data(contentsOf: url),
-              let catalog = try? JSONDecoder().decode(CaskCategoryData.self, from: data)
-        else {
-            return
-        }
-        applyData(catalog)
-    }
-
     /// Off-main decode; never overwrites fresher remote data.
     func loadBundledCategoriesAsync() async {
         guard let catalog = await Self.decodeBundledCategories(),

--- a/CaskHub/Services/Catalog/RecentlyAddedService.swift
+++ b/CaskHub/Services/Catalog/RecentlyAddedService.swift
@@ -39,16 +39,6 @@ final class RecentlyAddedService {
     private(set) var generatedDate = ""
     private(set) var catalogStateRevision = 0
 
-    func loadBundledDates(bundle: Bundle = .main) {
-        guard let url = bundle.url(forResource: "added_dates", withExtension: "json"),
-              let data = try? Data(contentsOf: url),
-              let bundled = try? JSONDecoder().decode(AddedDatesData.self, from: data),
-              bundled.version == Self.schemaVersion
-        else { return }
-
-        apply(bundled)
-    }
-
     /// Off-main decode; never overwrites fresher remote data.
     func loadBundledDatesAsync() async {
         guard let bundled = await Self.decodeBundledDates(),
@@ -76,7 +66,7 @@ final class RecentlyAddedService {
 
     // Full-dictionary filter per projection recompute hangs slow machines.
     @ObservationIgnored
-    private let recentTokensCache = MemoizedValue<String, Set<String>>()
+    private let recentTokensCache = BoundedMemoizedValues<String, Set<String>>(capacity: 1)
 
     func recentTokens(within days: Int) -> Set<String> {
         let cutoff = Self.dateString(daysAgo: days)

--- a/CaskHub/Services/Downloads/DownloadMetadataProvider.swift
+++ b/CaskHub/Services/Downloads/DownloadMetadataProvider.swift
@@ -12,11 +12,7 @@ nonisolated enum DownloadSizeResult: Equatable, Sendable {
     case unknown
 }
 
-nonisolated protocol DownloadMetadataProviding: Sendable {
-    func downloadSize(for urlString: String?) async -> DownloadSizeResult
-}
-
-actor DownloadMetadataProvider: DownloadMetadataProviding {
+actor DownloadMetadataProvider {
     typealias ContentLengthLoader = @Sendable (URL) async -> Int64?
 
     static let shared = DownloadMetadataProvider()
@@ -57,11 +53,5 @@ actor DownloadMetadataProvider: DownloadMetadataProviding {
               let total = contentRange.split(separator: "/").last.flatMap({ Int64($0) })
         else { return nil }
         return total
-    }
-}
-
-nonisolated struct UnavailableDownloadMetadataProvider: DownloadMetadataProviding {
-    func downloadSize(for urlString: String?) async -> DownloadSizeResult {
-        .unknown
     }
 }

--- a/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskOperationStore.swift
@@ -56,18 +56,13 @@ final class CaskOperationStore {
         updateAllProgress = nil
     }
 
-    func canBeginOperation(for token: String) -> Bool {
-        guard let state = boxes[token]?.state else { return true }
-        if case .running = state { return false }
-        return true
-    }
-
     func canBeginOperation(_ action: CaskAction, for token: String) -> Bool {
         if action == .updatingHomebrew {
             return !hasActiveOperations
         }
         guard !isUpdatingHomebrew else { return false }
-        return canBeginOperation(for: token)
+        if case .running = boxes[token]?.state { return false }
+        return true
     }
 
     var isUpdatingHomebrew: Bool {

--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -7,15 +7,6 @@
 
 import Foundation
 
-struct HomebrewMutationRequest {
-    let action: CaskAction
-    let token: String
-    let displayName: String
-    let arguments: [String]
-    let origin: CaskActionOrigin
-    let environmentOverrides: [String: String]
-}
-
 enum HomebrewMutationRecoveryBehavior: Equatable {
     case finishMutation
     case continueSequence
@@ -40,7 +31,6 @@ struct HomebrewMutationSequenceRequest {
 struct HomebrewMutationCallbacks {
     let refresh: () async -> Void
     let strandedCopyExists: () -> Bool
-    let recoverIf: (() -> Bool)?
 }
 
 @MainActor
@@ -63,30 +53,6 @@ final class HomebrewMutationCoordinator {
         self.brewBinaryProvider = brewBinaryProvider
         self.fileManager = fileManager
         outputAggregator = BrewOutputAggregator(fileManager: fileManager)
-    }
-
-    func run(
-        _ request: HomebrewMutationRequest,
-        callbacks: HomebrewMutationCallbacks
-    ) async throws {
-        try await runSequence(
-            HomebrewMutationSequenceRequest(
-                action: request.action,
-                token: request.token,
-                displayName: request.displayName,
-                origin: request.origin,
-                steps: [
-                    HomebrewMutationStep(
-                        arguments: request.arguments,
-                        environmentOverrides: request.environmentOverrides,
-                        cancellable: request.action == .installing,
-                        recoverIf: callbacks.recoverIf,
-                        recoveryBehavior: .finishMutation
-                    )
-                ]
-            ),
-            callbacks: callbacks
-        )
     }
 
     /// Runs a multi-command workflow as one logical mutation. The current

--- a/CaskHub/Services/Homebrew/Domain/CaskOperationProgress.swift
+++ b/CaskHub/Services/Homebrew/Domain/CaskOperationProgress.swift
@@ -115,61 +115,33 @@ nonisolated struct CaskByteProgress: Equatable, Sendable {
     }
 
     var text: String {
-        let unit = ByteUnit.forTotalBytes(totalBytes)
+        let unit = Self.units.first { totalBytes >= $0.threshold } ?? Self.units[3]
         let clampedCompleted = min(max(completedBytes, 0), max(totalBytes, 0))
-        return [
-            Self.format(clampedCompleted, in: unit),
-            "/",
-            Self.format(totalBytes, in: unit),
-            unit.symbol
-        ].joined(separator: " ")
+        let completedText = Self.format(clampedCompleted, divisor: unit.divisor)
+        let totalText = Self.format(totalBytes, divisor: unit.divisor)
+        return "\(completedText) / \(totalText) \(unit.symbol)"
     }
 
-    private static func format(_ bytes: Int64, in unit: ByteUnit) -> String {
+    private struct Unit {
+        let threshold: Int64
+        let divisor: Double
+        let symbol: String
+    }
+
+    private static let units: [Unit] = [
+        Unit(threshold: 1_000_000_000, divisor: 1e9, symbol: "GB"),
+        Unit(threshold: 1_000_000, divisor: 1e6, symbol: "MB"),
+        Unit(threshold: 1_000, divisor: 1e3, symbol: "KB"),
+        Unit(threshold: 0, divisor: 1, symbol: "B")
+    ]
+
+    private static func format(_ bytes: Int64, divisor: Double) -> String {
         let formatted = String(
             format: "%.1f",
             locale: Locale(identifier: "en_US_POSIX"),
-            Double(bytes) / unit.divisor
+            Double(bytes) / divisor
         )
         return formatted.hasSuffix(".0") ? String(formatted.dropLast(2)) : formatted
-    }
-
-    private enum ByteUnit {
-        case bytes
-        case kilobytes
-        case megabytes
-        case gigabytes
-
-        static func forTotalBytes(_ bytes: Int64) -> ByteUnit {
-            switch bytes {
-            case 1_000_000_000...:
-                return .gigabytes
-            case 1_000_000...:
-                return .megabytes
-            case 1_000...:
-                return .kilobytes
-            default:
-                return .bytes
-            }
-        }
-
-        var divisor: Double {
-            switch self {
-            case .bytes: return 1
-            case .kilobytes: return 1_000
-            case .megabytes: return 1_000_000
-            case .gigabytes: return 1_000_000_000
-            }
-        }
-
-        var symbol: String {
-            switch self {
-            case .bytes: return "B"
-            case .kilobytes: return "KB"
-            case .megabytes: return "MB"
-            case .gigabytes: return "GB"
-            }
-        }
     }
 }
 
@@ -250,20 +222,21 @@ nonisolated enum BrewProgressParser {
         let cachedDownloadPath: String?
     }
 
-    private static let progressRegex = try? NSRegularExpression(pattern:
-        #"Downloading\s+([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)\s*/\s*([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)"#
-    )
+    private static let progressRegex =
+        #/Downloading\s+([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)\s*\/\s*([0-9]+(?:\.[0-9]+)?)\s*(B|KB|MB|GB)/#
 
     static func parse(_ output: String) -> Update {
-        let progressMatch = progressMatches(in: output).last
-        let byteProgress = progressMatch.flatMap {
-            parsedByteProgress(in: output, match: $0)
+        let progressMatch = output.matches(of: progressRegex).last
+        let byteProgress: (completed: Int64, total: Int64)? = progressMatch.flatMap { match in
+            guard let completed = bytes(match.1, unit: match.2),
+                  let total = bytes(match.3, unit: match.4)
+            else { return nil }
+            return (completed, total)
         }
 
         var events: [(String.Index, CaskOperationPhase)] = []
-        if let match = progressMatch,
-           let range = Range(match.range, in: output) {
-            events.append((range.lowerBound, .downloading))
+        if let progressMatch {
+            events.append((progressMatch.range.lowerBound, .downloading))
         }
 
         let markers: [(String, CaskOperationPhase)] = [
@@ -296,21 +269,15 @@ nonisolated enum BrewProgressParser {
         )
     }
 
-    private static func parsedByteProgress(
-        in output: String,
-        match: NSTextCheckingResult
-    ) -> (completed: Int64, total: Int64)? {
-        guard
-            let completed = value(in: output, match: match, valueGroup: 1, unitGroup: 2),
-            let total = value(in: output, match: match, valueGroup: 3, unitGroup: 4)
-        else { return nil }
-        return (completed, total)
-    }
-
-    private static func progressMatches(in output: String) -> [NSTextCheckingResult] {
-        guard let expression = progressRegex else { return [] }
-        let range = NSRange(output.startIndex..<output.endIndex, in: output)
-        return expression.matches(in: output, range: range)
+    private static func bytes(_ value: Substring, unit: Substring) -> Int64? {
+        guard let value = Double(value) else { return nil }
+        let multiplier: Double = switch unit {
+        case "KB": 1_000
+        case "MB": 1_000_000
+        case "GB": 1_000_000_000
+        default: 1
+        }
+        return Int64((value * multiplier).rounded())
     }
 
     private static func cachedDownloadPath(in output: String) -> String? {
@@ -322,24 +289,5 @@ nonisolated enum BrewProgressParser {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         let path = trimmed.dropFirst(prefix.count).trimmingCharacters(in: .whitespaces)
         return path.hasPrefix("/") ? path : nil
-    }
-
-    private static func value(
-        in output: String,
-        match: NSTextCheckingResult,
-        valueGroup: Int,
-        unitGroup: Int
-    ) -> Int64? {
-        guard let valueRange = Range(match.range(at: valueGroup), in: output),
-              let unitRange = Range(match.range(at: unitGroup), in: output),
-              let value = Double(output[valueRange])
-        else { return nil }
-        let multiplier: Double = switch output[unitRange] {
-        case "KB": 1_000
-        case "MB": 1_000_000
-        case "GB": 1_000_000_000
-        default: 1
-        }
-        return Int64((value * multiplier).rounded())
     }
 }

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Adoption.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Adoption.swift
@@ -60,14 +60,6 @@ extension LocalHomebrewService {
         }
     }
 
-    func cancelAdoptionRequest(token: String) {
-        operationStore.send(.clear, for: token)
-    }
-
-    func cancelPermissionRequest(token: String) {
-        operationStore.send(.clear, for: token)
-    }
-
     /// A linked artifact missing from the on-disk bundle makes Homebrew fail
     /// after it has moved the app aside. Its rollback can then remove the only
     /// copy. Check every bundle-relative link source before `--adopt` runs.

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Intents.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Intents.swift
@@ -103,11 +103,9 @@ extension LocalHomebrewService {
         switch intent {
         case let .cancel(token):
             cancelInstall(token: token)
-        case let .cancelAdoption(token):
-            cancelAdoptionRequest(token: token)
-        case let .cancelPermission(token):
-            cancelPermissionRequest(token: token)
-        case let .dismissFailure(token):
+        case let .cancelAdoption(token),
+             let .cancelPermission(token),
+             let .dismissFailure(token):
             clearError(for: token)
         default:
             return false

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Mutations.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Mutations.swift
@@ -20,23 +20,27 @@ extension LocalHomebrewService {
         _ action: CaskAction,
         token: String,
         args: [String],
-        origin: CaskActionOrigin = .individual,
-        environmentOverrides: [String: String] = [:],
-        recoverIf: (() -> Bool)? = nil
+        origin: CaskActionOrigin = .individual
     ) async throws {
-        try await mutationCoordinator.run(
-            HomebrewMutationRequest(
+        try await mutationCoordinator.runSequence(
+            HomebrewMutationSequenceRequest(
                 action: action,
                 token: token,
                 displayName: displayName(for: token),
-                arguments: args,
                 origin: origin,
-                environmentOverrides: environmentOverrides
+                steps: [
+                    HomebrewMutationStep(
+                        arguments: args,
+                        environmentOverrides: [:],
+                        cancellable: action == .installing,
+                        recoverIf: nil,
+                        recoveryBehavior: .finishMutation
+                    )
+                ]
             ),
             callbacks: HomebrewMutationCallbacks(
                 refresh: { [self] in await refresh() },
-                strandedCopyExists: { [self] in hasStrandedCopy(token: token) },
-                recoverIf: recoverIf
+                strandedCopyExists: { [self] in hasStrandedCopy(token: token) }
             )
         )
     }
@@ -61,8 +65,7 @@ extension LocalHomebrewService {
                     if action == .updatingHomebrew { invalidateBrewVersion() }
                     await refresh()
                 },
-                strandedCopyExists: { [self] in hasStrandedCopy(token: token) },
-                recoverIf: nil
+                strandedCopyExists: { [self] in hasStrandedCopy(token: token) }
             )
         )
     }

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewCommandExecutor.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewCommandExecutor.swift
@@ -74,21 +74,12 @@ final class SystemHomebrewCommandExecutor: HomebrewCommandExecuting {
     }
 
     private nonisolated static func signalTree(pid: Int32, signal: Int32) {
-        let pgrep = Process()
-        pgrep.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-        pgrep.arguments = ["-P", "\(pid)"]
-        let stdout = Pipe()
-        pgrep.standardOutput = stdout
-        pgrep.standardError = FileHandle.nullDevice
-        if (try? pgrep.run()) != nil {
-            let data = stdout.fileHandleForReading.readDataToEndOfFile()
-            pgrep.waitUntilExit()
-            let children = String(data: data, encoding: .utf8)?
-                .split(whereSeparator: \.isNewline)
-                .compactMap { Int32($0) } ?? []
-            for child in children {
-                signalTree(pid: child, signal: signal)
-            }
+        let output = ProcessCapture.capture(
+            URL(fileURLWithPath: "/usr/bin/pgrep"),
+            arguments: ["-P", "\(pid)"]
+        )?.output ?? ""
+        for child in output.split(whereSeparator: \.isNewline).compactMap({ Int32($0) }) {
+            signalTree(pid: child, signal: signal)
         }
         kill(pid, signal)
     }

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewInstallationScanner.swift
@@ -160,22 +160,6 @@ nonisolated struct HomebrewInstallationScanner: InstalledSoftwareScanning {
 }
 
 extension HomebrewInstallationScanner {
-    /// A missing Caskroom is valid for fresh or absent Homebrew installations.
-    static func scanCaskroom(
-        fileManager: FileManager,
-        applicationDirectories: [URL]? = nil
-    ) -> [String: LocalCaskInstallation] {
-        guard let caskroomURL = HomebrewLocator.caskroomURL(
-            fileManager: fileManager
-        ) else { return [:] }
-        return scanCaskroom(
-            at: caskroomURL,
-            fileManager: fileManager,
-            applicationDirectories: applicationDirectories
-                ?? ApplicationDiscovery.defaultDirectories(fileManager: fileManager)
-        )
-    }
-
     static func scanCaskroom(
         at caskroomURL: URL,
         fileManager: FileManager,

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewVersionLoader.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewVersionLoader.swift
@@ -7,26 +7,42 @@
 
 import Foundation
 
-nonisolated struct HomebrewVersionLoader: Sendable {
-    @concurrent
-    func load(from brewURL: URL?) async -> String? {
-        guard let brewURL else { return nil }
+nonisolated enum ProcessCapture {
+    /// One pipe serves both streams: a single read cannot deadlock on a full sibling buffer.
+    static func capture(
+        _ executableURL: URL,
+        arguments: [String],
+        environment: [String: String]? = nil,
+        mergeStderr: Bool = false
+    ) -> (status: Int32, output: String?)? {
         let process = Process()
-        process.executableURL = brewURL
-        process.arguments = ["--version"]
-        let stdoutPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = FileHandle.nullDevice
+        process.executableURL = executableURL
+        process.arguments = arguments
+        if let environment {
+            process.environment = ProcessInfo.processInfo.environment
+                .merging(environment) { _, override in override }
+        }
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = mergeStderr ? pipe : FileHandle.nullDevice
         do {
             try process.run()
         } catch {
             return nil
         }
-        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
-        guard process.terminationStatus == 0,
-              let firstLine = String(data: data, encoding: .utf8)?
-                .split(separator: "\n").first
+        return (process.terminationStatus, String(data: data, encoding: .utf8))
+    }
+}
+
+nonisolated struct HomebrewVersionLoader: Sendable {
+    @concurrent
+    func load(from brewURL: URL?) async -> String? {
+        guard let brewURL,
+              let result = ProcessCapture.capture(brewURL, arguments: ["--version"]),
+              result.status == 0,
+              let firstLine = result.output?.split(separator: "\n").first
         else { return nil }
         return firstLine.split(separator: " ").last.map(String.init)
     }

--- a/CaskHub/Services/Homebrew/Infrastructure/MaintenanceProbe.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/MaintenanceProbe.swift
@@ -75,28 +75,13 @@ nonisolated struct SystemMaintenanceProbe: MaintenanceProbing {
         arguments: [String],
         environment: [String: String]?
     ) async -> BrewProbeResult? {
-        let process = Process()
-        process.executableURL = executable
-        process.arguments = arguments
-        if let environment {
-            process.environment = ProcessInfo.processInfo.environment
-                .merging(environment) { _, override in override }
-        }
-        // One pipe for both streams: a single read cannot deadlock on a full sibling buffer.
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        return BrewProbeResult(
-            exitCode: process.terminationStatus,
-            output: String(data: data, encoding: .utf8) ?? ""
-        )
+        guard let result = ProcessCapture.capture(
+            executable,
+            arguments: arguments,
+            environment: environment,
+            mergeStderr: true
+        ) else { return nil }
+        return BrewProbeResult(exitCode: result.status, output: result.output ?? "")
     }
 
     @concurrent

--- a/CaskHub/Services/Homebrew/Infrastructure/PackageReceiptResolver.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/PackageReceiptResolver.swift
@@ -163,18 +163,7 @@ nonisolated struct PackageReceiptResolver: Sendable {
     }
 
     static func identifier(_ identifier: String, matches pattern: String) -> Bool {
-        guard pattern.contains("*") || pattern.contains("?") else {
-            return identifier == pattern
-        }
-        var expression = NSRegularExpression.escapedPattern(for: pattern)
-        expression = expression
-            .replacingOccurrences(of: "\\*", with: ".*")
-            .replacingOccurrences(of: "\\?", with: ".")
-        guard let regex = try? NSRegularExpression(pattern: "^\(expression)$") else {
-            return false
-        }
-        let range = NSRange(identifier.startIndex..., in: identifier)
-        return regex.firstMatch(in: identifier, range: range) != nil
+        fnmatch(pattern, identifier, 0) == 0
     }
 
     static func appBundleNames(inPackageFileList output: String) -> Set<String> {
@@ -208,20 +197,10 @@ nonisolated struct PackageReceiptResolver: Sendable {
     }
 
     private static func pkgutilOutput(arguments: [String]) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/pkgutil")
-        process.arguments = arguments
-        let output = Pipe()
-        process.standardOutput = output
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        let data = output.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else { return nil }
-        return String(data: data, encoding: .utf8)
+        guard let result = ProcessCapture.capture(
+            URL(fileURLWithPath: "/usr/sbin/pkgutil"),
+            arguments: arguments
+        ), result.status == 0 else { return nil }
+        return result.output
     }
 }

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -82,15 +82,15 @@ final class CaskCatalogViewModel {
     @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
 
     @ObservationIgnored let libraryCache =
-        MemoizedValue<CatalogLibraryCacheKey, CatalogLibrarySnapshot>()
+        BoundedMemoizedValues<CatalogLibraryCacheKey, CatalogLibrarySnapshot>(capacity: 1)
     @ObservationIgnored let filteredCache =
         BoundedMemoizedValues<FilteredCatalogCacheKey, [Cask]>(capacity: 16)
     @ObservationIgnored let browseCache =
-        MemoizedValue<BrowseCatalogCacheKey, [BrowseSection]>()
-    @ObservationIgnored let searchKeysCache = MemoizedValue<Int, [String: String]>()
-    @ObservationIgnored let nameRankCache = MemoizedValue<Int, [String: Int]>()
+        BoundedMemoizedValues<BrowseCatalogCacheKey, [BrowseSection]>(capacity: 1)
+    @ObservationIgnored let searchKeysCache = BoundedMemoizedValues<Int, [String: String]>(capacity: 1)
+    @ObservationIgnored let nameRankCache = BoundedMemoizedValues<Int, [String: Int]>(capacity: 1)
     @ObservationIgnored let categoryPresentationCache =
-        MemoizedValue<CategoryPresentationCacheKey, [String: CaskCategoryPresentation]>()
+        BoundedMemoizedValues<CategoryPresentationCacheKey, [String: CaskCategoryPresentation]>(capacity: 1)
 
     private static let periodKey = "analyticsPeriod"
     private static let windowKey = "recentlyAddedWindow"

--- a/CaskHub/ViewModels/Catalog/Projection/CatalogProjectionCache.swift
+++ b/CaskHub/ViewModels/Catalog/Projection/CatalogProjectionCache.swift
@@ -16,19 +16,6 @@ struct CatalogLibrarySnapshot {
     let localStates: [String: CaskLocalState]
 }
 
-final class MemoizedValue<Key: Equatable, Value> {
-    private var entry: (key: Key, value: Value)?
-
-    func value(for key: Key, create: () -> Value) -> Value {
-        if let entry, entry.key == key {
-            return entry.value
-        }
-        let value = create()
-        entry = (key, value)
-        return value
-    }
-}
-
 final class BoundedMemoizedValues<Key: Equatable, Value> {
     private let capacity: Int
     private var entries: [(key: Key, value: Value)] = []

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -43,19 +43,17 @@ struct ContentView: View {
             .navigationSplitViewColumnWidth(min: 245, ideal: 245, max: 300)
         } detail: {
             VStack(spacing: 0) {
-                if isUtilityPage {
-                    utilityTopBar
-                        .frame(maxWidth: CHSize.contentWidth)
-                        .padding(.horizontal, CHSpace.s5)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, CHSpace.s4)
-                } else {
-                    catalogTopBar
-                        .frame(maxWidth: CHSize.contentWidth)
-                        .padding(.horizontal, CHSpace.s5)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, CHSpace.s4)
+                Group {
+                    if isUtilityPage {
+                        utilityTopBar
+                    } else {
+                        catalogTopBar
+                    }
                 }
+                .frame(maxWidth: CHSize.contentWidth)
+                .padding(.horizontal, CHSpace.s5)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, CHSpace.s4)
 
                 if showsResultsHeader {
                     Text("Results for “\(viewModel.searchText)”")

--- a/CaskHub/Views/Maintenance/MaintenanceView.swift
+++ b/CaskHub/Views/Maintenance/MaintenanceView.swift
@@ -179,12 +179,7 @@ extension MaintenanceView {
         ) {
             switch model.homebrewState {
             case .idle where model.brewFreshness == .current:
-                StatusPill(
-                    title: String(localized: .maintenanceUpToDate),
-                    background: .chActionDoneBg,
-                    border: .chActionDoneBorder,
-                    foreground: .chActionDoneFg
-                )
+                StatusPill(title: String(localized: .maintenanceUpToDate))
             case .idle:
                 PillButton(
                     title: String(localized: .maintenanceWidgetHomebrewButton),
@@ -198,12 +193,7 @@ extension MaintenanceView {
             case .running:
                 WorkingPill(title: String(localized: .maintenanceWorking))
             case .done:
-                StatusPill(
-                    title: String(localized: .maintenanceWidgetHomebrewDone),
-                    background: .chActionDoneBg,
-                    border: .chActionDoneBorder,
-                    foreground: .chActionDoneFg
-                )
+                StatusPill(title: String(localized: .maintenanceWidgetHomebrewDone))
             }
         }
     }
@@ -238,12 +228,7 @@ extension MaintenanceView {
         ) {
             switch model.syncState {
             case .idle where model.collectionFreshness == .current:
-                StatusPill(
-                    title: String(localized: .maintenanceUpToDate),
-                    background: .chActionDoneBg,
-                    border: .chActionDoneBorder,
-                    foreground: .chActionDoneFg
-                )
+                StatusPill(title: String(localized: .maintenanceUpToDate))
             case .idle:
                 PillButton(
                     title: String(localized: .maintenanceWidgetSyncButton),
@@ -256,12 +241,7 @@ extension MaintenanceView {
             case .running:
                 WorkingPill(title: String(localized: .maintenanceWidgetSyncRunning))
             case .done:
-                StatusPill(
-                    title: String(localized: .maintenanceWidgetSyncDone),
-                    background: .chActionDoneBg,
-                    border: .chActionDoneBorder,
-                    foreground: .chActionDoneFg
-                )
+                StatusPill(title: String(localized: .maintenanceWidgetSyncDone))
             }
         }
     }
@@ -339,18 +319,15 @@ struct WorkingPill: View {
 
 struct StatusPill: View {
     let title: String
-    let background: Color
-    let border: Color
-    let foreground: Color
 
     var body: some View {
         Text(title)
             .font(CHType.button)
-            .foregroundStyle(foreground)
+            .foregroundStyle(Color.chActionDoneFg)
             .padding(.vertical, 4)
             .padding(.horizontal, 13)
-            .background(Capsule().fill(background))
-            .overlay(Capsule().strokeBorder(border, lineWidth: 1))
+            .background(Capsule().fill(Color.chActionDoneBg))
+            .overlay(Capsule().strokeBorder(Color.chActionDoneBorder, lineWidth: 1))
     }
 }
 

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -122,12 +122,8 @@ struct AboutSettingsView: View {
 
 struct GeneralSettingsView: View {
     @Environment(ImageCacheService.self) private var imageCache
-    @State private var settingsModel: GeneralSettingsModel
+    @State private var settingsModel = GeneralSettingsModel()
     @AppStorage(SidebarView.showAdoptKey) private var showAdoptApps = true
-
-    init(settingsModel: GeneralSettingsModel? = nil) {
-        _settingsModel = State(initialValue: settingsModel ?? GeneralSettingsModel())
-    }
 
     var body: some View {
         Form {

--- a/CaskHub/Views/Shared/CaskInfoPopover.swift
+++ b/CaskHub/Views/Shared/CaskInfoPopover.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CaskInfoPopover: View {
     let cask: Cask
     let category: CaskCategoryPresentation?
-    let downloadMetadataProvider: any DownloadMetadataProviding
+    let downloadMetadataProvider: DownloadMetadataProvider
 
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @State private var downloadSize: DownloadSizeResult?
@@ -18,8 +18,7 @@ struct CaskInfoPopover: View {
     init(
         cask: Cask,
         category: CaskCategoryPresentation?,
-        downloadMetadataProvider: any DownloadMetadataProviding =
-            DownloadMetadataProvider.shared
+        downloadMetadataProvider: DownloadMetadataProvider = .shared
     ) {
         self.cask = cask
         self.category = category
@@ -108,7 +107,7 @@ struct CaskInfoPopover: View {
             mainName: "Security & Privacy",
             subcategoryNames: ["Productivity"]
         ),
-        downloadMetadataProvider: UnavailableDownloadMetadataProvider()
+        downloadMetadataProvider: DownloadMetadataProvider { _ in nil }
     )
     .environment(LocalHomebrewService())
 }

--- a/CaskHub/Views/Sidebar/SidebarView.swift
+++ b/CaskHub/Views/Sidebar/SidebarView.swift
@@ -128,7 +128,17 @@ struct SidebarView: View {
         selection: .constant(.discover(.browse)),
         categoryService: {
             let service = CategoryService()
-            service.loadCategories()
+            service.applyData(CaskCategoryData(
+                version: 1,
+                generatedDate: "",
+                releaseTag: nil,
+                categories: [
+                    "productivity": CategoryDefinition(displayName: "Productivity", icon: "checklist"),
+                    "developerTools": CategoryDefinition(displayName: "Developer Tools", icon: "hammer")
+                ],
+                tokenToCategory: [:],
+                iconTokens: nil
+            ))
             return service
         }(),
         updatesCount: 1,

--- a/CaskHubTests/Catalog/CaskCatalogSortTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogSortTests.swift
@@ -19,17 +19,6 @@ final class CaskCatalogSortTests: XCTestCase {
         }
     }
 
-    private func detectedApplication(named name: String) -> DetectedApplication {
-        DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/\(name)"),
-            bundleName: name,
-            bundleIdentifier: "com.example.\(name)",
-            version: nil,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true
-        )
-    }
-
     private func localState(
         source: CaskInstallationSource,
         cask: Cask,
@@ -190,8 +179,8 @@ final class CaskCatalogSortTests: XCTestCase {
         )
         updateInstallationSnapshot(of: local) {
             $0.externalApplicationOwners = [
-                "able": detectedApplication(named: "Able.app"),
-                "bravo": detectedApplication(named: "Bravo.app")
+                "able": makeDetectedApplication("Able.app"),
+                "bravo": makeDetectedApplication("Bravo.app")
             ]
         }
 

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -409,10 +409,10 @@ final class CaskCatalogViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_recently_added_loads_bundled_offline_snapshot() {
+    func test_recently_added_loads_bundled_offline_snapshot() async {
         let recent = RecentlyAddedService()
 
-        recent.loadBundledDates()
+        await recent.loadBundledDatesAsync()
 
         XCTAssertFalse(recent.addedDates.isEmpty)
         XCTAssertFalse(recent.generatedDate.isEmpty)

--- a/CaskHubTests/Homebrew/Detection/ExternalApplicationOwnershipTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ExternalApplicationOwnershipTests.swift
@@ -9,14 +9,7 @@
 import XCTest
 
 final class ExternalApplicationOwnershipTests: XCTestCase {
-    private let glaze = DetectedApplication(
-        url: URL(fileURLWithPath: "/Applications/Glaze.app"),
-        bundleName: "Glaze.app",
-        bundleIdentifier: "app.glaze.macos.main",
-        version: nil,
-        isMacAppStore: false,
-        isDirectlyInApplicationDirectory: true
-    )
+    private let glaze = makeDetectedApplication("Glaze.app", id: "app.glaze.macos.main")
 
     private let glazeSignatures = [
         ApplicationCaskSignature(
@@ -30,20 +23,6 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
             bundleIdentifiers: ["app.glaze.macos.main"]
         )
     ]
-
-    private func storeApplication(
-        named bundleName: String,
-        bundleIdentifier: String
-    ) -> DetectedApplication {
-        DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/\(bundleName)"),
-            bundleName: bundleName,
-            bundleIdentifier: bundleIdentifier,
-            version: nil,
-            isMacAppStore: true,
-            isDirectlyInApplicationDirectory: true
-        )
-    }
 
     private func storeSignature(
         token: String,
@@ -90,14 +69,7 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
     }
 
     func test_shared_app_name_without_one_exact_identifier_match_is_not_adoptable() {
-        let application = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/Shared.app"),
-            bundleName: "Shared.app",
-            bundleIdentifier: "com.example.shared",
-            version: nil,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true
-        )
+        let application = makeDetectedApplication("Shared.app", id: "com.example.shared")
         let signatures = [
             ApplicationCaskSignature(
                 token: "shared-one",
@@ -121,14 +93,7 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
     }
 
     func test_unique_app_name_remains_adoptable_without_bundle_identifier_metadata() {
-        let application = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/Unique.app"),
-            bundleName: "Unique.app",
-            bundleIdentifier: "com.example.unique",
-            version: nil,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true
-        )
+        let application = makeDetectedApplication("Unique.app", id: "com.example.unique")
         let signature = ApplicationCaskSignature(
             token: "unique",
             appBundleNames: ["Unique.app"],
@@ -146,17 +111,20 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
 
     func test_store_resolution_indexes_direct_and_bundle_family_matches() {
         let applications = [
-            storeApplication(
-                named: "Canva.app",
-                bundleIdentifier: "com.canva.CanvaDesktop"
+            makeDetectedApplication(
+                "Canva.app",
+                id: "com.canva.CanvaDesktop",
+                isMacAppStore: true
             ),
-            storeApplication(
-                named: "Tailscale.app",
-                bundleIdentifier: "io.tailscale.ipn.macos"
+            makeDetectedApplication(
+                "Tailscale.app",
+                id: "io.tailscale.ipn.macos",
+                isMacAppStore: true
             ),
-            storeApplication(
-                named: "Shade.app",
-                bundleIdentifier: "com.limit-point.Shade"
+            makeDetectedApplication(
+                "Shade.app",
+                id: "com.limit-point.Shade",
+                isMacAppStore: true
             )
         ]
         let signatures = [
@@ -198,13 +166,10 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
             installedAt: nil,
             appBundleNames: ["Store.app"]
         )
-        let storeApplication = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/Store.app"),
-            bundleName: "Store.app",
-            bundleIdentifier: "com.example.store",
-            version: nil,
-            isMacAppStore: true,
-            isDirectlyInApplicationDirectory: true
+        let storeApplication = makeDetectedApplication(
+            "Store.app",
+            id: "com.example.store",
+            isMacAppStore: true
         )
         let cliURL = URL(fileURLWithPath: "/usr/local/bin/tool")
 
@@ -245,14 +210,7 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
                 launchableBundleNames: ["Gone.app"]
             )
         ]
-        let liveApplication = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/Live.app"),
-            bundleName: "Live.app",
-            bundleIdentifier: "com.example.live",
-            version: nil,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true
-        )
+        let liveApplication = makeDetectedApplication("Live.app", id: "com.example.live")
         let installed = [
             "live": LocalCaskInstallation(
                 token: "live", installedVersion: "1.0", installedAt: nil,
@@ -350,9 +308,10 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
             makeCask("store-\(index)", appNames: ["Store \(index).app"])
         }
         let applications = (0..<itemCount).map { index in
-            storeApplication(
-                named: "Store \(index).app",
-                bundleIdentifier: "com.example.store\(index)"
+            makeDetectedApplication(
+                "Store \(index).app",
+                id: "com.example.store\(index)",
+                isMacAppStore: true
             )
         }
         let storeSignatures = casks.map { cask in

--- a/CaskHubTests/Homebrew/Detection/ExternalInstallationTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ExternalInstallationTests.swift
@@ -261,13 +261,10 @@ final class ExternalInstallationTests: XCTestCase {
             $0.installationIndex = CaskInstallationIndex(
                 catalogTokens: [store.token, package.token],
                 macAppStoreApplications: [
-                    store.token: DetectedApplication(
-                        url: URL(fileURLWithPath: "/Applications/Store App.app"),
-                        bundleName: "Store App.app",
-                        bundleIdentifier: "com.example.store-app",
-                        version: nil,
-                        isMacAppStore: true,
-                        isDirectlyInApplicationDirectory: true
+                    store.token: makeDetectedApplication(
+                        "Store App.app",
+                        id: "com.example.store-app",
+                        isMacAppStore: true
                     )
                 ],
                 externalCLIPaths: [:]

--- a/CaskHubTests/Homebrew/Detection/InstallationSnapshotTests.swift
+++ b/CaskHubTests/Homebrew/Detection/InstallationSnapshotTests.swift
@@ -18,14 +18,7 @@ final class InstallationSnapshotTests: XCTestCase {
             installedAt: nil,
             appBundleNames: ["Firefox.app"]
         )
-        let application = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/Firefox.app"),
-            bundleName: "Firefox.app",
-            bundleIdentifier: "org.mozilla.firefox",
-            version: nil,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true
-        )
+        let application = makeDetectedApplication("Firefox.app", id: "org.mozilla.firefox")
         let snapshot = InstallationSnapshot(
             installedCasks: ["firefox": installed],
             applications: ApplicationInstallationSnapshot(
@@ -72,10 +65,7 @@ final class InstallationSnapshotTests: XCTestCase {
             ],
             scannedAt: Date(timeIntervalSince1970: 200)
         )
-        let scanner = StubInstalledSoftwareScanner(
-            scanned: scanned,
-            reconciled: scanned
-        )
+        let scanner = FixedInstalledSoftwareScanner(snapshot: scanned)
         let service = LocalHomebrewService(
             defaults: makeScratchDefaults("snapshot-scanner")
         ) {
@@ -128,13 +118,9 @@ final class InstallationSnapshotTests: XCTestCase {
     func test_local_date_lookup_uses_the_snapshot_token_index() {
         let indexedDate = Date(timeIntervalSince1970: 400)
         let unrelatedDate = Date(timeIntervalSince1970: 500)
-        let unrelatedApplication = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/Shared.app"),
-            bundleName: "Shared.app",
-            bundleIdentifier: "com.example.unrelated",
-            version: nil,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true,
+        let unrelatedApplication = makeDetectedApplication(
+            "Shared.app",
+            id: "com.example.unrelated",
             installedAt: unrelatedDate
         )
         let service = LocalHomebrewService(
@@ -165,22 +151,6 @@ final class InstallationSnapshotTests: XCTestCase {
         )
 
         XCTAssertEqual(service.installationDates(for: cask)?.installedAt, indexedDate)
-    }
-}
-
-private nonisolated struct StubInstalledSoftwareScanner: InstalledSoftwareScanning {
-    let scanned: InstallationSnapshot
-    let reconciled: InstallationSnapshot
-
-    func scan(_ request: InstalledSoftwareScanRequest) async -> InstallationSnapshot {
-        scanned
-    }
-
-    func reconcileCatalog(
-        _ request: InstalledSoftwareScanRequest,
-        with current: InstallationSnapshot
-    ) async -> InstallationSnapshot {
-        reconciled
     }
 }
 

--- a/CaskHubTests/Homebrew/Domain/CaskOperationProgressTests.swift
+++ b/CaskHubTests/Homebrew/Domain/CaskOperationProgressTests.swift
@@ -279,28 +279,21 @@ final class CaskOperationProgressTests: XCTestCase {
         )
         await service.mutationCoordinator.awaitPendingOutput()
 
-        render(CaskActionsView(cask: makeCask("plain")).environment(service))
-        render(CaskActionsView(cask: makeCask("plain"), fullWidth: false).environment(service))
+        render(CaskActionsView(cask: makeCask("plain")).environment(service), width: 420, height: 400)
+        render(CaskActionsView(cask: makeCask("plain"), fullWidth: false).environment(service), width: 420, height: 400)
         render(
             StatusBarView(
                 caskCount: 3_781,
                 caskFlowRelease: "caskflow-v2026.07.18",
                 operation: service.statusBarOperation
-            )
-        )
+            ),
+            width: 420, height: 400)
         render(
             ObservedStatusBarView(
                 caskCount: 3_781,
                 caskFlowRelease: "caskflow-v2026.07.18"
             )
-            .environment(service)
-        )
-    }
-
-    @MainActor
-    private func render(_ view: some View, width: CGFloat = 420, height: CGFloat = 400) {
-        let hosting = NSHostingView(rootView: AnyView(view))
-        hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
-        hosting.layoutSubtreeIfNeeded()
+            .environment(service),
+            width: 420, height: 400)
     }
 }

--- a/CaskHubTests/Homebrew/Infrastructure/InstallationDateIndexTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/InstallationDateIndexTests.swift
@@ -13,23 +13,18 @@ final class InstallationDateIndexTests: XCTestCase {
         let homebrewInstalledAt = Date(timeIntervalSince1970: 100)
         let storeCreatedAt = Date(timeIntervalSince1970: 200)
         let packageCreatedAt = Date(timeIntervalSince1970: 300)
-        let storeApplication = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/Shared.app"),
-            bundleName: "Shared.app",
-            bundleIdentifier: "com.example.store",
-            version: nil,
+        let storeApplication = makeDetectedApplication(
+            "Shared.app",
+            id: "com.example.store",
             isMacAppStore: true,
-            isDirectlyInApplicationDirectory: true,
             installedAt: storeCreatedAt
         )
-        let packageApplication = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/Direct/Shared.app"),
-            bundleName: "Shared.app",
-            bundleIdentifier: "com.example.direct",
-            version: nil,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: false,
-            installedAt: packageCreatedAt
+        let packageApplication = makeDetectedApplication(
+            "Shared.app",
+            id: "com.example.direct",
+            inApplicationsDirectory: false,
+            installedAt: packageCreatedAt,
+            url: URL(fileURLWithPath: "/Applications/Direct/Shared.app")
         )
 
         let dates = InstallationIndexBuilder().resolveInstallationDates(

--- a/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
+++ b/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
@@ -293,12 +293,8 @@ final class CaskHubTests: XCTestCase {
             appNames: ["ChatGPT Classic.app"]
         )
         let replaceCask = makeCask("canva", appNames: ["Canva.app"])
-        let adoptApplication = externalApplication(
-            named: "ChatGPT Classic.app", version: "1.0"
-        )
-        let replaceApplication = externalApplication(
-            named: "Canva.app", version: "2.0"
-        )
+        let adoptApplication = makeDetectedApplication("ChatGPT Classic.app", version: "1.0")
+        let replaceApplication = makeDetectedApplication("Canva.app", version: "2.0")
         updateInstallationSnapshot(of: service) {
             $0.externalAppNames = [
                 adoptApplication.bundleName,
@@ -332,7 +328,7 @@ final class CaskHubTests: XCTestCase {
         try await Task.sleep(for: .milliseconds(100))
         XCTAssertEqual(service.operationStore.pendingPermissions.count, 2)
 
-        service.cancelPermissionRequest(token: "canva")
+        service.clearError(for: "canva")
         XCTAssertNil(service.operationStore.pendingPermissions["canva"])
     }
 
@@ -483,17 +479,4 @@ final class CaskHubTests: XCTestCase {
         XCTAssertEqual(vm.filteredCasks.map(\.token), ["google-chrome"])
     }
 
-    private func externalApplication(
-        named bundleName: String,
-        version: String
-    ) -> DetectedApplication {
-        DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/\(bundleName)"),
-            bundleName: bundleName,
-            bundleIdentifier: "com.example.\(bundleName)",
-            version: version,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true
-        )
-    }
 }

--- a/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
@@ -129,13 +129,6 @@ final class CaskActionPresentationTests: XCTestCase {
 
 final class AdoptionViewRenderTests: XCTestCase {
     @MainActor
-    private func render(_ view: some View, width: CGFloat = 420, height: CGFloat = 400) {
-        let hosting = NSHostingView(rootView: AnyView(view))
-        hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
-        hosting.layoutSubtreeIfNeeded()
-    }
-
-    @MainActor
     func test_cask_actions_render_every_external_state() {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("render-actions"))
         updateInstallationSnapshot(of: service) {
@@ -155,18 +148,18 @@ final class AdoptionViewRenderTests: XCTestCase {
         }
 
         let adoptable = makeCask("chrome", appNames: ["Chrome.app"])
-        render(CaskActionsView(cask: adoptable).environment(service).environment(\.isAdoptPage, true))
+        render(CaskActionsView(cask: adoptable).environment(service).environment(\.isAdoptPage, true), width: 420, height: 400)
         render(
             CaskActionsView(cask: adoptable, usesIconOnlyOpenAndUpdate: true)
-                .environment(service)
-        )
-        render(CaskActionsView(cask: makeCask("store", appNames: ["Store.app"])).environment(service))
-        render(CaskActionsView(cask: makeCask("claude-code", binaryNames: ["claude"])).environment(service))
-        render(CaskActionsView(cask: makeCask("plain")).environment(service))
+                .environment(service),
+            width: 420, height: 400)
+        render(CaskActionsView(cask: makeCask("store", appNames: ["Store.app"])).environment(service), width: 420, height: 400)
+        render(CaskActionsView(cask: makeCask("claude-code", binaryNames: ["claude"])).environment(service), width: 420, height: 400)
+        render(CaskActionsView(cask: makeCask("plain")).environment(service), width: 420, height: 400)
         render(
             CaskActionsView(cask: makeCask("managed", version: "2.0"), onUninstall: {})
-                .environment(service)
-        )
+                .environment(service),
+            width: 420, height: 400)
     }
 
     @MainActor
@@ -191,8 +184,8 @@ final class AdoptionViewRenderTests: XCTestCase {
         render(
             Text("host")
                 .caskActionAlerts(for: cask, showUninstallConfirmation: .constant(false))
-                .environment(service)
-        )
+                .environment(service),
+            width: 420, height: 400)
     }
 
     @MainActor
@@ -203,13 +196,13 @@ final class AdoptionViewRenderTests: XCTestCase {
                 cask: makeCask("mystery", appNames: ["NoSuchApp.app"]),
                 category: nil
             )
-            .environment(service)
-        )
+            .environment(service),
+            width: 420, height: 400)
 
         updateInstalledCask(LocalCaskInstallation(
             token: "known", installedVersion: "3.1", installedAt: .now, appBundleNames: []
         ), in: service)
-        render(CaskInfoPopover(cask: makeCask("known"), category: nil).environment(service))
+        render(CaskInfoPopover(cask: makeCask("known"), category: nil).environment(service), width: 420, height: 400)
     }
 
     @MainActor

--- a/CaskHubTests/Homebrew/Presentation/CaskListActionTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskListActionTests.swift
@@ -23,18 +23,6 @@ final class CaskListActionTests: XCTestCase {
         return cache
     }
 
-    @discardableResult
-    private func render(
-        _ view: some View,
-        width: CGFloat = 760,
-        height: CGFloat = 64
-    ) -> NSHostingView<AnyView> {
-        let hosting = NSHostingView(rootView: AnyView(view))
-        hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
-    }
-
     private func row(
         _ cask: Cask,
         service: LocalHomebrewService,
@@ -135,7 +123,7 @@ final class CaskListActionTests: XCTestCase {
             presentMenu: { presentedTitles = $0.items.map(\.title) }
         )
 
-        render(button)
+        render(button, width: 760, height: 64)
         button.presentActionsMenu()
 
         XCTAssertEqual(
@@ -201,10 +189,10 @@ final class CaskListActionTests: XCTestCase {
             ]
         }
 
-        render(row(makeCask("plain", desc: "A new app"), service: service))
-        render(row(makeCask("adoptable", appNames: ["Adoptable.app"]), service: service))
-        render(row(makeCask("store", appNames: ["Store.app"]), service: service))
-        render(row(makeCask("native", binaryNames: ["native-cli"]), service: service, downloads: nil))
+        render(row(makeCask("plain", desc: "A new app"), service: service), width: 760, height: 64)
+        render(row(makeCask("adoptable", appNames: ["Adoptable.app"]), service: service), width: 760, height: 64)
+        render(row(makeCask("store", appNames: ["Store.app"]), service: service), width: 760, height: 64)
+        render(row(makeCask("native", binaryNames: ["native-cli"]), service: service, downloads: nil), width: 760, height: 64)
     }
 
     func test_list_rows_render_every_managed_action_layout() throws {
@@ -231,20 +219,20 @@ final class CaskListActionTests: XCTestCase {
             appBundleNames: ["Managed.app"]
         ), in: service)
 
-        render(row(managed, service: service))
-        render(row(makeCask("managed", version: "2.0", appNames: ["Managed.app"]), service: service))
+        render(row(managed, service: service), width: 760, height: 64)
+        render(row(makeCask("managed", version: "2.0", appNames: ["Managed.app"]), service: service), width: 760, height: 64)
 
         service.operationStore.send(.enqueue(.updating), for: managed.token)
-        render(row(managed, service: service))
+        render(row(managed, service: service), width: 760, height: 64)
         service.operationStore.send(.clear, for: managed.token)
 
         let installedOnly = makeCask("installed-only")
         updateInstalledCask(installation(installedOnly.token, version: "1.0"), in: service)
-        render(row(installedOnly, service: service))
+        render(row(installedOnly, service: service), width: 760, height: 64)
 
         let updateOnly = makeCask("update-only", version: "2.0")
         updateInstalledCask(installation(updateOnly.token, version: "1.0"), in: service)
-        render(row(updateOnly, service: service))
+        render(row(updateOnly, service: service), width: 760, height: 64)
 
         let zombie = makeCask("zombie", appNames: ["Missing.app"])
         updateInstalledCask(LocalCaskInstallation(
@@ -254,7 +242,7 @@ final class CaskListActionTests: XCTestCase {
             appBundleNames: ["Missing.app"],
             isZombie: true
         ), in: service)
-        render(row(zombie, service: service))
+        render(row(zombie, service: service), width: 760, height: 64)
     }
 
     func test_icon_only_open_and_update_controls_render() {
@@ -262,7 +250,7 @@ final class CaskListActionTests: XCTestCase {
             HStack {
                 ActionCapsuleIconButton(action: .open) {}
                 ActionCapsuleIconButton(action: .update) {}
-            }
-        )
+            },
+            width: 760, height: 64)
     }
 }

--- a/CaskHubTests/Homebrew/Presentation/MaintenanceViewModelTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/MaintenanceViewModelTests.swift
@@ -9,47 +9,6 @@
 import XCTest
 
 final class MaintenanceViewModelTests: XCTestCase {
-    @MainActor
-    private func makeHomebrew(
-        defaults: UserDefaults,
-        executor: RecordingHomebrewCommandExecutor? = nil
-    ) -> LocalHomebrewService {
-        LocalHomebrewService(defaults: defaults) {
-            $0.softwareScanner = EmptyInstalledSoftwareScanner()
-            $0.brewBinaryProvider = { URL(fileURLWithPath: "/opt/homebrew/bin/brew") }
-            $0.brewVersionProvider = { "4.6.15" }
-            if let executor { $0.commandExecutor = executor }
-        }
-    }
-
-    @MainActor
-    private func makeModel(
-        probe: RecordingMaintenanceProbe? = nil,
-        homebrew: LocalHomebrewService? = nil,
-        clearImageCache: @escaping () async -> Void = {},
-        latestReleaseTag: @escaping (String, String) async -> String? = { _, _ in nil },
-        categories: CategoryService? = nil,
-        defaults: UserDefaults? = nil,
-        function: String = #function
-    ) -> MaintenanceViewModel {
-        let probe = probe ?? RecordingMaintenanceProbe()
-        let defaults = defaults ?? makeScratchDefaults(function)
-        let service = homebrew ?? makeHomebrew(defaults: defaults)
-        let catalog = makeViewModel(
-            api: MockBrewAPIClient(),
-            categories: categories,
-            localHomebrew: service
-        )
-        return MaintenanceViewModel(
-            localHomebrew: service,
-            catalog: catalog,
-            clearImageCache: clearImageCache,
-            probe: probe,
-            latestReleaseTag: latestReleaseTag,
-            defaults: defaults
-        )
-    }
-
     // MARK: - Checkup
 
     @MainActor
@@ -65,7 +24,7 @@ final class MaintenanceViewModelTests: XCTestCase {
             """)
         ]
         let defaults = makeScratchDefaults("checkup-warnings")
-        let model = makeModel(probe: probe, defaults: defaults)
+        let model = makeMaintenanceModel(probe: probe, defaults: defaults)
 
         await model.runCheckup()
 
@@ -77,7 +36,7 @@ final class MaintenanceViewModelTests: XCTestCase {
         XCTAssertNotNil(model.lastChecked)
         XCTAssertNotNil(model.topBarSummary)
 
-        let relaunched = makeModel(defaults: defaults)
+        let relaunched = makeMaintenanceModel(defaults: defaults)
         XCTAssertEqual(relaunched.advisoryCount, 2)
         XCTAssertNotNil(relaunched.lastChecked)
     }
@@ -89,7 +48,7 @@ final class MaintenanceViewModelTests: XCTestCase {
             "-p": BrewProbeResult(exitCode: 0, output: "/Library/Developer/CommandLineTools\n"),
             "doctor": BrewProbeResult(exitCode: 0, output: "Your system is ready to brew.\n")
         ]
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
 
         await model.runCheckup()
 
@@ -105,7 +64,7 @@ final class MaintenanceViewModelTests: XCTestCase {
             "-p": BrewProbeResult(exitCode: 2, output: "xcode-select: error: unable to get active developer directory\n"),
             "doctor": BrewProbeResult(exitCode: 0, output: "Your system is ready to brew.\n")
         ]
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
 
         await model.runCheckup()
 
@@ -116,7 +75,7 @@ final class MaintenanceViewModelTests: XCTestCase {
     @MainActor
     func test_checkup_runs_doctor_with_brew_path_first() async {
         let probe = RecordingMaintenanceProbe()
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
 
         await model.runCheckup()
 
@@ -151,7 +110,7 @@ final class MaintenanceViewModelTests: XCTestCase {
         probe.cachedInstallersResult = [
             CachedInstaller(name: "foo--1.0.zip", bytes: 900)
         ]
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
         XCTAssertFalse(model.hasDiskSnapshot)
 
         await model.refreshDisk()
@@ -176,7 +135,7 @@ final class MaintenanceViewModelTests: XCTestCase {
     @MainActor
     func test_clean_orphans_runs_autoremove_and_zeroes_row() async {
         let probe = RecordingMaintenanceProbe()
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
 
         await model.clean(.orphans)
 
@@ -192,7 +151,7 @@ final class MaintenanceViewModelTests: XCTestCase {
         probe.cachedInstallersResult = [
             CachedInstaller(name: "foo--1.0.zip", bytes: 900)
         ]
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
         await model.refreshDisk()
 
         await model.clean(.cache)
@@ -208,7 +167,7 @@ final class MaintenanceViewModelTests: XCTestCase {
     @MainActor
     func test_clean_image_cache_calls_injected_closure() async {
         var cleared = false
-        let model = makeModel(clearImageCache: { cleared = true })
+        let model = makeMaintenanceModel(clearImageCache: { cleared = true })
 
         await model.clean(.imageCache)
 
@@ -223,7 +182,7 @@ final class MaintenanceViewModelTests: XCTestCase {
         probe.resultsByFirstArgument = [
             "autoremove": BrewProbeResult(exitCode: 1, output: "Error: nope")
         ]
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
 
         await model.clean(.orphans)
 
@@ -234,7 +193,7 @@ final class MaintenanceViewModelTests: XCTestCase {
     @MainActor
     func test_apps_row_is_not_cleanable() async {
         let probe = RecordingMaintenanceProbe()
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
 
         await model.clean(.apps)
 
@@ -247,11 +206,11 @@ final class MaintenanceViewModelTests: XCTestCase {
     @MainActor
     func test_updateHomebrew_runs_two_update_passes() async {
         let executor = RecordingHomebrewCommandExecutor()
-        let homebrew = makeHomebrew(
+        let homebrew = makeMaintenanceHomebrew(
             defaults: makeScratchDefaults("update-homebrew"),
             executor: executor
         )
-        let model = makeModel(homebrew: homebrew)
+        let model = makeMaintenanceModel(homebrew: homebrew)
 
         await model.updateHomebrew()
 
@@ -274,7 +233,7 @@ final class MaintenanceViewModelTests: XCTestCase {
             $0.brewBinaryProvider = { URL(fileURLWithPath: "/opt/homebrew/bin/brew") }
             $0.brewVersionProvider = { "4.6.15" }
         }
-        let model = makeModel(homebrew: homebrew)
+        let model = makeMaintenanceModel(homebrew: homebrew)
 
         await model.updateHomebrew()
 
@@ -285,27 +244,13 @@ final class MaintenanceViewModelTests: XCTestCase {
     // MARK: - Freshness
 
     @MainActor
-    private func makeSeededCategories(tag: String?) -> CategoryService {
-        let service = CategoryService()
-        service.applyData(CaskCategoryData(
-            version: 1,
-            generatedDate: "2026-08-18",
-            releaseTag: tag,
-            categories: [:],
-            tokenToCategory: [:],
-            iconTokens: nil
-        ))
-        return service
-    }
-
-    @MainActor
     func test_freshness_marks_both_widgets_current() async {
-        let homebrew = makeHomebrew(defaults: makeScratchDefaults("freshness-current"))
+        let homebrew = makeMaintenanceHomebrew(defaults: makeScratchDefaults("freshness-current"))
         await homebrew.refresh()
-        let model = makeModel(
+        let model = makeMaintenanceModel(
             homebrew: homebrew,
             latestReleaseTag: { _, repo in repo == "brew" ? "4.6.15" : "v0.7.1" },
-            categories: makeSeededCategories(tag: "v0.7.1")
+            categories: seededCategories([:], categories: [:], releaseTag: "v0.7.1")
         )
 
         await model.refreshFreshness()
@@ -316,12 +261,12 @@ final class MaintenanceViewModelTests: XCTestCase {
 
     @MainActor
     func test_freshness_reports_updates_available() async {
-        let homebrew = makeHomebrew(defaults: makeScratchDefaults("freshness-behind"))
+        let homebrew = makeMaintenanceHomebrew(defaults: makeScratchDefaults("freshness-behind"))
         await homebrew.refresh()
-        let model = makeModel(
+        let model = makeMaintenanceModel(
             homebrew: homebrew,
             latestReleaseTag: { _, repo in repo == "brew" ? "9.9.9" : "v0.8.0" },
-            categories: makeSeededCategories(tag: "v0.7.1")
+            categories: seededCategories([:], categories: [:], releaseTag: "v0.7.1")
         )
 
         await model.refreshFreshness()
@@ -332,7 +277,7 @@ final class MaintenanceViewModelTests: XCTestCase {
 
     @MainActor
     func test_freshness_is_unknown_when_the_check_fails() async {
-        let model = makeModel(latestReleaseTag: { _, _ in nil })
+        let model = makeMaintenanceModel(latestReleaseTag: { _, _ in nil })
 
         await model.refreshFreshness()
 
@@ -343,9 +288,9 @@ final class MaintenanceViewModelTests: XCTestCase {
     @MainActor
     func test_freshness_check_is_cached_within_the_ttl() async {
         let counter = Counter()
-        let homebrew = makeHomebrew(defaults: makeScratchDefaults("freshness-ttl"))
+        let homebrew = makeMaintenanceHomebrew(defaults: makeScratchDefaults("freshness-ttl"))
         await homebrew.refresh()
-        let model = makeModel(
+        let model = makeMaintenanceModel(
             homebrew: homebrew,
             latestReleaseTag: { _, _ in
                 counter.value += 1
@@ -369,7 +314,7 @@ final class MaintenanceViewModelTests: XCTestCase {
 
     @MainActor
     func test_directories_point_at_the_expected_caches() {
-        let model = makeModel()
+        let model = makeMaintenanceModel()
         XCTAssertEqual(
             model.directories(for: .cache).map(\.lastPathComponent),
             ["Homebrew"]

--- a/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
@@ -29,8 +29,6 @@ final class StubBrewProcessRunner: BrewProcessRunning {
     }
 
     var queuedResults: [BrewProcessResult] = []
-    var queuedChunks: [[String]] = []
-    var thrownError: Error?
     var onRequest: ((Request) throws -> Void)?
     private(set) var requests: [Request] = []
 
@@ -39,7 +37,7 @@ final class StubBrewProcessRunner: BrewProcessRunning {
         arguments: [String],
         environment: [String: String],
         onStart _: @escaping (Process) -> Void,
-        onChunk: @escaping @MainActor @Sendable (String) -> Void
+        onChunk _: @escaping @MainActor @Sendable (String) -> Void
     ) async throws -> BrewProcessResult {
         let askpassContents = environment["SUDO_ASKPASS"].flatMap {
             try? String(contentsOfFile: $0, encoding: .utf8)
@@ -52,10 +50,6 @@ final class StubBrewProcessRunner: BrewProcessRunning {
         )
         requests.append(request)
         try onRequest?(request)
-        if let thrownError { throw thrownError }
-        if !queuedChunks.isEmpty {
-            queuedChunks.removeFirst().forEach(onChunk)
-        }
         return queuedResults.isEmpty
             ? BrewProcessResult(exitCode: 0, output: "")
             : queuedResults.removeFirst()
@@ -65,50 +59,6 @@ final class StubBrewProcessRunner: BrewProcessRunning {
 // MARK: - Adoption error surfaces & scans
 
 final class AdoptionSurfaceTests: XCTestCase {
-    @MainActor
-    private func makeMutationService(runner: StubBrewProcessRunner) -> LocalHomebrewService {
-        LocalHomebrewService(
-            defaults: makeScratchDefaults("mutation-runner-\(UUID().uuidString)")
-        ) {
-            $0.fileManager = NoFilesFileManager()
-            $0.processRunner = runner
-            $0.brewBinaryProvider = {
-                URL(fileURLWithPath: "/test/bin/brew")
-            }
-            $0.brewVersionProvider = { "test" }
-        }
-    }
-
-    @MainActor
-    private func seedExternalInstallation(
-        of cask: Cask,
-        version: String?,
-        in service: LocalHomebrewService
-    ) {
-        let bundleName = (cask.packageAppNameCandidates + cask.appArtifactNames).first
-            ?? "\(cask.displayName).app"
-        let application = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/\(bundleName)"),
-            bundleName: bundleName,
-            bundleIdentifier: "com.example.\(cask.token)",
-            version: version,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true
-        )
-        updateInstallationSnapshot(of: service) {
-            $0.detectedApplications.append(application)
-            if cask.hasPackageArtifact {
-                $0.externalPackageInstallations[cask.token] = ExternalPackageInstallation(
-                    appBundleNames: [bundleName]
-                )
-                $0.externalPackageApplicationOwners[cask.token] = application
-            } else {
-                $0.externalAppNames.insert(bundleName)
-                $0.externalApplicationOwners[cask.token] = application
-            }
-        }
-    }
-
     func test_error_descriptions_cover_every_case() {
         XCTAssertNotNil(LocalHomebrewError.brewBinaryNotFound.errorDescription)
         XCTAssertTrue(
@@ -203,15 +153,6 @@ final class AdoptionSurfaceTests: XCTestCase {
         service.openExternalApp(cask: external)
         XCTAssertNotNil(service.operationStore.state(for: "ghost2")?.failure?.message)
         XCTAssertNil(service.externalAppVersion(for: external))
-    }
-
-    func test_missing_caskroom_scans_as_no_installed_casks() {
-        XCTAssertEqual(
-            HomebrewInstallationScanner.scanCaskroom(
-                fileManager: NoFilesFileManager()
-            ).count,
-            0
-        )
     }
 
     @MainActor
@@ -467,10 +408,6 @@ final class AdoptionSurfaceTests: XCTestCase {
          {"bash_completion": ["Docker.app/Contents/Resources/etc/docker-compose.bash-completion"]}]
         """.utf8)
         let stanzas = try JSONDecoder().decode([ArtifactStanza].self, from: json)
-        XCTAssertEqual(
-            stanzas[1].binarySourcePaths,
-            ["/Applications/Obsidian.app/Contents/MacOS/obsidian-cli"]
-        )
         XCTAssertEqual(stanzas[1].binaryNames, ["obsidian"])
         XCTAssertEqual(
             stanzas.flatMap(\.adoptionSourcePaths),

--- a/CaskHubTests/Homebrew/Workflows/CaskAdoptionWorkflowTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/CaskAdoptionWorkflowTests.swift
@@ -10,51 +10,6 @@ import XCTest
 
 @MainActor
 final class CaskAdoptionWorkflowTests: XCTestCase {
-    private func makeService(
-        runner: StubBrewProcessRunner,
-        scanner: (any InstalledSoftwareScanning)? = nil
-    ) -> LocalHomebrewService {
-        let service = LocalHomebrewService(
-            defaults: makeScratchDefaults("planned-adoption-\(UUID().uuidString)")
-        ) {
-            $0.fileManager = NoFilesFileManager()
-            $0.processRunner = runner
-            $0.softwareScanner = scanner
-            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
-            $0.brewVersionProvider = { "test" }
-        }
-        service.permissionProbe = { .granted }
-        return service
-    }
-
-    private func seedExternalInstallation(
-        cask: Cask,
-        version: String,
-        service: LocalHomebrewService
-    ) {
-        let bundleName = (cask.packageAppNameCandidates + cask.appArtifactNames).first
-            ?? "\(cask.displayName).app"
-        let application = DetectedApplication(
-            url: URL(fileURLWithPath: "/Applications/\(bundleName)"),
-            bundleName: bundleName,
-            bundleIdentifier: "com.example.\(cask.token)",
-            version: version,
-            isMacAppStore: false,
-            isDirectlyInApplicationDirectory: true
-        )
-        updateInstallationSnapshot(of: service) {
-            if cask.hasPackageArtifact {
-                $0.externalPackageInstallations[cask.token] = ExternalPackageInstallation(
-                    appBundleNames: [bundleName]
-                )
-                $0.externalPackageApplicationOwners[cask.token] = application
-            } else {
-                $0.externalAppNames.insert(bundleName)
-                $0.externalApplicationOwners[cask.token] = application
-            }
-        }
-    }
-
     func test_application_plan_executes_adopt_or_replace_from_version_relation() async throws {
         try await assertApplicationExecution(
             installedVersion: "1.0",
@@ -72,7 +27,7 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
 
     func test_onedrive_newer_package_executes_staged_downgrade() async throws {
         let runner = StubBrewProcessRunner()
-        let service = makeService(runner: runner)
+        let service = makeMutationService(runner: runner, permissionProbe: { .granted })
         let cask = makeCask(
             "onedrive",
             name: "OneDrive",
@@ -80,11 +35,7 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
             packageIdentifiers: ["com.microsoft.OneDrive"],
             packageAppNames: ["OneDrive.app"]
         )
-        seedExternalInstallation(
-            cask: cask,
-            version: "26.129.0706",
-            service: service
-        )
+        seedExternalInstallation(of: cask, version: "26.129.0706", in: service)
 
         await service.requestAdoption(cask)
         let request = try XCTUnwrap(
@@ -105,7 +56,7 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
 
     func test_same_version_package_executes_staged_replacement() async throws {
         let runner = StubBrewProcessRunner()
-        let service = makeService(runner: runner)
+        let service = makeMutationService(runner: runner, permissionProbe: { .granted })
         let cask = makeCask(
             "ilok-license-manager",
             name: "iLok License Manager",
@@ -113,7 +64,7 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
             packageIdentifiers: ["com.paceap.pkg.iLokLicenseManager"],
             packageAppNames: ["iLok License Manager.app"]
         )
-        seedExternalInstallation(cask: cask, version: "6.2.0", service: service)
+        seedExternalInstallation(of: cask, version: "6.2.0", in: service)
 
         await service.requestAdoption(cask)
         let request = try XCTUnwrap(
@@ -146,13 +97,14 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
             installedAt: nil,
             appBundleNames: ["OneDrive.app"]
         )
-        let service = makeService(
+        let service = makeMutationService(
             runner: runner,
             scanner: FixedInstalledSoftwareScanner(snapshot: InstallationSnapshot(
                 installedCasks: [cask.token: installed]
-            ))
+            )),
+            permissionProbe: { .granted }
         )
-        seedExternalInstallation(cask: cask, version: "26.129.0706", service: service)
+        seedExternalInstallation(of: cask, version: "26.129.0706", in: service)
         let stableRevision = service.catalogStateRevision
         var inspectedInstallStep = false
         runner.onRequest = { request in
@@ -184,14 +136,14 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
 
     func test_package_conflict_is_blocked_before_permission_or_brew() async throws {
         let runner = StubBrewProcessRunner()
-        let service = makeService(runner: runner)
+        let service = makeMutationService(runner: runner, permissionProbe: { .granted })
         let cask = makeCask(
             "microsoft-office",
             packageIdentifiers: ["com.microsoft.office"],
             packageAppNames: ["Microsoft Word.app"],
             conflictingCaskTokens: ["microsoft-excel"]
         )
-        seedExternalInstallation(cask: cask, version: "1.0", service: service)
+        seedExternalInstallation(of: cask, version: "1.0", in: service)
         updateInstalledCask(
             installation("microsoft-excel", version: "1.0"),
             in: service
@@ -214,17 +166,13 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
         expectedArguments: [String]
     ) async throws {
         let runner = StubBrewProcessRunner()
-        let service = makeService(runner: runner)
+        let service = makeMutationService(runner: runner, permissionProbe: { .granted })
         let cask = makeCask(
             "sample",
             version: homebrewVersion,
             appNames: ["Sample.app"]
         )
-        seedExternalInstallation(
-            cask: cask,
-            version: installedVersion,
-            service: service
-        )
+        seedExternalInstallation(of: cask, version: installedVersion, in: service)
 
         await service.requestAdoption(cask)
         let request = try XCTUnwrap(
@@ -233,20 +181,5 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
         XCTAssertEqual(request.plan.operation, expectedOperation)
         try await service.confirmAdoption(request)
         XCTAssertEqual(runner.requests.map(\.arguments), [expectedArguments])
-    }
-}
-
-private nonisolated struct FixedInstalledSoftwareScanner: InstalledSoftwareScanning {
-    let snapshot: InstallationSnapshot
-
-    func scan(_ request: InstalledSoftwareScanRequest) async -> InstallationSnapshot {
-        snapshot
-    }
-
-    func reconcileCatalog(
-        _ request: InstalledSoftwareScanRequest,
-        with current: InstallationSnapshot
-    ) async -> InstallationSnapshot {
-        snapshot
     }
 }

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -67,7 +67,6 @@ func makeCask(
         artifacts.append(ArtifactStanza(
             keys: ["binary"],
             binaryNames: binaryNames ?? [],
-            binarySourcePaths: binarySourcePaths ?? [],
             adoptionSourcePaths: binarySourcePaths ?? []
         ))
     }
@@ -288,12 +287,13 @@ func makeSUT(
 
 @MainActor
 func seededCategories(_ tokenToCategory: [String: TokenCategoryMapping],
-                      categories: [String: CategoryDefinition]) -> CategoryService {
+                      categories: [String: CategoryDefinition],
+                      releaseTag: String? = nil) -> CategoryService {
     let service = CategoryService()
     service.applyData(CaskCategoryData(
         version: 1,
         generatedDate: "2026-07-11",
-        releaseTag: nil,
+        releaseTag: releaseTag,
         categories: categories,
         tokenToCategory: tokenToCategory,
         iconTokens: nil
@@ -303,23 +303,18 @@ func seededCategories(_ tokenToCategory: [String: TokenCategoryMapping],
 
 @MainActor
 final class RecordingApplicationLauncher: ApplicationLaunching {
-    private(set) var openedURLs: [URL] = []
-
-    var lastOpenedURL: URL? {
-        openedURLs.last
-    }
+    private(set) var lastOpenedURL: URL?
 
     func open(_ url: URL) {
-        openedURLs.append(url)
+        lastOpenedURL = url
     }
 }
 
 nonisolated final class RecordingMaintenanceProbe: MaintenanceProbing, @unchecked Sendable {
     private let lock = NSLock()
     private var storedResults: [String: BrewProbeResult] = [:]
-    private var storedDefault: BrewProbeResult? = BrewProbeResult(exitCode: 0, output: "")
+    private let storedDefault = BrewProbeResult(exitCode: 0, output: "")
     private var storedSizes: [String: Int64] = [:]
-    private var storedRemoveSucceeds = true
     private var storedCommands: [[String]] = []
     private var storedEnvironments: [[String: String]?] = []
     private var storedRemoved: [URL] = []
@@ -333,11 +328,6 @@ nonisolated final class RecordingMaintenanceProbe: MaintenanceProbing, @unchecke
     var directorySizes: [String: Int64] {
         get { lock.withLock { storedSizes } }
         set { lock.withLock { storedSizes = newValue } }
-    }
-
-    var removeSucceeds: Bool {
-        get { lock.withLock { storedRemoveSucceeds } }
-        set { lock.withLock { storedRemoveSucceeds = newValue } }
     }
 
     var cachedInstallersResult: [CachedInstaller] {
@@ -369,10 +359,8 @@ nonisolated final class RecordingMaintenanceProbe: MaintenanceProbing, @unchecke
     }
 
     func removeDirectoryContents(at url: URL) async -> Bool {
-        lock.withLock {
-            storedRemoved.append(url)
-            return storedRemoveSucceeds
-        }
+        lock.withLock { storedRemoved.append(url) }
+        return true
     }
 
     func cachedInstallers(at cacheURL: URL) async -> [CachedInstaller] {

--- a/CaskHubTests/Support/TestFactories.swift
+++ b/CaskHubTests/Support/TestFactories.swift
@@ -1,0 +1,143 @@
+//
+//  TestFactories.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 19/08/2026.
+//
+
+@testable import CaskHub
+import Foundation
+import SwiftUI
+
+internal nonisolated func makeDetectedApplication(
+    _ bundleName: String,
+    id: String? = nil,
+    version: String? = nil,
+    isMacAppStore: Bool = false,
+    inApplicationsDirectory: Bool = true,
+    installedAt: Date? = nil,
+    url: URL? = nil
+) -> DetectedApplication {
+    DetectedApplication(
+        url: url ?? URL(fileURLWithPath: "/Applications/\(bundleName)"),
+        bundleName: bundleName,
+        bundleIdentifier: id ?? "com.example.\(bundleName)",
+        version: version,
+        isMacAppStore: isMacAppStore,
+        isDirectlyInApplicationDirectory: inApplicationsDirectory,
+        installedAt: installedAt
+    )
+}
+
+@MainActor
+func render(_ view: some View, width: CGFloat = 1100, height: CGFloat = 700) {
+    let hosting = NSHostingView(rootView: AnyView(view))
+    hosting.frame = NSRect(x: 0, y: 0, width: width, height: height)
+    hosting.layoutSubtreeIfNeeded()
+}
+
+nonisolated struct FixedInstalledSoftwareScanner: InstalledSoftwareScanning {
+    let snapshot: InstallationSnapshot
+
+    func scan(_ request: InstalledSoftwareScanRequest) async -> InstallationSnapshot {
+        snapshot
+    }
+
+    func reconcileCatalog(
+        _ request: InstalledSoftwareScanRequest,
+        with current: InstallationSnapshot
+    ) async -> InstallationSnapshot {
+        snapshot
+    }
+}
+
+@MainActor
+func makeMutationService(
+    runner: StubBrewProcessRunner,
+    scanner: (any InstalledSoftwareScanning)? = nil,
+    permissionProbe: (@Sendable () -> AppManagementPermission.Status)? = nil
+) -> LocalHomebrewService {
+    let service = LocalHomebrewService(
+        defaults: makeScratchDefaults("mutation-runner-\(UUID().uuidString)")
+    ) {
+        $0.fileManager = NoFilesFileManager()
+        $0.processRunner = runner
+        $0.softwareScanner = scanner
+        $0.brewBinaryProvider = {
+            URL(fileURLWithPath: "/test/bin/brew")
+        }
+        $0.brewVersionProvider = { "test" }
+    }
+    if let permissionProbe {
+        service.permissionProbe = permissionProbe
+    }
+    return service
+}
+
+@MainActor
+func seedExternalInstallation(
+    of cask: Cask,
+    version: String?,
+    in service: LocalHomebrewService
+) {
+    let bundleName = (cask.packageAppNameCandidates + cask.appArtifactNames).first
+        ?? "\(cask.displayName).app"
+    let application = makeDetectedApplication(
+        bundleName,
+        id: "com.example.\(cask.token)",
+        version: version
+    )
+    updateInstallationSnapshot(of: service) {
+        $0.detectedApplications.append(application)
+        if cask.hasPackageArtifact {
+            $0.externalPackageInstallations[cask.token] = ExternalPackageInstallation(
+                appBundleNames: [bundleName]
+            )
+            $0.externalPackageApplicationOwners[cask.token] = application
+        } else {
+            $0.externalAppNames.insert(bundleName)
+            $0.externalApplicationOwners[cask.token] = application
+        }
+    }
+}
+
+@MainActor
+func makeMaintenanceHomebrew(
+    defaults: UserDefaults,
+    executor: RecordingHomebrewCommandExecutor? = nil
+) -> LocalHomebrewService {
+    LocalHomebrewService(defaults: defaults) {
+        $0.softwareScanner = EmptyInstalledSoftwareScanner()
+        $0.brewBinaryProvider = { URL(fileURLWithPath: "/opt/homebrew/bin/brew") }
+        $0.brewVersionProvider = { "4.6.15" }
+        if let executor { $0.commandExecutor = executor }
+    }
+}
+
+@MainActor
+func makeMaintenanceModel(
+    probe: RecordingMaintenanceProbe? = nil,
+    homebrew: LocalHomebrewService? = nil,
+    clearImageCache: @escaping () async -> Void = {},
+    latestReleaseTag: @escaping (String, String) async -> String? = { _, _ in nil },
+    categories: CategoryService? = nil,
+    defaults: UserDefaults? = nil,
+    function: String = #function
+) -> MaintenanceViewModel {
+    let probe = probe ?? RecordingMaintenanceProbe()
+    let defaults = defaults ?? makeScratchDefaults(function)
+    let service = homebrew ?? makeMaintenanceHomebrew(defaults: defaults)
+    let catalog = makeViewModel(
+        api: MockBrewAPIClient(),
+        categories: categories,
+        localHomebrew: service
+    )
+    return MaintenanceViewModel(
+        localHomebrew: service,
+        catalog: catalog,
+        clearImageCache: clearImageCache,
+        probe: probe,
+        latestReleaseTag: latestReleaseTag,
+        defaults: defaults
+    )
+}

--- a/CaskHubTests/Views/MaintenanceViewTests.swift
+++ b/CaskHubTests/Views/MaintenanceViewTests.swift
@@ -11,35 +11,13 @@ import XCTest
 
 final class MaintenanceViewTests: XCTestCase {
     @MainActor
-    private func makeModel(
-        probe: RecordingMaintenanceProbe? = nil,
-        function: String = #function
-    ) -> MaintenanceViewModel {
-        let probe = probe ?? RecordingMaintenanceProbe()
-        let defaults = makeScratchDefaults(function)
-        let homebrew = LocalHomebrewService(defaults: defaults) {
-            $0.softwareScanner = EmptyInstalledSoftwareScanner()
-            $0.brewBinaryProvider = { URL(fileURLWithPath: "/opt/homebrew/bin/brew") }
-            $0.brewVersionProvider = { "4.6.15" }
-        }
-        let catalog = makeViewModel(api: MockBrewAPIClient(), localHomebrew: homebrew)
-        return MaintenanceViewModel(
-            localHomebrew: homebrew,
-            catalog: catalog,
-            clearImageCache: {},
-            probe: probe,
-            defaults: defaults
-        )
-    }
-
-    @MainActor
     func test_page_renders_before_first_checkup() {
-        render(MaintenanceView(model: makeModel()))
+        render(MaintenanceView(model: makeMaintenanceModel()))
     }
 
     @MainActor
     func test_disk_card_renders_loading_state_before_first_scan() {
-        render(MaintenanceDiskCard(model: makeModel()))
+        render(MaintenanceDiskCard(model: makeMaintenanceModel()))
     }
 
     @MainActor
@@ -52,7 +30,7 @@ final class MaintenanceViewTests: XCTestCase {
               /opt/homebrew/lib/libfoo.dylib
             """)
         ]
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
         await model.runCheckup()
 
         render(MaintenanceView(model: model))
@@ -71,7 +49,7 @@ final class MaintenanceViewTests: XCTestCase {
             """)
         ]
         probe.directorySizes = ["Homebrew": 1_000, "icons": 2_000, "libyaml": 300]
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
         await model.refreshDisk()
         model.expandedRows = [.cache, .imageCache]
 
@@ -84,17 +62,10 @@ final class MaintenanceViewTests: XCTestCase {
         probe.resultsByFirstArgument = [
             "autoremove": BrewProbeResult(exitCode: 1, output: "Error: nope")
         ]
-        let model = makeModel(probe: probe)
+        let model = makeMaintenanceModel(probe: probe)
         await model.clean(.imageCache)
         await model.clean(.orphans)
 
         render(MaintenanceDiskCard(model: model))
-    }
-
-    @MainActor
-    private func render(_ view: some View) {
-        let hosting = NSHostingView(rootView: AnyView(view))
-        hosting.frame = NSRect(x: 0, y: 0, width: 1100, height: 700)
-        hosting.layoutSubtreeIfNeeded()
     }
 }

--- a/CaskHubTests/Views/SettingsViewTests.swift
+++ b/CaskHubTests/Views/SettingsViewTests.swift
@@ -206,24 +206,17 @@ final class SettingsViewTests: XCTestCase {
     }
 
     @MainActor
-    private func render(_ view: some View) {
-        let hosting = NSHostingView(rootView: AnyView(view))
-        hosting.frame = NSRect(x: 0, y: 0, width: 460, height: 480)
-        hosting.layoutSubtreeIfNeeded()
-    }
-
-    @MainActor
     func test_settings_tabs_render() {
-        render(AppearanceSettingsView())
-        render(PrivacySettingsView())
+        render(AppearanceSettingsView(), width: 460, height: 480)
+        render(PrivacySettingsView(), width: 460, height: 480)
         render(
             GeneralSettingsView()
-                .environment(ImageCacheService())
-        )
+                .environment(ImageCacheService()),
+            width: 460, height: 480)
         render(
             HomebrewSettingsView()
-                .environment(LocalHomebrewService())
-        )
+                .environment(LocalHomebrewService()),
+            width: 460, height: 480)
     }
 
     @MainActor

--- a/CaskHubTests/Views/ShelfSetupViewTests.swift
+++ b/CaskHubTests/Views/ShelfSetupViewTests.swift
@@ -21,14 +21,7 @@ final class ShelfSetupViewTests: XCTestCase {
         updateInstallationSnapshot(of: homebrew) { fixture in
             fixture.externalAppNames = Set(externalApps.values)
             fixture.externalApplicationOwners = externalApps.mapValues { appName in
-                DetectedApplication(
-                    url: URL(fileURLWithPath: "/Applications/\(appName)"),
-                    bundleName: appName,
-                    bundleIdentifier: "com.example.\(appName)",
-                    version: nil,
-                    isMacAppStore: false,
-                    isDirectlyInApplicationDirectory: true
-                )
+                makeDetectedApplication(appName)
             }
         }
         return homebrew
@@ -107,7 +100,7 @@ final class ShelfSetupViewTests: XCTestCase {
 
         render(ShelfSetupView(viewModel: vm)
             .environment(homebrew)
-            .environment(ImageCacheService()))
+            .environment(ImageCacheService()), width: 1100, height: 600)
     }
 
     @MainActor
@@ -120,7 +113,7 @@ final class ShelfSetupViewTests: XCTestCase {
 
         render(ShelfSetupView(viewModel: vm)
             .environment(homebrew)
-            .environment(ImageCacheService()))
+            .environment(ImageCacheService()), width: 1100, height: 600)
     }
 
     @MainActor
@@ -172,7 +165,7 @@ final class ShelfSetupViewTests: XCTestCase {
         for phase in phases {
             render(BrewfileImportSheet(plan: plan, phase: phase)
                 .environment(homebrew)
-                .environment(ImageCacheService()))
+                .environment(ImageCacheService()), width: 1100, height: 600)
         }
         let nothingNew = BrewfileImportPlan(
             fileName: "~/Brewfile",
@@ -181,7 +174,7 @@ final class ShelfSetupViewTests: XCTestCase {
         )
         render(BrewfileImportSheet(plan: nothingNew)
             .environment(homebrew)
-            .environment(ImageCacheService()))
+            .environment(ImageCacheService()), width: 1100, height: 600)
     }
 
     @MainActor
@@ -203,7 +196,7 @@ final class ShelfSetupViewTests: XCTestCase {
 
         render(AdoptIgnorePickerSheet(viewModel: vm)
             .environment(homebrew)
-            .environment(ImageCacheService()))
+            .environment(ImageCacheService()), width: 1100, height: 600)
 
         homebrew.setAdoptIgnored("google-chrome", true)
         homebrew.setAdoptIgnored("slack", true)
@@ -211,7 +204,7 @@ final class ShelfSetupViewTests: XCTestCase {
 
         render(AdoptIgnorePickerSheet(viewModel: vm)
             .environment(homebrew)
-            .environment(ImageCacheService()))
+            .environment(ImageCacheService()), width: 1100, height: 600)
     }
 
     @MainActor
@@ -239,9 +232,9 @@ final class ShelfSetupViewTests: XCTestCase {
 
     @MainActor
     func test_page_chrome_renders() {
-        render(UtilityTopBar(title: "Shelf Setup", summary: "3 ignored"))
-        render(UtilityTopBar(title: "Health"))
-        render(CountBadge(count: 2))
+        render(UtilityTopBar(title: "Shelf Setup", summary: "3 ignored"), width: 1100, height: 600)
+        render(UtilityTopBar(title: "Health"), width: 1100, height: 600)
+        render(CountBadge(count: 2), width: 1100, height: 600)
     }
 
     @MainActor
@@ -286,12 +279,5 @@ final class ShelfSetupViewTests: XCTestCase {
             RunLoop.main.run(until: Date().addingTimeInterval(0.05))
             window.close()
         }
-    }
-
-    @MainActor
-    private func render(_ view: some View) {
-        let hosting = NSHostingView(rootView: AnyView(view))
-        hosting.frame = NSRect(x: 0, y: 0, width: 1100, height: 600)
-        hosting.layoutSubtreeIfNeeded()
     }
 }

--- a/CaskHubTests/Views/UpdateSettingsViewTests.swift
+++ b/CaskHubTests/Views/UpdateSettingsViewTests.swift
@@ -14,9 +14,9 @@ final class UpdateSettingsViewTests: XCTestCase {
     func test_update_settings_and_about_support_render() {
         render(
             UpdateSettingsView()
-                .environment(UpdaterService())
-        )
-        render(AboutSettingsView())
+                .environment(UpdaterService()),
+            width: 460, height: 480)
+        render(AboutSettingsView(), width: 460, height: 480)
     }
 
     @MainActor
@@ -47,12 +47,5 @@ final class UpdateSettingsViewTests: XCTestCase {
             CaskHubLinks.issues.absoluteString,
             "https://github.com/alielsokary/CaskHub/issues/new/choose"
         )
-    }
-
-    @MainActor
-    private func render(_ view: some View) {
-        let hosting = NSHostingView(rootView: AnyView(view))
-        hosting.frame = NSRect(x: 0, y: 0, width: 460, height: 480)
-        hosting.layoutSubtreeIfNeeded()
     }
 }


### PR DESCRIPTION
## Summary

Applies the verified findings from the full-repo over-engineering audit. **Net −653 lines across 44 files**, zero behavior changes intended, no dependencies touched.

### App (`refactor:` commit)
- Deleted the `HomebrewMutationCoordinator.run()` + `HomebrewMutationRequest` wrapper layer; `runMutation` builds its one-step sequence directly (cancellable and recovery flags preserved). Dropped the never-passed `environmentOverrides`/`recoverIf` params and the dead `HomebrewMutationCallbacks.recoverIf` field.
- Collapsed `cancelAdoptionRequest`/`cancelPermissionRequest` into `clearError(for:)`; inlined the one-caller `canBeginOperation(for:)` overload.
- `BrewProgressParser` rewritten on a Swift regex literal (NSRegularExpression plumbing gone); `ByteUnit` enum replaced by a threshold table (small struct, not a tuple, to keep SwiftLint quiet).
- Four hand-rolled `Process` capture blocks consolidated into one `ProcessCapture.capture` helper (version loader, maintenance probe, pkgutil receipts, signal-tree pgrep); streaming/pty paths untouched.
- Deleted: `scanCaskroom(fileManager:)` convenience overload, `DownloadMetadataProviding` protocol + stub, dead sync loaders `loadBundledDates(bundle:)`/`loadCategories()`, `ArtifactStanza.binarySourcePaths` + `Cask.binarySourcePaths` (zero production readers; `adoptionSourcePaths` covers the `binary` key), `MemoizedValue` (now `BoundedMemoizedValues(capacity: 1)` everywhere), glob-regex emulation in `PackageReceiptResolver` (now `fnmatch`; fixtures verified bracket-free).
- Views: `UpdateAllConfirmationModifier` inlined to its single `.alert` site, `StatusPill` reduced to `StatusPill(title:)`, `Keycap` branching collapsed, `CaskOperationCapsule` label computed once (its accessibility label is now localized as a side effect), ContentView top-bar chrome applied once via `Group`, unused `GeneralSettingsView` init seam removed.

### Tests (`test:` commit)
- New `CaskHubTests/Support/TestFactories.swift` (SharedTestHelpers is at the 450-line lint cap): `makeDetectedApplication` (replaces 16 hand-rolled constructions across 9 files), shared `render(_:width:height:)` (replaces 7 private copies), `FixedInstalledSoftwareScanner`, shared `seedExternalInstallation`/`makeMutationService` (permission probe exposed as a parameter), shared maintenance model factories.
- Dead mock knobs deleted: `RecordingMaintenanceProbe.removeSucceeds`, `StubBrewProcessRunner.queuedChunks`/`thrownError`, `RecordingApplicationLauncher.openedURLs` history.
- Deleted the self-referential `test_missing_caskroom_scans_as_no_installed_casks` (existed only to exercise the deleted overload).

### Deliberately NOT applied
- `MaintenanceVersion.isCurrent` → `NumericVersionComparison.compare`: edge-case semantics differ (`"6.0.18b"`, trailing dots, padded whitespace parse under `compare` but correctly yield nil/unknown today). Delegating would replace honest "unknown" freshness with false certainty.

## Testing
- Full suite green locally: 438 tests (439 minus the deleted self-referential test), zero SwiftLint violations, local Lizard sweep shows no new function-level breaches.
- Every change was applied against verified audit findings and then diff-reviewed against the audit spec by independent reviewers before commit.
