### PR TITLE
fix: Make Homebrew failures evidence-aware

### DIFF
--- a/CaskHub/App/Askpass.swift
+++ b/CaskHub/App/Askpass.swift
@@ -8,7 +8,7 @@
 import AppKit
 
 enum Askpass {
-    static func runDialog(token: String?) -> Never {
+    static func runDialog(token: String?, cancellationMarker: URL?) -> Never {
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
 
@@ -28,7 +28,15 @@ enum Askpass {
         alert.window.level = .floating
         app.activate()
         app.requestUserAttention(.criticalRequest)
-        guard alert.runModal() == .alertFirstButtonReturn else { exit(1) }
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn,
+              !passwordField.stringValue.isEmpty
+        else {
+            if let cancellationMarker {
+                try? Data().write(to: cancellationMarker, options: .atomic)
+            }
+            exit(1)
+        }
         print(passwordField.stringValue)
         exit(0)
     }

--- a/CaskHub/App/CaskHubApp.swift
+++ b/CaskHub/App/CaskHubApp.swift
@@ -14,10 +14,20 @@ enum CaskHubMain {
         if let flagIndex = CommandLine.arguments.firstIndex(of: "--askpass") {
             let token = CommandLine.arguments.indices.contains(flagIndex + 1)
                 ? CommandLine.arguments[flagIndex + 1] : nil
-            Askpass.runDialog(token: token)
+            let marker = argument(after: "--askpass-cancel-marker").map {
+                URL(fileURLWithPath: $0)
+            }
+            Askpass.runDialog(token: token, cancellationMarker: marker)
         }
         NSWindow.allowsAutomaticWindowTabbing = false
         CaskHubApp.main()
+    }
+
+    private static func argument(after flag: String) -> String? {
+        guard let index = CommandLine.arguments.firstIndex(of: flag),
+              CommandLine.arguments.indices.contains(index + 1)
+        else { return nil }
+        return CommandLine.arguments[index + 1]
     }
 }
 

--- a/CaskHub/Resources/Localizable.xcstrings
+++ b/CaskHub/Resources/Localizable.xcstrings
@@ -802,6 +802,16 @@
         }
       }
     },
+    "CaskHub couldn't prepare the administrator password prompt. Restart CaskHub and try again." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CaskHub 无法准备管理员密码提示。请重新启动 CaskHub，然后重试。"
+          }
+        }
+      }
+    },
     "CaskHub Website" : {
 
     },

--- a/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
+++ b/CaskHub/Services/Homebrew/Coordination/HomebrewMutationCoordinator.swift
@@ -26,18 +26,20 @@ struct HomebrewMutationSequenceRequest {
     let displayName: String
     let origin: CaskActionOrigin
     let steps: [HomebrewMutationStep]
+    let context: HomebrewMutationContext
 }
 
 struct HomebrewMutationCallbacks {
     let refresh: () async -> Void
     let strandedCopyExists: () -> Bool
+    let postconditionSatisfied: () -> Bool
 }
-
 @MainActor
 final class HomebrewMutationCoordinator {
     private let operationStore: CaskOperationStore
     private let commandExecutor: any HomebrewCommandExecuting
     private let brewBinaryProvider: () -> URL?
+    private let askpassProvider: @Sendable (String) async throws -> URL
     private let fileManager: FileManager
 
     private let outputAggregator: BrewOutputAggregator
@@ -46,11 +48,13 @@ final class HomebrewMutationCoordinator {
         operationStore: CaskOperationStore,
         commandExecutor: any HomebrewCommandExecuting,
         brewBinaryProvider: @escaping () -> URL?,
+        askpassProvider: @escaping @Sendable (String) async throws -> URL,
         fileManager: FileManager
     ) {
         self.operationStore = operationStore
         self.commandExecutor = commandExecutor
         self.brewBinaryProvider = brewBinaryProvider
+        self.askpassProvider = askpassProvider
         self.fileManager = fileManager
         outputAggregator = BrewOutputAggregator(fileManager: fileManager)
     }
@@ -67,7 +71,7 @@ final class HomebrewMutationCoordinator {
             for: request.token
         ) else { return }
         try preflightBrewLocation(
-            token: request.token,
+            request: request,
             strandedCopyExists: callbacks.strandedCopyExists()
         )
         beginOperation(
@@ -126,15 +130,18 @@ extension HomebrewMutationCoordinator {
     ) async throws {
         let brewURL = try validateBrewLocation()
 
-        let askpass = await AskpassScriptManager.create(token: token)
+        let askpass: URL
+        do {
+            askpass = try await askpassProvider(token)
+        } catch {
+            throw AskpassScriptManager.localError(for: error)
+        }
 
         var environment = ProcessInfo.processInfo.environment
         environment.merge(environmentOverrides) { _, override in override }
         // brew 6 ask-mode default prompts on our pty; stdin is nulled, so it EOF-aborts.
         environment["HOMEBREW_NO_ASK"] = "1"
-        if let askpass {
-            environment["SUDO_ASKPASS"] = askpass.path
-        }
+        environment["SUDO_ASKPASS"] = askpass.path
 
         // defer can't await; remove the script deterministically on both exits.
         let result: BrewProcessResult
@@ -154,17 +161,28 @@ extension HomebrewMutationCoordinator {
                 }
             )
         } catch {
-            if let askpass { await AskpassScriptManager.remove(at: askpass) }
+            await AskpassScriptManager.remove(at: askpass)
             throw error
         }
-        if let askpass { await AskpassScriptManager.remove(at: askpass) }
+        let userCancelled = FileManager.default.fileExists(
+            atPath: AskpassScriptManager.cancellationMarker(for: askpass).path
+        )
+        await AskpassScriptManager.remove(at: askpass)
 
         guard result.exitCode != 0 else { return }
-        throw LocalHomebrewError.brewCommandFailed(
-            args: arguments,
+        if result.wasTerminatedBySignal,
+           operationStore.state(for: token)?.cancellationRequested == true {
+            throw CancellationError()
+        }
+        let diagnostic = HomebrewOutputDiagnostics.make(from: result.output)
+        let failure = HomebrewCommandFailure(
+            arguments: arguments,
             exitCode: result.exitCode,
-            stderr: HomebrewOutputDiagnostics.make(from: result.output)
+            diagnostic: diagnostic,
+            machineIsAppleSilicon: HomebrewLocator.isAppleSilicon,
+            askpassUserCancelled: userCancelled
         )
+        throw LocalHomebrewError.brewCommandFailed(failure)
     }
 
     private func validateBrewLocation() throws -> URL {
@@ -178,17 +196,18 @@ extension HomebrewMutationCoordinator {
     }
 
     private func preflightBrewLocation(
-        token: String,
+        request: HomebrewMutationSequenceRequest,
         strandedCopyExists: Bool
     ) throws {
         do {
             _ = try validateBrewLocation()
         } catch {
             recordFailure(
-                token: token,
+                token: request.token,
                 error: error,
                 strandedCopyExists: strandedCopyExists
             )
+            recordUnrecoveredFailure(error, request: request, span: nil)
             throw error
         }
     }
@@ -319,7 +338,7 @@ extension HomebrewMutationCoordinator {
         span: CrashSpan,
         callbacks: HomebrewMutationCallbacks
     ) async throws -> FailureResolution {
-        if operationStore.state(for: request.token)?.cancellationRequested == true {
+        if error is CancellationError {
             span.finish()
             await callbacks.refresh()
             operationStore.send(.clear, for: request.token)
@@ -341,20 +360,23 @@ extension HomebrewMutationCoordinator {
             }
             return .continueSequence
         }
-
-        let localError = error as? LocalHomebrewError
-        if localError?.shouldReport == false {
-            span.finish()
-        } else {
-            span.finish(error: error)
+        if let localError = error as? LocalHomebrewError,
+           localError.commandFailure?.kind == .exitNonzeroAfterSuccess,
+           request.action != .updatingHomebrew {
+            await callbacks.refresh()
+            if callbacks.postconditionSatisfied() {
+                span.finish()
+                Analytics.caskActionRecovered(
+                    request.action,
+                    token: request.token,
+                    origin: request.origin
+                )
+                operationStore.send(.clear, for: request.token)
+                return .stopSequence
+            }
         }
-        CrashReporter.capture(error)
-        Analytics.caskActionFailed(
-            request.action,
-            token: request.token,
-            origin: request.origin,
-            failureKind: localError?.commandFailure?.kind
-        )
+
+        recordUnrecoveredFailure(error, request: request, span: span)
         recordFailure(
             token: request.token,
             error: error,
@@ -372,6 +394,40 @@ extension HomebrewMutationCoordinator {
     private enum FailureResolution: Equatable {
         case continueSequence
         case stopSequence
+    }
+
+    private func recordUnrecoveredFailure(
+        _ error: Error,
+        request: HomebrewMutationSequenceRequest,
+        span: CrashSpan?
+    ) {
+        span?.finish(error: error)
+        let localError = error as? LocalHomebrewError
+        Analytics.caskActionFailed(
+            request.action,
+            token: request.token,
+            origin: request.origin,
+            failureKind: localError?.failureKind
+        )
+        guard HomebrewIssuePolicy.shouldCapture(
+            error,
+            action: request.action,
+            context: request.context
+        ) else { return }
+        CrashReporter.capture(error, tags: failureTags(for: request))
+    }
+
+    private func failureTags(
+        for request: HomebrewMutationSequenceRequest
+    ) -> [String: String] {
+        var tags = request.context.telemetryTags
+        tags["brew.action"] = request.action.identifier
+        tags["brew.cask"] = request.token
+        tags["brew.origin"] = request.origin.rawValue
+        if operationStore.state(for: request.token)?.cancellationRequested == true {
+            tags["brew.cancellation_requested"] = "true"
+        }
+        return tags
     }
 
     /// Brew disagreeing about install state means the snapshot is stale.

--- a/CaskHub/Services/Homebrew/Coordination/LocalHomebrewDependencies.swift
+++ b/CaskHub/Services/Homebrew/Coordination/LocalHomebrewDependencies.swift
@@ -7,6 +7,57 @@
 
 import Foundation
 
+nonisolated struct HomebrewMutationContext: Sendable {
+    let adoptionPlan: CaskAdoptionPlan?
+    let permissionEvidence: AppManagementPermission.Evidence?
+
+    static let none = HomebrewMutationContext(
+        adoptionPlan: nil,
+        permissionEvidence: nil
+    )
+
+    var telemetryTags: [String: String] {
+        guard let adoptionPlan else { return [:] }
+        var tags = [
+            "brew.adoption_relationship": adoptionPlan.versionRelationship.rawValue,
+            "brew.adoption_execution": adoptionPlan.execution.rawValue
+        ]
+        tags["brew.permission_evidence"] = permissionEvidence?.rawValue
+        return tags
+    }
+}
+
+enum HomebrewIssuePolicy {
+    static func shouldCapture(
+        _ error: Error,
+        action: CaskAction,
+        context: HomebrewMutationContext
+    ) -> Bool {
+        guard let localError = error as? LocalHomebrewError else { return true }
+        switch localError {
+        case .brewBinaryNotFound:
+            return false
+        case .incompatibleBrewPath:
+            return true
+        case .appBundleNotFound:
+            return true
+        case let .askpassUnavailable(_, failureKind):
+            return !failureKind.isNormallyExternal
+        case let .brewCommandFailed(failure):
+            if failure.kind.isExplicitUserDecision
+                || failure.kind.isNormallyExternal {
+                return false
+            }
+            if action == .updatingHomebrew { return true }
+            guard failure.kind == .adoptVersionMismatch else { return true }
+            guard let relationship = context.adoptionPlan?.versionRelationship else {
+                return true
+            }
+            return relationship != .same && relationship != .unknown
+        }
+    }
+}
+
 @MainActor
 struct LocalHomebrewDependencies {
     var fileManager: FileManager = .default
@@ -15,6 +66,9 @@ struct LocalHomebrewDependencies {
     var commandExecutor: (any HomebrewCommandExecuting)?
     var softwareScanner: (any InstalledSoftwareScanning)?
     var applicationLauncher: (any ApplicationLaunching)?
+    var askpassProvider: @Sendable (String) async throws -> URL = {
+        try await AskpassScriptManager.create(token: $0)
+    }
     var brewBinaryProvider: () -> URL? = {
         HomebrewLocator.brewBinaryURL()
     }

--- a/CaskHub/Services/Homebrew/Coordination/LocalHomebrewDependencies.swift
+++ b/CaskHub/Services/Homebrew/Coordination/LocalHomebrewDependencies.swift
@@ -34,27 +34,49 @@ enum HomebrewIssuePolicy {
         context: HomebrewMutationContext
     ) -> Bool {
         guard let localError = error as? LocalHomebrewError else { return true }
-        switch localError {
+        return shouldCaptureLocalError(
+            localError,
+            action: action,
+            context: context
+        )
+    }
+
+    private static func shouldCaptureLocalError(
+        _ error: LocalHomebrewError,
+        action: CaskAction,
+        context: HomebrewMutationContext
+    ) -> Bool {
+        switch error {
         case .brewBinaryNotFound:
             return false
-        case .incompatibleBrewPath:
-            return true
-        case .appBundleNotFound:
+        case .incompatibleBrewPath, .appBundleNotFound:
             return true
         case let .askpassUnavailable(_, failureKind):
             return !failureKind.isNormallyExternal
         case let .brewCommandFailed(failure):
-            if failure.kind.isExplicitUserDecision
-                || failure.kind.isNormallyExternal {
-                return false
-            }
-            if action == .updatingHomebrew { return true }
-            guard failure.kind == .adoptVersionMismatch else { return true }
-            guard let relationship = context.adoptionPlan?.versionRelationship else {
-                return true
-            }
-            return relationship != .same && relationship != .unknown
+            return shouldCaptureCommandFailure(
+                failure,
+                action: action,
+                context: context
+            )
         }
+    }
+
+    private static func shouldCaptureCommandFailure(
+        _ failure: HomebrewCommandFailure,
+        action: CaskAction,
+        context: HomebrewMutationContext
+    ) -> Bool {
+        if failure.kind.isExplicitUserDecision
+            || failure.kind.isNormallyExternal {
+            return false
+        }
+        guard action != .updatingHomebrew,
+              failure.kind == .adoptVersionMismatch,
+              let relationship = context.adoptionPlan?.versionRelationship else {
+            return true
+        }
+        return relationship != .same && relationship != .unknown
     }
 }
 

--- a/CaskHub/Services/Homebrew/Domain/CaskAdoptionPlan.swift
+++ b/CaskHub/Services/Homebrew/Domain/CaskAdoptionPlan.swift
@@ -12,10 +12,10 @@ nonisolated enum CaskAdoptionArtifact: Equatable, Sendable {
     case packageInstaller
 }
 
-nonisolated enum CaskAdoptionVersionRelationship: Equatable, Sendable {
+nonisolated enum CaskAdoptionVersionRelationship: String, Equatable, Sendable {
     case same
-    case homebrewNewer
-    case homebrewOlder
+    case homebrewNewer = "homebrew-newer"
+    case homebrewOlder = "homebrew-older"
     case unknown
 }
 
@@ -25,11 +25,16 @@ nonisolated enum CaskAdoptionOperation: Equatable, Sendable {
     case downgradeAndAdopt
 }
 
-nonisolated enum CaskAdoptionExecution: Equatable, Sendable {
-    case adoptApplication
-    case replaceApplication
-    case installPackage
-    case replacePackage
+nonisolated enum CaskAdoptionExecution: String, Equatable, Sendable {
+    case adoptApplication = "adopt-application"
+    case replaceApplication = "replace-application"
+    case installPackage = "install-package"
+    case replacePackage = "replace-package"
+}
+
+nonisolated enum CaskAdoptionIntent: Equatable, Sendable {
+    case planned
+    case replacement
 }
 
 nonisolated struct CaskAdoptionPlan: Equatable, Sendable {
@@ -125,6 +130,7 @@ nonisolated struct CaskAdoptionPlan: Equatable, Sendable {
 
 nonisolated struct CaskAdoptionRequest: Equatable, Sendable {
     let cask: Cask
+    let intent: CaskAdoptionIntent
     let plan: CaskAdoptionPlan
 }
 

--- a/CaskHub/Services/Homebrew/Domain/HomebrewCommandFailure.swift
+++ b/CaskHub/Services/Homebrew/Domain/HomebrewCommandFailure.swift
@@ -10,10 +10,13 @@ import Foundation
 nonisolated enum HomebrewFailureKind: String, Equatable, Sendable {
     case adoptVersionMismatch = "adopt-version-mismatch"
     case appConflict = "app-conflict"
+    case appBundleNotFound = "app-bundle-not-found"
     case artifactConflict = "artifact-conflict"
+    case askpassUnavailable = "askpass-unavailable"
     case binaryConflict = "binary-conflict"
     case brewAPIUnavailable = "brew-api-unavailable"
     case brewArchitectureMismatch = "brew-architecture-mismatch"
+    case brewBinaryNotFound = "brew-binary-not-found"
     case brewBusy = "brew-busy"
     case brewLockCleanupRace = "brew-lock-cleanup-race"
     case caskConflict = "cask-conflict"
@@ -30,6 +33,7 @@ nonisolated enum HomebrewFailureKind: String, Equatable, Sendable {
     case filesystemPermissionDenied = "filesystem-permission-denied"
     case homebrewNotWritable = "homebrew-not-writable"
     case homebrewRuntimeIncompatible = "homebrew-runtime-incompatible"
+    case incompatibleBrewPath = "incompatible-brew-path"
     case missingArtifactSource = "missing-artifact-source"
     case missingUninstallScript = "missing-uninstall-script"
     case networkFailure = "network-failure"
@@ -55,37 +59,25 @@ nonisolated enum HomebrewFailureKind: String, Equatable, Sendable {
     case unknownCask = "unknown-cask"
     case upgradeRefused = "upgrade-refused"
 
-    var shouldReport: Bool {
+    var isExplicitUserDecision: Bool {
+        self == .sudoDeclined
+    }
+
+    /// Conditions whose normal cause is outside CaskHub.
+    var isNormallyExternal: Bool {
         switch self {
-        case .adoptVersionMismatch,
-             .appConflict,
-             .artifactConflict,
-             .binaryConflict,
-             .brewArchitectureMismatch,
-             .brewBusy,
-             .brewLockCleanupRace,
-             .caskConflict,
-             .checksumMismatch,
-             .dmgMountBusy,
-             .dmgMountCancelled,
+        case .checksumMismatch,
              .dmgReadOnly,
-             .downloadCacheRace,
-             .filesystemPermissionDenied,
              .homebrewRuntimeIncompatible,
              .networkFailure,
-             .permissionDenied,
              .platformUnsupported,
-             .portableRubyUnavailable,
              .quarantineInvalid,
              .requireSHAPolicy,
-             .strandedCaskroomApp,
              .storageFull,
-             .sudoDeclined,
-             .sudoPolicyDenied,
-             .sudoWrongPassword:
-            false
-        default:
+             .sudoNotAdmin,
+             .sudoPolicyDenied:
             true
+        default: false
         }
     }
 }
@@ -96,15 +88,42 @@ nonisolated struct HomebrewCommandFailure: Equatable, Sendable {
     let diagnostic: String
     let kind: HomebrewFailureKind
 
-    init(arguments: [String], exitCode: Int32, diagnostic: String) {
+    init(
+        arguments: [String],
+        exitCode: Int32,
+        diagnostic: String,
+        machineIsAppleSilicon: Bool? = nil,
+        askpassUserCancelled: Bool? = nil
+    ) {
         self.arguments = arguments
         self.exitCode = exitCode
         self.diagnostic = diagnostic
-        kind = Self.classify(
+        let classified = Self.classify(
             arguments: arguments,
             exitCode: exitCode,
-            diagnostic: diagnostic
+            diagnostic: diagnostic,
+            machineIsAppleSilicon: machineIsAppleSilicon
         )
+        if askpassUserCancelled == true,
+           [.sudoDeclined, .noDiagnosticOutput, .unknown].contains(classified) {
+            kind = .sudoDeclined
+        } else if classified == .sudoDeclined && askpassUserCancelled == false {
+            kind = .askpassUnavailable
+        } else {
+            kind = classified
+        }
+    }
+
+    init(
+        arguments: [String],
+        exitCode: Int32,
+        diagnostic: String,
+        kind: HomebrewFailureKind
+    ) {
+        self.arguments = arguments
+        self.exitCode = exitCode
+        self.diagnostic = diagnostic
+        self.kind = kind
     }
 
     var subcommand: String? {
@@ -116,9 +135,22 @@ nonisolated struct HomebrewCommandFailure: Equatable, Sendable {
         return ["brewCommandFailed", subcommand, kind.rawValue]
     }
 
+    var diagnosticBucket: String? {
+        guard kind == .unknown else { return nil }
+        return HomebrewDiagnosticRedactor.bucket(diagnostic, token: caskToken)
+    }
+
+    private var caskToken: String? {
+        arguments.drop(while: { $0 != "--cask" }).dropFirst().first
+    }
+
     var rateLimitSignature: String {
-        ["brewCommandFailed", subcommand ?? "missing-subcommand", kind.rawValue]
-            .joined(separator: ":")
+        var components = stableFingerprint
+            ?? ["brewCommandFailed", "missing-subcommand", kind.rawValue]
+        if let diagnosticBucket {
+            components.append("bucket-\(diagnosticBucket)")
+        }
+        return components.joined(separator: ":")
     }
 }
 
@@ -126,9 +158,16 @@ nonisolated extension HomebrewCommandFailure {
     static func classify(
         arguments: [String],
         exitCode: Int32?,
-        diagnostic: String
+        diagnostic: String,
+        machineIsAppleSilicon: Bool? = nil
     ) -> HomebrewFailureKind {
         let text = diagnostic.lowercased()
+        if runtimeArchitectureContradictsMachine(
+            text,
+            machineIsAppleSilicon: machineIsAppleSilicon
+        ) {
+            return .brewArchitectureMismatch
+        }
         return privilegeKind(text: text, diagnostic: diagnostic)
             ?? processKind(text: text, exitCode: exitCode)
             ?? installerKind(text: text)
@@ -138,6 +177,18 @@ nonisolated extension HomebrewCommandFailure {
             ?? environmentKind(text: text)
             ?? downloadKind(text: text)
             ?? (text.isBlank ? .noDiagnosticOutput : .unknown)
+    }
+
+    private static func runtimeArchitectureContradictsMachine(
+        _ text: String,
+        machineIsAppleSilicon: Bool?
+    ) -> Bool {
+        guard text.contains("depends on hardware architecture"),
+              let machineIsAppleSilicon
+        else { return false }
+        let brewReportsIntel = text.contains("but you are running {type: :intel")
+        let brewReportsARM = text.contains("but you are running {type: :arm")
+        return machineIsAppleSilicon ? brewReportsIntel : brewReportsARM
     }
 
     private struct Match {

--- a/CaskHub/Services/Homebrew/Domain/LocalHomebrewError.swift
+++ b/CaskHub/Services/Homebrew/Domain/LocalHomebrewError.swift
@@ -5,11 +5,61 @@
 //  Created by Ali Elsokary on 10/08/2026.
 //
 
+import CryptoKit
 import Foundation
+
+nonisolated enum AskpassFailureStage: String, Sendable {
+    case executable
+    case directory
+    case script
+    case permissions
+    case unknown
+}
+
+nonisolated enum HomebrewDiagnosticRedactor {
+    static func normalized(_ diagnostic: String, token: String?) -> String {
+        var normalized = diagnostic.lowercased()
+        if let token {
+            normalized = normalized.replacingOccurrences(
+                of: token.lowercased(),
+                with: "<cask>"
+            )
+        }
+        let redactions = [
+            (#"https?://[^\s]+"#, "<url>"),
+            (#"[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}"#, "<email>"),
+            (#"[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}"#, "<uuid>"),
+            (#"[0-9a-f]{16,}"#, "<hash>"),
+            (#"/[^\r\n]*"#, "<path>"),
+            (#"\d+(?:\.\d+)*"#, "<number>")
+        ]
+        for (pattern, replacement) in redactions {
+            normalized = normalized.replacingOccurrences(
+                of: pattern,
+                with: replacement,
+                options: .regularExpression
+            )
+        }
+        return normalized
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    static func bucket(_ diagnostic: String, token: String?) -> String {
+        let digest = SHA256.hash(data: Data(normalized(diagnostic, token: token).utf8))
+        let firstByte = digest.prefix(1).reduce(UInt8.zero) { _, byte in byte }
+        return String(Int(firstByte & 31))
+    }
+}
 
 enum LocalHomebrewError: LocalizedError {
     case brewBinaryNotFound
     case incompatibleBrewPath
+    case askpassUnavailable(
+        stage: AskpassFailureStage,
+        failureKind: HomebrewFailureKind
+    )
     case appBundleNotFound(token: String)
     case brewCommandFailed(HomebrewCommandFailure)
 
@@ -25,16 +75,19 @@ enum LocalHomebrewError: LocalizedError {
         ))
     }
 
-    /// Expected user or environment state is not an app defect.
-    var shouldReport: Bool {
+    var failureKind: HomebrewFailureKind? {
         switch self {
-        case .brewBinaryNotFound, .incompatibleBrewPath:
-            return false
-        case .appBundleNotFound:
-            return true
+        case .brewBinaryNotFound: .brewBinaryNotFound
+        case .incompatibleBrewPath: .incompatibleBrewPath
+        case let .askpassUnavailable(_, failureKind): failureKind
+        case .appBundleNotFound: .appBundleNotFound
         case let .brewCommandFailed(failure):
-            return failure.kind.shouldReport
+            failure.kind
         }
+    }
+
+    var isExplicitUserDecision: Bool {
+        commandFailure?.kind.isExplicitUserDecision == true
     }
 
     var commandFailure: HomebrewCommandFailure? {
@@ -92,6 +145,15 @@ extension LocalHomebrewError {
             return String(
                 localized: "This Mac requires Intel Homebrew. Choose /usr/local/bin/brew in Settings."
             )
+        case let .askpassUnavailable(_, failureKind):
+            if failureKind == .storageFull {
+                return String(
+                    localized: "There is not enough free storage to complete this operation. Free some space, then try again."
+                )
+            }
+            return String(
+                localized: "CaskHub couldn't prepare the administrator password prompt. Restart CaskHub and try again."
+            )
         case let .appBundleNotFound(token):
             return String(localized: "Couldn't find an installed app for \(token).")
         case let .brewCommandFailed(failure):
@@ -110,6 +172,10 @@ extension LocalHomebrewError {
                 return String(localized: .errorAdoptVersionMismatch)
             }
             switch failure.kind {
+            case .askpassUnavailable:
+                return String(
+                    localized: "CaskHub couldn't prepare the administrator password prompt. Restart CaskHub and try again."
+                )
             case .binaryConflict:
                 return "A leftover command-line tool from a previous installation "
                     + "is in the way. Replacing with Homebrew's version overwrites it — "

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Adoption.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Adoption.swift
@@ -9,54 +9,70 @@ import Foundation
 
 extension LocalHomebrewService {
     func requestAdoption(_ cask: Cask) async {
-        guard let plan = localState(for: cask).adoptionPlan else { return }
-        await requestAdoption(CaskAdoptionRequest(cask: cask, plan: plan))
+        guard let request = currentAdoptionRequest(for: cask, intent: .planned) else {
+            return
+        }
+        await requestAdoption(request)
     }
 
     func requestReplacementAdoption(_ cask: Cask) async {
-        let localPlan = localState(for: cask).adoptionPlan
-        let artifact: CaskAdoptionArtifact = cask.hasPackageArtifact
-            ? .packageInstaller
-            : .applicationBundle
-        let plan = CaskAdoptionPlan(
-            artifact: artifact,
-            versionRelationship: localPlan?.versionRelationship ?? .unknown,
-            operation: localPlan?.operation ?? .adopt,
-            execution: artifact == .packageInstaller
-                ? .replacePackage
-                : .replaceApplication,
-            installedVersion: localPlan?.installedVersion,
-            homebrewVersion: cask.displayVersion,
-            blockingInstalledCask: localPlan?.blockingInstalledCask
-        )
-        await requestAdoption(CaskAdoptionRequest(cask: cask, plan: plan))
+        guard let request = currentAdoptionRequest(for: cask, intent: .replacement) else {
+            return
+        }
+        await requestAdoption(request)
     }
 
     func confirmAdoption(_ request: CaskAdoptionRequest) async throws {
-        guard await requireAdoptionPermission(for: request) else { return }
+        await refresh()
+        guard let current = currentAdoptionRequest(
+            for: request.cask,
+            intent: request.intent
+        ) else {
+            operationStore.send(.clear, for: request.cask.token)
+            return
+        }
+        guard current == request else {
+            operationStore.send(.awaitAdoption(current), for: request.cask.token)
+            return
+        }
+        guard let permission = await requireAdoptionPermission(
+            for: request,
+            allowUnverified: true
+        ) else {
+            return
+        }
         guard preflightAdoption(request) else { return }
+        let context = HomebrewMutationContext(
+            adoptionPlan: request.plan, permissionEvidence: permission.evidence
+        )
 
         switch request.plan.execution {
         case .adoptApplication:
             try await runMutation(
                 .adopting,
                 token: request.cask.token,
-                args: ["install", "--cask", request.cask.token, "--adopt"]
+                args: ["install", "--cask", request.cask.token, "--adopt"],
+                context: context
             )
         case .replaceApplication:
             try await runMutation(
                 .adopting,
                 token: request.cask.token,
-                args: ["install", "--cask", request.cask.token, "--force"]
+                args: ["install", "--cask", request.cask.token, "--force"],
+                context: context
             )
         case .installPackage:
             try await runMutation(
                 .adopting,
                 token: request.cask.token,
-                args: ["install", "--cask", request.cask.token]
+                args: ["install", "--cask", request.cask.token],
+                context: context
             )
         case .replacePackage:
-            try await replacePackageForAdoption(token: request.cask.token)
+            try await replacePackageForAdoption(
+                token: request.cask.token,
+                context: context
+            )
         }
     }
 
@@ -81,26 +97,40 @@ extension LocalHomebrewService {
 
     /// Called after returning from System Settings. Permission approval resumes
     /// at confirmation; it never starts a destructive replacement implicitly.
-    func resumePendingAdoptions() {
+    func resumePendingAdoptions() async {
         let pending = operationStore.pendingPermissions
         guard !pending.isEmpty else { return }
-        Task {
-            guard await permissionAllowsAdoption() else { return }
-            for (token, request) in pending {
-                guard preflightAdoption(request) else { continue }
-                operationStore.send(.awaitAdoption(request), for: token)
+        for (token, request) in pending {
+            guard let current = currentAdoptionRequest(
+                for: request.cask,
+                intent: request.intent
+            ) else {
+                operationStore.send(.clear, for: token)
+                continue
             }
+            let assessment = await permissionAssessment(for: current)
+            guard assessment.status != .denied else { continue }
+            guard preflightAdoption(current) else { continue }
+            operationStore.send(.awaitAdoption(current), for: token)
         }
     }
 
     private func requestAdoption(_ request: CaskAdoptionRequest) async {
         guard preflightAdoption(request) else { return }
-        guard await requireAdoptionPermission(for: request) else { return }
+        guard await requireAdoptionPermission(for: request) != nil else { return }
         operationStore.send(.awaitAdoption(request), for: request.cask.token)
     }
 
     private func preflightAdoption(_ request: CaskAdoptionRequest) -> Bool {
-        if let conflict = request.plan.blockingInstalledCask {
+        if let conflict = request.cask.conflictsWith?.caskTokens
+            .filter({ installedCasks[$0] != nil })
+            .sorted()
+            .first {
+            Analytics.caskActionFailed(
+                .adopting,
+                token: request.cask.token,
+                failureKind: .caskConflict
+            )
             operationStore.send(
                 .fail(CaskOperationFailure(
                     kind: .adoptionPreflight,
@@ -121,6 +151,11 @@ extension LocalHomebrewService {
                 missing
             )
         )
+        Analytics.caskActionFailed(
+            .adopting,
+            token: request.cask.token,
+            failureKind: .missingArtifactSource
+        )
         operationStore.send(
             .fail(CaskOperationFailure(
                 kind: .adoptionPreflight,
@@ -133,24 +168,73 @@ extension LocalHomebrewService {
     }
 
     private func requireAdoptionPermission(
-        for request: CaskAdoptionRequest
-    ) async -> Bool {
-        guard await permissionAllowsAdoption() else {
+        for request: CaskAdoptionRequest,
+        allowUnverified: Bool = false
+    ) async -> AppManagementPermission.Assessment? {
+        let assessment = await permissionAssessment(for: request)
+        switch assessment.status {
+        case .granted:
+            return assessment
+        case .unknown where allowUnverified:
+            return AppManagementPermission.Assessment(
+                status: .unknown,
+                evidence: .unverified
+            )
+        case .denied, .unknown:
             operationStore.send(
                 .awaitPermission(request),
                 for: request.cask.token
             )
-            return false
+            return nil
         }
-        return true
     }
 
-    /// Adoption only proceeds after the probe positively demonstrates access.
-    /// An indeterminate probe stays gated because it cannot prove Homebrew can
-    /// modify the existing application.
-    private func permissionAllowsAdoption() async -> Bool {
+    /// The exact scanner-owned bundle is stronger evidence than a catalog name.
+    /// macOS has no public query API, so an unprobeable target can proceed only
+    /// after the user returns from Settings and confirms the adoption again.
+    private func permissionAssessment(
+        for request: CaskAdoptionRequest
+    ) async -> AppManagementPermission.Assessment {
         let probe = permissionProbe
-        let status = await Task.detached(priority: .userInitiated) { probe() }.value
-        return status == .granted
+        let bundle = installationSnapshot
+            .externalPackageApplicationOwners[request.cask.token]?.url
+            ?? installationSnapshot.externalApplicationOwners[request.cask.token]?.url
+            ?? existingBundleURL(named:
+                request.cask.packageAppNameCandidates + request.cask.appArtifactNames
+            )
+        let assessment = await Task.detached(priority: .userInitiated) {
+            probe(bundle)
+        }.value
+        return assessment
+    }
+
+    private func currentAdoptionRequest(
+        for cask: Cask,
+        intent: CaskAdoptionIntent
+    ) -> CaskAdoptionRequest? {
+        let state = localState(for: cask)
+        let current = state.adoptionPlan
+        let plan: CaskAdoptionPlan
+        switch intent {
+        case .planned:
+            guard let current else { return nil }
+            plan = current
+        case .replacement:
+            let artifact = current?.artifact ?? (cask.hasPackageArtifact
+                ? .packageInstaller
+                : .applicationBundle)
+            plan = CaskAdoptionPlan(
+                artifact: artifact,
+                versionRelationship: current?.versionRelationship ?? .unknown,
+                operation: current?.operation ?? .adopt,
+                execution: artifact == .packageInstaller
+                    ? .replacePackage
+                    : .replaceApplication,
+                installedVersion: current?.installedVersion,
+                homebrewVersion: current?.homebrewVersion ?? cask.displayVersion,
+                blockingInstalledCask: current?.blockingInstalledCask
+            )
+        }
+        return CaskAdoptionRequest(cask: cask, intent: intent, plan: plan)
     }
 }

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Mutations.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Mutations.swift
@@ -20,8 +20,10 @@ extension LocalHomebrewService {
         _ action: CaskAction,
         token: String,
         args: [String],
-        origin: CaskActionOrigin = .individual
+        origin: CaskActionOrigin = .individual,
+        context: HomebrewMutationContext = .none
     ) async throws {
+        let previousInstallation = installationSnapshot.installedCasks[token]
         try await mutationCoordinator.runSequence(
             HomebrewMutationSequenceRequest(
                 action: action,
@@ -36,11 +38,19 @@ extension LocalHomebrewService {
                         recoverIf: nil,
                         recoveryBehavior: .finishMutation
                     )
-                ]
+                ],
+                context: context
             ),
             callbacks: HomebrewMutationCallbacks(
                 refresh: { [self] in await refresh() },
-                strandedCopyExists: { [self] in hasStrandedCopy(token: token) }
+                strandedCopyExists: { [self] in hasStrandedCopy(token: token) },
+                postconditionSatisfied: { [self] in
+                    mutationPostconditionSatisfied(
+                        action: action,
+                        token: token,
+                        previousInstallation: previousInstallation
+                    )
+                }
             )
         )
     }
@@ -50,22 +60,32 @@ extension LocalHomebrewService {
         token: String,
         steps: [HomebrewMutationStep],
         origin: CaskActionOrigin,
-        displayName: String? = nil
+        displayName: String? = nil,
+        context: HomebrewMutationContext = .none
     ) async throws {
+        let previousInstallation = installationSnapshot.installedCasks[token]
         try await mutationCoordinator.runSequence(
             HomebrewMutationSequenceRequest(
                 action: action,
                 token: token,
                 displayName: displayName ?? self.displayName(for: token),
                 origin: origin,
-                steps: steps
+                steps: steps,
+                context: context
             ),
             callbacks: HomebrewMutationCallbacks(
                 refresh: { [self] in
                     if action == .updatingHomebrew { invalidateBrewVersion() }
                     await refresh()
                 },
-                strandedCopyExists: { [self] in hasStrandedCopy(token: token) }
+                strandedCopyExists: { [self] in hasStrandedCopy(token: token) },
+                postconditionSatisfied: { [self] in
+                    mutationPostconditionSatisfied(
+                        action: action,
+                        token: token,
+                        previousInstallation: previousInstallation
+                    )
+                }
             )
         )
     }
@@ -80,5 +100,23 @@ extension LocalHomebrewService {
             token: token,
             fileManager: fileManager
         )
+    }
+
+    private func mutationPostconditionSatisfied(
+        action: CaskAction,
+        token: String,
+        previousInstallation: LocalCaskInstallation?
+    ) -> Bool {
+        let current = installationSnapshot.installedCasks[token]
+        switch action {
+        case .installing, .adopting, .repairing:
+            return current?.isZombie == false
+        case .uninstalling:
+            return current == nil
+        case .updating:
+            return current?.isZombie == false && current != previousInstallation
+        case .opening, .updatingHomebrew, .queued:
+            return false
+        }
     }
 }

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+State.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+State.swift
@@ -67,10 +67,18 @@ extension LocalHomebrewService {
 
     private func openApplication(at url: URL?, token: String) {
         guard let url else {
-            noteFailure(
+            let error = LocalHomebrewError.appBundleNotFound(token: token)
+            noteFailure(token: token, error: error)
+            Analytics.caskActionFailed(
+                .opening,
                 token: token,
-                error: LocalHomebrewError.appBundleNotFound(token: token)
+                failureKind: error.failureKind
             )
+            CrashReporter.capture(error, tags: [
+                "brew.action": CaskAction.opening.identifier,
+                "brew.cask": token,
+                "brew.origin": CaskActionOrigin.individual.rawValue
+            ])
             return
         }
         applicationLauncher.open(url)

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
@@ -12,6 +12,11 @@ extension LocalHomebrewService {
         if let conflict = cask.conflictsWith?.caskTokens.first(where: {
             installedCasks[$0] != nil
         }) {
+            Analytics.caskActionFailed(
+                .installing,
+                token: cask.token,
+                failureKind: .caskConflict
+            )
             operationStore.send(
                 .fail(CaskOperationFailure(
                     kind: .installationPreflight,
@@ -95,18 +100,23 @@ extension LocalHomebrewService {
     /// recovery after a vendor installer refuses an in-place install), fetch the
     /// payload first, ask Homebrew to run the cask's uninstall stanza even though
     /// it has no receipt (`--force`), then install the requested package.
-    func replacePackageForAdoption(token: String) async throws {
+    func replacePackageForAdoption(
+        token: String,
+        context: HomebrewMutationContext = .none
+    ) async throws {
         try await stagedReplacement(
             token: token,
             action: .adopting,
-            origin: .individual
+            origin: .individual,
+            context: context
         )
     }
 
     private func stagedReplacement(
         token: String,
         action: CaskAction,
-        origin: CaskActionOrigin
+        origin: CaskActionOrigin,
+        context: HomebrewMutationContext = .none
     ) async throws {
         let caskroomEntry = HomebrewLocator.caskroomURL(
             customPrefix: customBrewPrefix,
@@ -148,7 +158,8 @@ extension LocalHomebrewService {
                     recoveryBehavior: .finishMutation
                 )
             ],
-            origin: origin
+            origin: origin,
+            context: context
         )
     }
 

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService.swift
@@ -29,8 +29,9 @@ final class LocalHomebrewService {
     @ObservationIgnored var packageCatalogGeneration = 0
 
     /// Test seam — the real probe hits TCC via the filesystem.
-    @ObservationIgnored var permissionProbe: @Sendable () -> AppManagementPermission.Status
-        = { AppManagementPermission.probe() }
+    @ObservationIgnored var permissionProbe:
+        @Sendable (URL?) -> AppManagementPermission.Assessment
+        = { AppManagementPermission.assess(target: $0) }
 
     @ObservationIgnored private var activationObserver: (any NSObjectProtocol)?
 
@@ -98,6 +99,7 @@ final class LocalHomebrewService {
             operationStore: operationStore,
             commandExecutor: dependencies.resolvedCommandExecutor(),
             brewBinaryProvider: dependencies.brewBinaryProvider,
+            askpassProvider: dependencies.askpassProvider,
             fileManager: dependencies.fileManager
         )
         softwareScanner = dependencies.softwareScanner
@@ -118,8 +120,10 @@ final class LocalHomebrewService {
         ) { [weak self] _ in
             Task { @MainActor in
                 guard let self else { return }
-                self.resumePendingAdoptions()
-                if self.brewVersion == nil {
+                if !self.operationStore.pendingPermissions.isEmpty {
+                    await self.refresh()
+                    await self.resumePendingAdoptions()
+                } else if self.brewVersion == nil {
                     await self.refresh()
                 }
             }

--- a/CaskHub/Services/Homebrew/Infrastructure/AppManagementPermission.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/AppManagementPermission.swift
@@ -12,8 +12,19 @@ import Foundation
 /// consults the gate (TCC enforces actual writes only), so status is probed
 /// Homebrew-style: attempt a harmless write inside protected bundles.
 nonisolated enum AppManagementPermission {
-    enum Status: Equatable {
+    enum Status: Equatable, Sendable {
         case granted, denied, unknown
+    }
+
+    enum Evidence: String, Equatable, Sendable {
+        case target
+        case generic
+        case unverified
+    }
+
+    struct Assessment: Equatable, Sendable {
+        let status: Status
+        let evidence: Evidence?
     }
 
     enum WriteAttempt {
@@ -28,7 +39,41 @@ nonisolated enum AppManagementPermission {
     }
 
     nonisolated static func probe() -> Status {
-        probe(targets: probeTargets(), attempt: attemptWrite)
+        assess(target: nil).status
+    }
+
+    /// Prefer the app that will actually be adopted. Root-owned bundles cannot
+    /// be tested without another password prompt, so they fall back to the
+    /// conservative multi-bundle probe and retain that weaker provenance.
+    nonisolated static func assess(target: URL?) -> Assessment {
+        assess(
+            target: target,
+            fallbackTargets: probeTargets(),
+            attempt: attemptWrite
+        )
+    }
+
+    nonisolated static func assess(
+        target: URL?,
+        fallbackTargets: [URL],
+        attempt: (URL) -> WriteAttempt
+    ) -> Assessment {
+        if let target {
+            switch attempt(target) {
+            case .allowed:
+                return Assessment(status: .granted, evidence: .target)
+            case .blocked:
+                return Assessment(status: .denied, evidence: .target)
+            case .skipped:
+                break
+            }
+        }
+
+        let status = probe(targets: fallbackTargets, attempt: attempt)
+        return Assessment(
+            status: status,
+            evidence: status == .unknown ? nil : .generic
+        )
     }
 
     /// One blocked write proves denied; allowed writes are weaker evidence (bundles
@@ -49,7 +94,7 @@ nonisolated enum AppManagementPermission {
                 continue
             }
         }
-        return allowed > 0 ? .granted : .unknown
+        return .unknown
     }
 
     /// After the posixWritable guard only the TCC gate returns EPERM; EACCES (ACLs) is not it.

--- a/CaskHub/Services/Homebrew/Infrastructure/AskpassScriptManager.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/AskpassScriptManager.swift
@@ -7,6 +7,43 @@
 
 import Foundation
 
+nonisolated enum AskpassScriptError: Error, Equatable, Sendable {
+    case executableUnavailable
+    case fileSystem(stage: AskpassFailureStage, failureKind: HomebrewFailureKind)
+
+    var stage: AskpassFailureStage {
+        switch self {
+        case .executableUnavailable: .executable
+        case let .fileSystem(stage, _): stage
+        }
+    }
+
+    var failureKind: HomebrewFailureKind {
+        switch self {
+        case .executableUnavailable: .askpassUnavailable
+        case let .fileSystem(_, failureKind): failureKind
+        }
+    }
+
+    static func fileSystem(
+        _ error: Error,
+        stage: AskpassFailureStage
+    ) -> Self {
+        let nsError = error as NSError
+        let isStorageFull = (
+            nsError.domain == NSCocoaErrorDomain
+                && nsError.code == CocoaError.fileWriteOutOfSpace.rawValue
+        ) || (
+            nsError.domain == NSPOSIXErrorDomain
+                && nsError.code == ENOSPC
+        )
+        return .fileSystem(
+            stage: stage,
+            failureKind: isStorageFull ? .storageFull : .askpassUnavailable
+        )
+    }
+}
+
 nonisolated enum AskpassScriptManager {
     // @concurrent: callers are MainActor; these touch disk and must not run there.
     @concurrent
@@ -14,45 +51,54 @@ nonisolated enum AskpassScriptManager {
         token: String,
         directory: URL? = nil,
         executableURL: URL? = Bundle.main.executableURL
-    ) async -> URL? {
-        guard let executablePath = executableURL?.path else { return nil }
-        let safeToken = token.filter {
-            $0.isLetter || $0.isNumber || "-_+@.".contains($0)
+    ) async throws -> URL {
+        guard let executablePath = executableURL?.path else {
+            throw AskpassScriptError.executableUnavailable
         }
-        let script = """
-        #!/bin/sh
-        exec \(shellQuoted(executablePath)) --askpass \(shellQuoted(safeToken))
-        """
+        let safeToken = token.filter { $0.isLetter || $0.isNumber || "-_+@.".contains($0) }
         let fileManager = FileManager.default
         let destinationDirectory: URL
         if let directory {
             destinationDirectory = directory
         } else {
-            guard let base = try? fileManager.url(
+            let base = (try? fileManager.url(
                 for: .applicationSupportDirectory,
                 in: .userDomainMask,
                 appropriateFor: nil,
                 create: true
-            ) else { return nil }
+            )) ?? fileManager.temporaryDirectory
             destinationDirectory = base.appendingPathComponent(
                 "CaskHub",
                 isDirectory: true
             )
         }
-        let url = destinationDirectory
-            .appendingPathComponent("askpass-\(UUID().uuidString).sh")
+        let url = destinationDirectory.appendingPathComponent("askpass-\(UUID().uuidString).sh")
+        let script = script(
+            executablePath: executablePath,
+            token: safeToken,
+            marker: cancellationMarker(for: url)
+        )
         do {
             try fileManager.createDirectory(
                 at: destinationDirectory,
                 withIntermediateDirectories: true
             )
+        } catch {
+            throw AskpassScriptError.fileSystem(error, stage: .directory)
+        }
+        do {
             try script.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            throw AskpassScriptError.fileSystem(error, stage: .script)
+        }
+        do {
             try fileManager.setAttributes(
                 [.posixPermissions: 0o700],
                 ofItemAtPath: url.path
             )
         } catch {
-            return nil
+            try? fileManager.removeItem(at: url)
+            throw AskpassScriptError.fileSystem(error, stage: .permissions)
         }
         return url
     }
@@ -60,6 +106,36 @@ nonisolated enum AskpassScriptManager {
     @concurrent
     static func remove(at url: URL) async {
         try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(at: cancellationMarker(for: url))
+    }
+
+    static func cancellationMarker(for scriptURL: URL) -> URL {
+        scriptURL.appendingPathExtension("cancelled")
+    }
+
+    static func localError(for error: Error) -> LocalHomebrewError {
+        guard let error = error as? AskpassScriptError else {
+            return .askpassUnavailable(
+                stage: .unknown,
+                failureKind: .askpassUnavailable
+            )
+        }
+        return .askpassUnavailable(
+            stage: error.stage,
+            failureKind: error.failureKind
+        )
+    }
+
+    private static func script(
+        executablePath: String,
+        token: String,
+        marker: URL
+    ) -> String {
+        """
+        #!/bin/sh
+        exec \(shellQuoted(executablePath)) --askpass \(shellQuoted(token)) \
+          --askpass-cancel-marker \(shellQuoted(marker.path))
+        """
     }
 
     private static func shellQuoted(_ value: String) -> String {

--- a/CaskHub/Services/Homebrew/Infrastructure/BrewProcessRunner.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/BrewProcessRunner.swift
@@ -11,6 +11,17 @@ import Foundation
 struct BrewProcessResult: Sendable {
     let exitCode: Int32
     let output: String
+    let wasTerminatedBySignal: Bool
+
+    init(
+        exitCode: Int32,
+        output: String,
+        wasTerminatedBySignal: Bool = false
+    ) {
+        self.exitCode = exitCode
+        self.output = output
+        self.wasTerminatedBySignal = wasTerminatedBySignal
+    }
 }
 
 /// Execution seam for Homebrew mutations. Tests can supply deterministic
@@ -86,7 +97,8 @@ final class SystemBrewProcessRunner: BrewProcessRunning {
         await deliveryTask.value
         return BrewProcessResult(
             exitCode: process.terminationStatus,
-            output: output
+            output: output,
+            wasTerminatedBySignal: process.terminationReason == .uncaughtSignal
         )
     }
 }

--- a/CaskHub/Services/Homebrew/Infrastructure/HomebrewCommandExecutor.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/HomebrewCommandExecutor.swift
@@ -31,6 +31,8 @@ protocol HomebrewCommandExecuting {
 final class SystemHomebrewCommandExecutor: HomebrewCommandExecuting {
     private let processRunner: any BrewProcessRunning
     private var runningProcesses: [String: Process] = [:]
+    private static var isExecuting = false
+    private static var waiters: [CheckedContinuation<Void, Never>] = []
 
     init(processRunner: (any BrewProcessRunning)? = nil) {
         self.processRunner = processRunner ?? SystemBrewProcessRunner()
@@ -41,6 +43,9 @@ final class SystemHomebrewCommandExecutor: HomebrewCommandExecuting {
         onStart: @escaping @MainActor @Sendable () -> Void,
         onChunk: @escaping @MainActor @Sendable (String) -> Void
     ) async throws -> BrewProcessResult {
+        await Self.acquireGlobalTurn()
+        defer { Self.releaseGlobalTurn() }
+        try Task.checkCancellation()
         defer { runningProcesses[request.token] = nil }
         return try await processRunner.run(
             executableURL: request.executableURL,
@@ -52,6 +57,24 @@ final class SystemHomebrewCommandExecutor: HomebrewCommandExecuting {
             },
             onChunk: onChunk
         )
+    }
+
+    // ponytail: Homebrew uses global locks, so one FIFO is the correct ceiling
+    // until CaskHub supports independent Homebrew prefixes at the same time.
+    static func acquireGlobalTurn() async {
+        guard !isExecuting else {
+            await withCheckedContinuation { waiters.append($0) }
+            return
+        }
+        isExecuting = true
+    }
+
+    static func releaseGlobalTurn() {
+        guard !waiters.isEmpty else {
+            isExecuting = false
+            return
+        }
+        waiters.removeFirst().resume()
     }
 
     func cancel(token: String) -> Bool {

--- a/CaskHub/Services/Homebrew/Infrastructure/MaintenanceProbe.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/MaintenanceProbe.swift
@@ -75,12 +75,15 @@ nonisolated struct SystemMaintenanceProbe: MaintenanceProbing {
         arguments: [String],
         environment: [String: String]?
     ) async -> BrewProbeResult? {
-        guard let result = ProcessCapture.capture(
+        await SystemHomebrewCommandExecutor.acquireGlobalTurn()
+        let result = ProcessCapture.capture(
             executable,
             arguments: arguments,
             environment: environment,
             mergeStderr: true
-        ) else { return nil }
+        )
+        await SystemHomebrewCommandExecutor.releaseGlobalTurn()
+        guard let result else { return nil }
         return BrewProbeResult(exitCode: result.status, output: result.output ?? "")
     }
 

--- a/CaskHub/Services/Telemetry/Analytics+Events.swift
+++ b/CaskHub/Services/Telemetry/Analytics+Events.swift
@@ -40,9 +40,9 @@ extension Analytics {
         origin: CaskActionOrigin = .individual,
         failureKind: HomebrewFailureKind? = nil
     ) {
-        guard let verb = action.analyticsVerb else { return }
+        guard let verb = action.failureAnalyticsVerb else { return }
         var parameters = actionParameters(
-            verb: verb.base, token: token, origin: origin
+            verb: verb, token: token, origin: origin
         )
         parameters["failureClass"] = failureKind?.rawValue
         send("Cask.actionFailed", parameters: parameters)
@@ -153,6 +153,12 @@ extension Analytics {
 // MARK: - Analytics names for domain types
 
 private extension CaskAction {
+    var failureAnalyticsVerb: String? {
+        if self == .updatingHomebrew { return "updateHomebrew" }
+        if self == .opening { return "open" }
+        return analyticsVerb?.base
+    }
+
     /// Verb forms for signal names; nil means "don't track this action".
     var analyticsVerb: (base: String, past: String)? {
         switch self {

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -16,7 +16,7 @@ protocol CrashSpan {
 protocol CrashReporterProvider {
     func start(consent: SentryConsent)
     func setConsent(_ consent: SentryConsent)
-    func capture(_ error: Error)
+    func capture(_ error: Error, tags: [String: String])
     func addBreadcrumb(_ message: String, data: [String: String])
     func setTag(_ key: String, value: String)
     func startSpan(name: String, operation: String) -> CrashSpan
@@ -81,13 +81,10 @@ enum CrashReporter {
         SentryConsent(crashReporting: isEnabled, analytics: Analytics.isEnabled)
     }
 
-    static func capture(_ error: Error) {
+    static func capture(_ error: Error, tags: [String: String] = [:]) {
         guard isEnabled, !isRunningTests else { return }
         // Task cancellation (e.g. a view disappearing mid-fetch) is not an error.
         if error is CancellationError {
-            return
-        }
-        if let localError = error as? LocalHomebrewError, !localError.shouldReport {
             return
         }
         let nsError = error as NSError
@@ -118,7 +115,7 @@ enum CrashReporter {
         let count = captureCounts[signature, default: 0]
         guard count < captureLimit else { return }
         captureCounts[signature] = count + 1
-        provider.capture(error)
+        provider.capture(error, tags: tags)
     }
 
     static func breadcrumb(_ message: String, data: [String: String] = [:]) {
@@ -370,23 +367,41 @@ final class SentryProvider: CrashReporterProvider {
         }
     }
 
-    func capture(_ error: Error) {
-        SentrySDK.capture(error: error) { scope in
+    func capture(_ error: Error, tags: [String: String]) {
+        SentrySDK.capture(error: Self.sanitized(error)) { scope in
             if let fingerprint = Self.fingerprint(for: error) {
                 scope.setFingerprint(fingerprint)
             }
-            guard let localError = error as? LocalHomebrewError,
-                  case let .brewCommandFailed(failure) = localError
-            else { return }
-            scope.setTag(value: failure.kind.rawValue, key: "brew.failure_class")
+            for (key, value) in tags {
+                scope.setTag(value: value, key: key)
+            }
+            guard let localError = error as? LocalHomebrewError else { return }
+            if let failureKind = localError.failureKind {
+                scope.setTag(value: failureKind.rawValue, key: "brew.failure_class")
+            }
+            if case let .askpassUnavailable(stage, _) = localError {
+                scope.setTag(value: stage.rawValue, key: "brew.askpass_stage")
+            }
+            guard case let .brewCommandFailed(failure) = localError else { return }
             scope.setTag(value: failure.subcommand ?? "missing", key: "brew.subcommand")
             scope.setTag(value: String(failure.exitCode), key: "brew.exit_code")
+            if let diagnosticBucket = failure.diagnosticBucket {
+                scope.setTag(value: diagnosticBucket, key: "brew.diagnostic_bucket")
+            }
         }
     }
+    private static func sanitized(_ error: Error) -> any Error {
+        guard case let LocalHomebrewError.brewCommandFailed(failure) = error else {
+            return error
+        }
+        return LocalHomebrewError.brewCommandFailed(HomebrewCommandFailure(
+            arguments: failure.subcommand.map { [$0] } ?? [],
+            exitCode: failure.exitCode,
+            diagnostic: "",
+            kind: failure.kind
+        ))
+    }
 
-    /// Groups brew failures per subcommand and failure class instead of NSError
-    /// domain+code — one issue per way brew fails, so a rare destructive failure
-    /// can't hide inside a busy catch-all group.
     static func fingerprint(for error: Error) -> [String]? {
         guard case let LocalHomebrewError.brewCommandFailed(failure) = error else {
             return nil
@@ -410,24 +425,22 @@ final class SentryProvider: CrashReporterProvider {
         return SentrySpanHandle(span: SentrySDK.startTransaction(name: name, operation: operation))
     }
 
-    func pauseHangTracking() {
-        SentrySDK.pauseAppHangTracking()
-    }
-
-    func resumeHangTracking() {
-        SentrySDK.resumeAppHangTracking()
-    }
+    func pauseHangTracking() { SentrySDK.pauseAppHangTracking() }
+    func resumeHangTracking() { SentrySDK.resumeAppHangTracking() }
 }
 
 private struct SentrySpanHandle: CrashSpan {
     let span: any Span
 
-    func finish() {
-        span.finish()
-    }
+    func finish() { span.finish() }
 
     func finish(error: Error) {
-        span.setData(value: String(describing: error), key: "error")
+        span.setData(value: String(reflecting: type(of: error)), key: "error.type")
+        if case let LocalHomebrewError.brewCommandFailed(failure) = error {
+            span.setData(value: failure.kind.rawValue, key: "brew.failure_class")
+            span.setData(value: failure.subcommand ?? "missing", key: "brew.subcommand")
+            span.setData(value: failure.exitCode, key: "brew.exit_code")
+        }
         span.finish(status: .internalError)
     }
 }

--- a/CaskHub/Services/Telemetry/CrashReporter.swift
+++ b/CaskHub/Services/Telemetry/CrashReporter.swift
@@ -327,6 +327,8 @@ final class SentryProvider: CrashReporterProvider {
         isAnalyticsEnabled: @escaping () -> Bool = { Analytics.isEnabled }
     ) {
         options.enableMetrics = true
+        // Report handled failures at app boundaries, not once per raw request attempt.
+        options.enableCaptureFailedRequests = false
         options.beforeSendMetric = { metric in
             guard isAnalyticsEnabled() else { return nil }
             var metric = metric
@@ -347,7 +349,6 @@ final class SentryProvider: CrashReporterProvider {
             options.enableNetworkTracking = false
             options.enableFileIOTracing = false
             options.enableCoreDataTracing = false
-            options.enableCaptureFailedRequests = false
             options.enableAutoBreadcrumbTracking = false
             options.enableNetworkBreadcrumbs = false
             options.enableSwizzling = false

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -276,7 +276,10 @@ struct ResignFocusOnOutsideClick: ViewModifier {
                     if isFocused(),
                        let frameView = event.window?.contentView?.superview,
                        !(frameView.hitTest(event.locationInWindow) is NSTextView) {
-                        resign()
+                        DispatchQueue.main.async {
+                            guard isFocused() else { return }
+                            resign()
+                        }
                     }
                     return event
                 }

--- a/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogViewModelTests.swift
@@ -437,7 +437,7 @@ final class CaskCatalogViewModelTests: XCTestCase {
     // MARK: - Crash reporting
 
     @MainActor
-    func test_fetch_failure_is_captured_and_finishes_span_with_error() async {
+    func test_fetch_http_500_is_captured_and_finishes_span_with_error() async throws {
         let crashSpy = SpyCrashReporterProvider()
         let originalCrash = CrashReporter.provider
         CrashReporter.provider = crashSpy
@@ -449,13 +449,14 @@ final class CaskCatalogViewModelTests: XCTestCase {
         CrashReporter.captureCounts = [:]
 
         let api = MockBrewAPIClient()
-        // Transport failures are deliberately ignored; malformed server responses are reportable.
-        api.casksError = URLError(.badServerResponse)
+        api.casksError = BrewAPIClient.HTTPError(statusCode: 500)
         let vm = makeViewModel(api: api)
 
         await vm.fetchCasks()
 
         XCTAssertEqual(crashSpy.capturedErrors.count, 1)
+        let error = try XCTUnwrap(crashSpy.capturedErrors.first as? BrewAPIClient.HTTPError)
+        XCTAssertEqual(error.statusCode, 500)
         XCTAssertEqual(crashSpy.spans.last?.name, "catalog.fetch")
         XCTAssertEqual(crashSpy.spans.last?.operation, "http")
         XCTAssertNotNil(crashSpy.spans.last?.span.finishedError)

--- a/CaskHubTests/Homebrew/Coordination/CaskOperationStoreTests.swift
+++ b/CaskHubTests/Homebrew/Coordination/CaskOperationStoreTests.swift
@@ -158,6 +158,7 @@ final class CaskOperationStoreTests: XCTestCase {
         let cask = makeCask("sample", appNames: ["Sample.app"])
         return CaskAdoptionRequest(
             cask: cask,
+            intent: .planned,
             plan: CaskAdoptionPlan(
                 artifact: .applicationBundle,
                 versionRelationship: .same,

--- a/CaskHubTests/Homebrew/Coordination/MutationRecoveryTests.swift
+++ b/CaskHubTests/Homebrew/Coordination/MutationRecoveryTests.swift
@@ -34,6 +34,10 @@ final class MutationRecoveryTests: XCTestCase {
 
     private func makeService(
         runner: StubBrewProcessRunner,
+        scanner: (any InstalledSoftwareScanning)? = nil,
+        askpassProvider: @escaping @Sendable (String) async throws -> URL = {
+            URL(fileURLWithPath: "/private/tmp/caskhub-test-askpass-\($0)")
+        },
         brewVersionProvider: @escaping () async -> String? = { "test" }
     ) -> LocalHomebrewService {
         LocalHomebrewService(defaults: defaults) {
@@ -46,6 +50,8 @@ final class MutationRecoveryTests: XCTestCase {
                 URL(fileURLWithPath: "/test/bin/brew")
             }
             $0.brewVersionProvider = brewVersionProvider
+            $0.askpassProvider = askpassProvider
+            if let scanner { $0.softwareScanner = scanner }
         }
     }
 
@@ -135,10 +141,10 @@ final class MutationRecoveryTests: XCTestCase {
     func test_update_homebrew_runs_two_update_passes() async throws {
         let runner = StubBrewProcessRunner()
         var versionLoads = 0
-        let service = makeService(runner: runner) {
+        let service = makeService(runner: runner, brewVersionProvider: {
             versionLoads += 1
             return versionLoads == 1 ? "old" : "new"
-        }
+        })
 
         await service.refresh()
         XCTAssertEqual(service.brewVersion, "old")
@@ -174,11 +180,11 @@ final class MutationRecoveryTests: XCTestCase {
         ]
         let versionReloaded = expectation(description: "Homebrew version reloaded")
         var versionLoads = 0
-        let service = makeService(runner: runner) {
+        let service = makeService(runner: runner, brewVersionProvider: {
             versionLoads += 1
             if versionLoads == 2 { versionReloaded.fulfill() }
             return versionLoads == 1 ? "old" : "new"
-        }
+        })
         await service.refresh()
         let cask = makeCask("gimp")
 
@@ -229,6 +235,106 @@ final class MutationRecoveryTests: XCTestCase {
         }
     }
 
+    func test_askpass_setup_failure_stops_before_brew_and_surfaces_app_error() async {
+        let runner = StubBrewProcessRunner()
+        let service = makeService(runner: runner, askpassProvider: { _ in
+            throw AskpassScriptError.executableUnavailable
+        })
+
+        do {
+            try await service.install(token: "zed")
+            XCTFail("brew must not start without a working password prompt")
+        } catch let LocalHomebrewError.askpassUnavailable(stage, failureKind) {
+            XCTAssertEqual(stage, .executable)
+            XCTAssertEqual(failureKind, .askpassUnavailable)
+            XCTAssertTrue(runner.requests.isEmpty)
+            XCTAssertTrue(
+                service.operationStore.state(for: "zed")?
+                    .failure?.message.contains("password prompt") == true
+            )
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+    }
+
+    func test_sudo_decline_is_suppressed_only_with_the_helper_cancel_marker() async {
+        let unmarkedRunner = StubBrewProcessRunner()
+        unmarkedRunner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "sudo: no password was provided"
+        )]
+        do {
+            try await makeService(runner: unmarkedRunner).install(token: "zed")
+            XCTFail("the failed helper must not look like a user cancellation")
+        } catch let LocalHomebrewError.brewCommandFailed(failure) {
+            XCTAssertEqual(failure.kind, .askpassUnavailable)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        let markedRunner = StubBrewProcessRunner()
+        markedRunner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "sudo: no password was provided"
+        )]
+        markedRunner.onRequest = { request in
+            let script = try XCTUnwrap(request.environment["SUDO_ASKPASS"])
+            try Data().write(to: AskpassScriptManager.cancellationMarker(
+                for: URL(fileURLWithPath: script)
+            ))
+        }
+        do {
+            try await makeService(runner: markedRunner).install(token: "zed")
+            XCTFail("the user cancellation still stops the operation")
+        } catch let LocalHomebrewError.brewCommandFailed(failure) {
+            XCTAssertEqual(failure.kind, .sudoDeclined)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_askpass_cancel_marker_does_not_depend_on_sudo_output() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(exitCode: 1, output: "")]
+        runner.onRequest = { request in
+            let script = try XCTUnwrap(request.environment["SUDO_ASKPASS"])
+            try Data().write(to: AskpassScriptManager.cancellationMarker(
+                for: URL(fileURLWithPath: script)
+            ))
+        }
+
+        do {
+            try await makeService(runner: runner).install(token: "zed")
+            XCTFail("the marker must prove cancellation without English sudo output")
+        } catch let LocalHomebrewError.brewCommandFailed(failure) {
+            XCTAssertEqual(failure.kind, .sudoDeclined)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_askpass_disk_full_keeps_its_external_failure_kind() async {
+        let runner = StubBrewProcessRunner()
+        let service = makeService(runner: runner, askpassProvider: { _ in
+            throw AskpassScriptError.fileSystem(
+                stage: .script,
+                failureKind: .storageFull
+            )
+        })
+
+        do {
+            try await service.install(token: "zed")
+            XCTFail("brew must not start when askpass cannot be written")
+        } catch let LocalHomebrewError.askpassUnavailable(stage, failureKind) {
+            XCTAssertEqual(stage, .script)
+            XCTAssertEqual(failureKind, .storageFull)
+            XCTAssertTrue(runner.requests.isEmpty)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
     func test_failed_upgrade_for_uninstalled_cask_refreshes_stale_local_state() async {
         let runner = StubBrewProcessRunner()
         runner.queuedResults = [BrewProcessResult(
@@ -249,6 +355,93 @@ final class MutationRecoveryTests: XCTestCase {
             service.localState(for: thorium).isPresent,
             "brew disagreeing about install state must trigger a snapshot refresh"
         )
+    }
+
+    func test_nonzero_upgrade_is_recovered_only_when_refresh_proves_changed_receipt() async throws {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "🍺  zed was successfully upgraded!"
+        )]
+        let previous = LocalCaskInstallation(
+            token: "zed",
+            installedVersion: "1.0",
+            installedAt: nil,
+            lastUpdatedAt: Date(timeIntervalSince1970: 1),
+            appBundleNames: []
+        )
+        let refreshed = LocalCaskInstallation(
+            token: "zed",
+            installedVersion: "1.0",
+            installedAt: nil,
+            lastUpdatedAt: Date(timeIntervalSince1970: 2),
+            appBundleNames: []
+        )
+        let scanner = FixedInstalledSoftwareScanner(snapshot: InstallationSnapshot(
+            installedCasks: ["zed": refreshed]
+        ))
+        let service = makeService(runner: runner, scanner: scanner)
+        updateInstalledCask(previous, in: service)
+
+        try await service.upgrade(token: "zed")
+
+        XCTAssertEqual(service.installedCasks["zed"], refreshed)
+        XCTAssertNil(service.actionAlert(for: "zed"))
+    }
+
+    func test_nonzero_upgrade_still_fails_when_refresh_does_not_prove_change() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "🍺  zed was successfully upgraded!"
+        )]
+        let scanner = FixedInstalledSoftwareScanner(snapshot: InstallationSnapshot(
+            installedCasks: ["zed": installation("zed", version: "1.0")]
+        ))
+        let service = makeService(runner: runner, scanner: scanner)
+        updateInstalledCask(installation("zed", version: "1.0"), in: service)
+
+        do {
+            try await service.upgrade(token: "zed")
+            XCTFail("the unchanged snapshot must not prove success")
+        } catch let LocalHomebrewError.brewCommandFailed(failure) {
+            XCTAssertEqual(failure.kind, .exitNonzeroAfterSuccess)
+            XCTAssertNotNil(service.actionAlert(for: "zed"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_nonzero_upgrade_does_not_treat_a_zombie_receipt_as_success() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(
+            exitCode: 1,
+            output: "🍺  zed was successfully upgraded!"
+        )]
+        let previous = installation("zed", version: "1.0")
+        let zombie = LocalCaskInstallation(
+            token: "zed",
+            installedVersion: "2.0",
+            installedAt: nil,
+            appBundleNames: ["Zed.app"],
+            isZombie: true
+        )
+        let scanner = FixedInstalledSoftwareScanner(snapshot: InstallationSnapshot(
+            installedCasks: ["zed": zombie]
+        ))
+        let service = makeService(runner: runner, scanner: scanner)
+        updateInstalledCask(previous, in: service)
+
+        do {
+            try await service.upgrade(token: "zed")
+            XCTFail("a degraded installation cannot prove upgrade success")
+        } catch let LocalHomebrewError.brewCommandFailed(failure) {
+            XCTAssertEqual(failure.kind, .exitNonzeroAfterSuccess)
+            XCTAssertEqual(service.installedCasks["zed"], zombie)
+            XCTAssertNotNil(service.actionAlert(for: "zed"))
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
     }
 
     func test_brew_error_diagnostics_keep_error_before_long_cleanup_tail() async {

--- a/CaskHubTests/Homebrew/Domain/CaskOperationStateTests.swift
+++ b/CaskHubTests/Homebrew/Domain/CaskOperationStateTests.swift
@@ -254,6 +254,7 @@ final class CaskOperationStateTests: XCTestCase {
         let cask = Cask.preview(token: "sample", version: "1.0")
         return CaskAdoptionRequest(
             cask: cask,
+            intent: .planned,
             plan: CaskAdoptionPlan(
                 artifact: .applicationBundle,
                 versionRelationship: .same,

--- a/CaskHubTests/Homebrew/Domain/HomebrewCommandFailureTests.swift
+++ b/CaskHubTests/Homebrew/Domain/HomebrewCommandFailureTests.swift
@@ -98,7 +98,7 @@ final class HomebrewCommandFailureTests: XCTestCase {
         XCTAssertLessThanOrEqual(buckets.count, 32)
     }
 
-    func test_machine_and_askpass_provenance_split_app_invariants_from_user_state() {
+    func test_machine_provenance_splits_app_invariants_from_user_state() {
         let architecture = """
         This cask depends on hardware architecture being one of \
         [{type: :arm, bits: 64}], but you are running {type: :intel, bits: 64}.
@@ -121,7 +121,9 @@ final class HomebrewCommandFailureTests: XCTestCase {
             ),
             .platformUnsupported
         )
+    }
 
+    func test_askpass_provenance_splits_user_decision_from_helper_failure() {
         let sudoOutput = "sudo: no password was provided"
         XCTAssertEqual(
             HomebrewCommandFailure(

--- a/CaskHubTests/Homebrew/Domain/HomebrewCommandFailureTests.swift
+++ b/CaskHubTests/Homebrew/Domain/HomebrewCommandFailureTests.swift
@@ -52,7 +52,7 @@ final class HomebrewCommandFailureTests: XCTestCase {
         let first = unknownFailure(
             token: "cask-alpha",
             diagnostic: """
-            Error: cask-alpha failed for /Users/alice at /private/tmp/homebrew-one/payload.dmg
+            Error: cask-alpha failed for /Users/Alice Smith/Documents/Tax Return.pdf
             Source https://one.example/cask-alpha/1.2.3/payload.dmg version 1.2.3 build 42
             Hash aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
             UUID 123e4567-e89b-12d3-a456-426614174000
@@ -61,7 +61,7 @@ final class HomebrewCommandFailureTests: XCTestCase {
         let second = unknownFailure(
             token: "cask-beta",
             diagnostic: """
-            Error: cask-beta failed for /Users/bob at /private/tmp/homebrew-two/payload.dmg
+            Error: cask-beta failed for /Users/Bob Jones/Documents/Tax Return.pdf
             Source https://two.example/cask-beta/9.8.7/payload.dmg version 9.8.7 build 99
             Hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
             UUID 987e6543-e21b-43d3-b654-426614179999
@@ -74,9 +74,11 @@ final class HomebrewCommandFailureTests: XCTestCase {
         let secondFingerprint = try XCTUnwrap(second.stableFingerprint)
         XCTAssertEqual(firstFingerprint, secondFingerprint)
         XCTAssertEqual(
-            firstFingerprint,
+            Array(firstFingerprint.prefix(3)),
             ["brewCommandFailed", "install", "unknown"]
         )
+        XCTAssertEqual(firstFingerprint.count, 3)
+        XCTAssertEqual(first.rateLimitSignature, second.rateLimitSignature)
         XCTAssertFalse(first.rateLimitSignature.contains("alice"))
         XCTAssertFalse(first.rateLimitSignature.contains("cask-alpha"))
 
@@ -85,6 +87,75 @@ final class HomebrewCommandFailureTests: XCTestCase {
             diagnostic: "Error: renderer crashed before launch"
         )
         XCTAssertEqual(firstFingerprint, different.stableFingerprint)
+
+        let buckets = Set((1 ... 100).compactMap { length in
+            unknownFailure(
+                token: "example",
+                diagnostic: String(repeating: "x", count: length)
+            ).diagnosticBucket
+        })
+        XCTAssertGreaterThan(buckets.count, 1)
+        XCTAssertLessThanOrEqual(buckets.count, 32)
+    }
+
+    func test_machine_and_askpass_provenance_split_app_invariants_from_user_state() {
+        let architecture = """
+        This cask depends on hardware architecture being one of \
+        [{type: :arm, bits: 64}], but you are running {type: :intel, bits: 64}.
+        """
+        XCTAssertEqual(
+            HomebrewCommandFailure.classify(
+                arguments: ["install"],
+                exitCode: 1,
+                diagnostic: architecture,
+                machineIsAppleSilicon: true
+            ),
+            .brewArchitectureMismatch
+        )
+        XCTAssertEqual(
+            HomebrewCommandFailure.classify(
+                arguments: ["install"],
+                exitCode: 1,
+                diagnostic: architecture,
+                machineIsAppleSilicon: false
+            ),
+            .platformUnsupported
+        )
+
+        let sudoOutput = "sudo: no password was provided"
+        XCTAssertEqual(
+            HomebrewCommandFailure(
+                arguments: ["install"],
+                exitCode: 1,
+                diagnostic: sudoOutput,
+                askpassUserCancelled: true
+            ).kind,
+            .sudoDeclined
+        )
+        XCTAssertEqual(
+            HomebrewCommandFailure(
+                arguments: ["install"],
+                exitCode: 1,
+                diagnostic: sudoOutput,
+                askpassUserCancelled: false
+            ).kind,
+            .askpassUnavailable
+        )
+        XCTAssertEqual(
+            HomebrewCommandFailure(
+                arguments: ["install"],
+                exitCode: 1,
+                diagnostic: "",
+                askpassUserCancelled: true
+            ).kind,
+            .sudoDeclined
+        )
+    }
+
+    func test_only_proven_user_decision_is_explicit() {
+        XCTAssertTrue(HomebrewFailureKind.sudoDeclined.isExplicitUserDecision)
+        XCTAssertFalse(HomebrewFailureKind.sudoWrongPassword.isExplicitUserDecision)
+        XCTAssertFalse(HomebrewFailureKind.dmgMountCancelled.isExplicitUserDecision)
     }
 
     func test_unknown_disk_image_output_keeps_a_reportable_mount_class() {
@@ -95,7 +166,7 @@ final class HomebrewCommandFailureTests: XCTestCase {
         )
 
         XCTAssertEqual(failure.kind, .dmgMountFailed)
-        XCTAssertTrue(failure.kind.shouldReport)
+        XCTAssertFalse(failure.kind.isNormallyExternal)
     }
 
     func test_runtime_incompatible_failure_offers_update_homebrew() {
@@ -109,7 +180,7 @@ final class HomebrewCommandFailureTests: XCTestCase {
         )
 
         XCTAssertEqual(error.commandFailure?.kind, .homebrewRuntimeIncompatible)
-        XCTAssertFalse(error.shouldReport)
+        XCTAssertTrue(error.commandFailure?.kind.isNormallyExternal == true)
         XCTAssertEqual(
             CaskOperationFailureFactory.make(
                 from: error,
@@ -128,7 +199,7 @@ final class HomebrewCommandFailureTests: XCTestCase {
         )
 
         XCTAssertEqual(failure.kind, .storageFull)
-        XCTAssertFalse(failure.kind.shouldReport)
+        XCTAssertTrue(failure.kind.isNormallyExternal)
     }
 
     private func unknownFailure(

--- a/CaskHubTests/Homebrew/Infrastructure/AppManagementPermissionTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/AppManagementPermissionTests.swift
@@ -44,16 +44,16 @@ final class AppManagementPermissionTests: XCTestCase {
         XCTAssertEqual(attempted.count, 3)
     }
 
-    func test_probe_reports_granted_when_single_candidate_allows() {
+    func test_generic_probe_stays_unknown_when_only_one_candidate_allows() {
         let status = AppManagementPermission.probe(targets: [targets[0]]) { _ in .allowed }
-        XCTAssertEqual(status, .granted)
+        XCTAssertEqual(status, .unknown)
     }
 
     func test_probe_skips_unwritable_candidates_without_verdict() {
         let status = AppManagementPermission.probe(targets: targets) { url in
             url.lastPathComponent == "D.app" ? .allowed : .skipped
         }
-        XCTAssertEqual(status, .granted)
+        XCTAssertEqual(status, .unknown)
     }
 
     func test_probe_reports_unknown_when_no_candidate_accepts_a_write() {
@@ -62,5 +62,33 @@ final class AppManagementPermissionTests: XCTestCase {
             .unknown
         )
         XCTAssertEqual(AppManagementPermission.probe(targets: []) { _ in .allowed }, .unknown)
+    }
+
+    func test_target_probe_records_strong_target_evidence() {
+        let assessment = AppManagementPermission.assess(
+            target: targets[0],
+            fallbackTargets: Array(targets.dropFirst())
+        ) { url in
+            url == self.targets[0] ? .allowed : .blocked
+        }
+
+        XCTAssertEqual(
+            assessment,
+            AppManagementPermission.Assessment(status: .granted, evidence: .target)
+        )
+    }
+
+    func test_skipped_target_uses_conservative_generic_evidence() {
+        let assessment = AppManagementPermission.assess(
+            target: targets[0],
+            fallbackTargets: Array(targets.dropFirst())
+        ) { url in
+            url == self.targets[0] ? .skipped : .allowed
+        }
+
+        XCTAssertEqual(
+            assessment,
+            AppManagementPermission.Assessment(status: .granted, evidence: .generic)
+        )
     }
 }

--- a/CaskHubTests/Homebrew/Infrastructure/BrewProcessRunnerTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/BrewProcessRunnerTests.swift
@@ -20,7 +20,28 @@ final class BrewProcessRunnerTests: XCTestCase {
         )
 
         XCTAssertEqual(result.exitCode, 0)
+        XCTAssertFalse(result.wasTerminatedBySignal)
         XCTAssertTrue(result.output.contains("terminal progress"))
+    }
+
+    @MainActor
+    func test_system_runner_reports_signal_termination() async throws {
+        var process: Process?
+        let resultTask = Task { @MainActor in
+            try await SystemBrewProcessRunner().run(
+                executableURL: URL(fileURLWithPath: "/bin/sleep"),
+                arguments: ["30"],
+                environment: ProcessInfo.processInfo.environment,
+                onStart: { process = $0 },
+                onChunk: { _ in }
+            )
+        }
+        while process == nil { await Task.yield() }
+        process?.terminate()
+
+        let result = try await resultTask.value
+
+        XCTAssertTrue(result.wasTerminatedBySignal)
     }
 
     @MainActor

--- a/CaskHubTests/Homebrew/Infrastructure/HomebrewCommandExecutorTests.swift
+++ b/CaskHubTests/Homebrew/Infrastructure/HomebrewCommandExecutorTests.swift
@@ -67,10 +67,114 @@ final class HomebrewCommandExecutorTests: XCTestCase {
             service.operationStore.state(for: "firefox")?.cancellationRequested == true
         )
 
-        executor.finish(BrewProcessResult(exitCode: 130, output: "interrupted"))
+        executor.finish(BrewProcessResult(
+            exitCode: 2,
+            output: "interrupted",
+            wasTerminatedBySignal: true
+        ))
         await mutation.value
 
         XCTAssertNil(service.operationStore.state(for: "firefox"))
+    }
+
+    func test_failure_after_cancel_request_is_not_mistaken_for_process_cancellation() async {
+        let executor = SuspendingHomebrewCommandExecutor()
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("cancel-race-failure")
+        ) {
+            $0.commandExecutor = executor
+            $0.softwareScanner = EmptyInstalledSoftwareScanner()
+            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
+            $0.brewVersionProvider = { "test" }
+        }
+        let mutation = Task { try? await service.install(token: "firefox") }
+        while executor.requests.isEmpty { await Task.yield() }
+
+        service.cancelInstall(token: "firefox")
+        executor.finish(BrewProcessResult(
+            exitCode: 1,
+            output: "Error: rollback failed"
+        ))
+        await mutation.value
+
+        XCTAssertNotNil(service.operationStore.state(for: "firefox")?.failure)
+    }
+
+    func test_services_share_global_process_fifo() async throws {
+        let overlap = expectation(description: "Homebrew processes overlap")
+        overlap.isInverted = true
+        let runner = ControlledBrewProcessRunner(overlapExpectation: overlap)
+        func makeService(_ name: String) -> LocalHomebrewService {
+            LocalHomebrewService(defaults: makeScratchDefaults(name)) {
+                $0.fileManager = NoFilesFileManager()
+                $0.commandExecutor = SystemHomebrewCommandExecutor(processRunner: runner)
+                $0.softwareScanner = EmptyInstalledSoftwareScanner()
+                $0.askpassProvider = { token in
+                    URL(fileURLWithPath: "/private/tmp/caskhub-test-askpass-\(token)")
+                }
+                $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
+                $0.brewVersionProvider = { "test" }
+            }
+        }
+        let firstService = makeService("serialized-homebrew-first")
+        let secondService = makeService("serialized-homebrew-second")
+
+        let first = Task { try await firstService.install(token: "firefox") }
+        await runner.waitForStarts(1)
+        let second = Task { try await secondService.install(token: "gimp") }
+
+        await fulfillment(of: [overlap], timeout: 0.1)
+        runner.finishNext()
+        await runner.waitForStarts(2)
+        runner.finishNext()
+
+        try await first.value
+        try await second.value
+        XCTAssertEqual(runner.maxActiveCount, 1)
+        XCTAssertEqual(runner.requests, [
+            ["install", "--cask", "firefox"],
+            ["install", "--cask", "gimp"]
+        ])
+        XCTAssertNil(firstService.operationStore.state(for: "firefox"))
+        XCTAssertNil(secondService.operationStore.state(for: "gimp"))
+    }
+
+    func test_maintenance_probe_waits_for_running_mutation() async throws {
+        let processOverlap = expectation(description: "Homebrew processes overlap")
+        processOverlap.isInverted = true
+        let maintenanceFinished = expectation(description: "maintenance finished early")
+        maintenanceFinished.isInverted = true
+        let runner = ControlledBrewProcessRunner(overlapExpectation: processOverlap)
+        let executor = SystemHomebrewCommandExecutor(processRunner: runner)
+        let mutation = Task {
+            try await executor.execute(
+                HomebrewCommandRequest(
+                    token: "firefox",
+                    executableURL: URL(fileURLWithPath: "/test/bin/brew"),
+                    arguments: ["install", "--cask", "firefox"],
+                    environment: [:]
+                ),
+                onStart: {},
+                onChunk: { _ in }
+            )
+        }
+        await runner.waitForStarts(1)
+        let maintenance = Task {
+            let result = await SystemMaintenanceProbe().run(
+                URL(fileURLWithPath: "/usr/bin/true"),
+                arguments: [],
+                environment: nil
+            )
+            maintenanceFinished.fulfill()
+            return result
+        }
+
+        await fulfillment(of: [processOverlap, maintenanceFinished], timeout: 0.1)
+        runner.finishNext()
+
+        _ = try await mutation.value
+        let maintenanceResult = await maintenance.value
+        XCTAssertEqual(maintenanceResult?.exitCode, 0)
     }
 
     func test_homebrew_update_blocks_other_tokens_until_both_passes_finish() async {
@@ -114,6 +218,56 @@ final class HomebrewCommandExecutorTests: XCTestCase {
 
         executor.finish(BrewProcessResult(exitCode: 0, output: "installed"))
         await install.value
+    }
+}
+
+@MainActor
+private final class ControlledBrewProcessRunner: BrewProcessRunning {
+    private let overlapExpectation: XCTestExpectation
+    private var activeCount = 0
+    private var continuations: [CheckedContinuation<BrewProcessResult, Never>] = []
+    private var startWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    private(set) var maxActiveCount = 0
+    private(set) var requests: [[String]] = []
+
+    init(overlapExpectation: XCTestExpectation) {
+        self.overlapExpectation = overlapExpectation
+    }
+
+    func run(
+        executableURL _: URL,
+        arguments: [String],
+        environment _: [String: String],
+        onStart: @escaping (Process) -> Void,
+        onChunk _: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> BrewProcessResult {
+        requests.append(arguments)
+        activeCount += 1
+        maxActiveCount = max(maxActiveCount, activeCount)
+        if activeCount > 1 { overlapExpectation.fulfill() }
+        resumeStartWaiters()
+        onStart(Process())
+        return await withCheckedContinuation { continuations.append($0) }
+    }
+
+    func waitForStarts(_ count: Int) async {
+        guard requests.count < count else { return }
+        await withCheckedContinuation { startWaiters.append((count, $0)) }
+    }
+
+    func finishNext() {
+        precondition(!continuations.isEmpty)
+        activeCount -= 1
+        continuations.removeFirst().resume(
+            returning: BrewProcessResult(exitCode: 0, output: "")
+        )
+    }
+
+    private func resumeStartWaiters() {
+        let ready = startWaiters.filter { $0.0 <= requests.count }
+        startWaiters.removeAll { $0.0 <= requests.count }
+        ready.forEach { $0.1.resume() }
     }
 }
 

--- a/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
+++ b/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
@@ -6,6 +6,8 @@
 //
 
 @testable import CaskHub
+import AppKit
+import Observation
 import XCTest
 
 final class CaskHubTests: XCTestCase {
@@ -287,7 +289,9 @@ final class CaskHubTests: XCTestCase {
     @MainActor
     func test_adopt_preflight_waits_for_app_management_permission() async throws {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("preflight"))
-        service.permissionProbe = { .denied }
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .denied, evidence: .target)
+        }
         let adoptCask = makeCask(
             "chatgpt-classic",
             appNames: ["ChatGPT Classic.app"]
@@ -324,12 +328,48 @@ final class CaskHubTests: XCTestCase {
         )
 
         // Returning to the app while still denied keeps the requests pending.
-        service.resumePendingAdoptions()
-        try await Task.sleep(for: .milliseconds(100))
+        await service.resumePendingAdoptions()
         XCTAssertEqual(service.operationStore.pendingPermissions.count, 2)
 
         service.clearError(for: "canva")
         XCTAssertNil(service.operationStore.pendingPermissions["canva"])
+    }
+
+    @MainActor
+    func test_activation_notification_refreshes_and_resumes_pending_adoption() async {
+        let scanner = MutableInstalledSoftwareScanner()
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("activation-adoption")
+        ) {
+            $0.softwareScanner = scanner
+            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
+            $0.brewVersionProvider = { "test" }
+        }
+        let cask = makeCask("activation-adoption", appNames: ["Activation.app"])
+        seedExternalInstallation(of: cask, version: cask.displayVersion, in: service)
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .denied, evidence: .target)
+        }
+        await service.requestAdoption(cask)
+        XCTAssertNotNil(service.operationStore.pendingPermissions[cask.token])
+
+        let resumed = expectation(description: "pending adoption resumed")
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .granted, evidence: .target)
+        }
+        withObservationTracking {
+            _ = service.operationStore.state(for: cask.token)
+        } onChange: {
+            resumed.fulfill()
+        }
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil
+        )
+
+        await fulfillment(of: [resumed], timeout: 1)
+        XCTAssertNotNil(service.operationStore.state(for: cask.token)?.adoptionRequest)
+        XCTAssertTrue(service.operationStore.pendingPermissions.isEmpty)
     }
 
     func test_app_management_denial_maps_to_permission_guidance() {
@@ -352,7 +392,7 @@ final class CaskHubTests: XCTestCase {
         XCTAssertTrue(
             LocalHomebrewError.brewCommandFailed(
                 args: ["install", "--cask", "tool"], exitCode: 1, stderr: unrelated
-            ).shouldReport
+            ).isExplicitUserDecision == false
         )
         XCTAssertEqual(classify([], "curl: (6) Could not resolve host"), .networkFailure)
     }

--- a/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
@@ -165,7 +165,9 @@ final class AdoptionViewRenderTests: XCTestCase {
     @MainActor
     func test_cask_action_alerts_render_with_pending_permission_and_error() async {
         let service = LocalHomebrewService(defaults: makeScratchDefaults("render-alerts"))
-        service.permissionProbe = { .denied }
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .denied, evidence: .target)
+        }
         let cask = makeCask("chrome", appNames: ["Chrome.app"])
         let plan = CaskAdoptionPlan(
             artifact: .applicationBundle,
@@ -177,7 +179,11 @@ final class AdoptionViewRenderTests: XCTestCase {
             blockingInstalledCask: nil
         )
         service.operationStore.send(
-            .awaitPermission(CaskAdoptionRequest(cask: cask, plan: plan)),
+            .awaitPermission(CaskAdoptionRequest(
+                cask: cask,
+                intent: .planned,
+                plan: plan
+            )),
             for: cask.token
         )
 
@@ -311,7 +317,9 @@ final class AdoptionViewRenderTests: XCTestCase {
             $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
             $0.brewVersionProvider = { "test" }
         }
-        service.permissionProbe = { .denied }
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .denied, evidence: .target)
+        }
         let failure = CaskOperationFailure(
             kind: .brewCommand,
             message: "short",

--- a/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/AdoptionTests.swift
@@ -108,7 +108,7 @@ final class AdoptionSurfaceTests: XCTestCase {
         XCTAssertTrue(generic.errorDescription?.contains("boom") == true)
     }
 
-    func test_cask_conflict_has_actionable_description_and_is_not_reportable() {
+    func test_cask_conflict_has_actionable_description() {
         let stderr = "Error: zen-privacy: Cask 'zen-privacy' conflicts with 'zen'."
         let error = LocalHomebrewError.brewCommandFailed(
             args: ["install", "--cask", "zen-privacy"],
@@ -124,7 +124,7 @@ final class AdoptionSurfaceTests: XCTestCase {
                 installedCask: "zen"
             )
         )
-        XCTAssertFalse(error.shouldReport)
+        XCTAssertFalse(error.isExplicitUserDecision)
     }
 
     @MainActor
@@ -229,11 +229,13 @@ final class AdoptionSurfaceTests: XCTestCase {
     func test_same_version_package_adoption_confirms_then_replaces_cleanly() async throws {
         let runner = StubBrewProcessRunner()
         let service = makeMutationService(runner: runner)
-        service.permissionProbe = { .granted }
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .granted, evidence: .target)
+        }
         let cask = makeCask(
             "zoom",
             packageIdentifiers: ["us.zoom.pkg.videomeeting"],
-            packageAppNames: ["zoom.us.app"]
+            packageAppNames: ["CaskHubTestZoom.app"]
         )
         seedExternalInstallation(of: cask, version: "1.0", in: service)
 
@@ -259,7 +261,9 @@ final class AdoptionSurfaceTests: XCTestCase {
         for status in [AppManagementPermission.Status.denied, .unknown] {
             let runner = StubBrewProcessRunner()
             let service = makeMutationService(runner: runner)
-            service.permissionProbe = { status }
+            service.permissionProbe = { _ in
+                AppManagementPermission.Assessment(status: status, evidence: .target)
+            }
 
             let application = makeCask("external-app", appNames: ["External.app"])
             let package = makeCask(
@@ -284,7 +288,9 @@ final class AdoptionSurfaceTests: XCTestCase {
     func test_adoption_resumes_at_confirmation_after_permission_is_granted() async {
         let runner = StubBrewProcessRunner()
         let service = makeMutationService(runner: runner)
-        service.permissionProbe = { .denied }
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .denied, evidence: .target)
+        }
         let cask = makeCask("zoom", appNames: ["zoom.us.app"])
         seedExternalInstallation(of: cask, version: "1.0", in: service)
 
@@ -292,9 +298,10 @@ final class AdoptionSurfaceTests: XCTestCase {
         let pending = service.operationStore.pendingPermissions[cask.token]
         XCTAssertEqual(pending?.cask, cask)
 
-        service.permissionProbe = { .granted }
-        service.resumePendingAdoptions()
-        try? await Task.sleep(for: .milliseconds(100))
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .granted, evidence: .target)
+        }
+        await service.resumePendingAdoptions()
 
         XCTAssertEqual(
             service.operationStore.state(for: cask.token)?.adoptionRequest,
@@ -337,26 +344,29 @@ final class AdoptionSurfaceTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directory) }
         let executable = URL(fileURLWithPath: "/Applications/Cask Hub's.app/Contents/MacOS/CaskHub")
 
-        let firstScript = await AskpassScriptManager.create(
+        let first = try await AskpassScriptManager.create(
             token: "first; unsafe", directory: directory, executableURL: executable
         )
-        let secondScript = await AskpassScriptManager.create(
+        let second = try await AskpassScriptManager.create(
             token: "second", directory: directory, executableURL: executable
         )
-        let first = try XCTUnwrap(firstScript)
-        let second = try XCTUnwrap(secondScript)
 
         XCTAssertNotEqual(first, second)
         XCTAssertTrue(first.lastPathComponent.hasPrefix("askpass-"))
         let script = try String(contentsOf: first, encoding: .utf8)
         XCTAssertTrue(script.contains("'firstunsafe'"))
         XCTAssertTrue(script.contains("Cask Hub'\"'\"'s.app"))
+        XCTAssertTrue(script.contains("--askpass-cancel-marker"))
         let permissions = try FileManager.default.attributesOfItem(atPath: first.path)[.posixPermissions] as? Int
         XCTAssertEqual(permissions, 0o700)
+
+        let marker = AskpassScriptManager.cancellationMarker(for: first)
+        try Data().write(to: marker)
 
         await AskpassScriptManager.remove(at: first)
         await AskpassScriptManager.remove(at: second)
         XCTAssertFalse(FileManager.default.fileExists(atPath: first.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: second.path))
     }
 
@@ -379,8 +389,12 @@ final class AdoptionSurfaceTests: XCTestCase {
         )
         setenv("HOMEBREW_NO_AUTO_UPDATE", "1", 1)
 
-        let service = LocalHomebrewService(defaults: makeScratchDefaults("adopt-e2e"))
-        service.permissionProbe = { .granted }
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("adopt-e2e")) {
+            $0.softwareScanner = MutableInstalledSoftwareScanner()
+        }
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .granted, evidence: .target)
+        }
         let token = "caskhub-test-nonexistent-cask"
         let cask = makeCask(token, appNames: ["No Such App.app"])
         seedExternalInstallation(of: cask, version: "1.0", in: service)
@@ -433,7 +447,9 @@ final class AdoptionSurfaceTests: XCTestCase {
         ) {
             $0.applicationDirectories = [appsDir]
         }
-        service.permissionProbe = { .granted }
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .granted, evidence: .target)
+        }
         let cask = makeCask(
             "caskhub-test-nonexistent-cask", appNames: ["Fake.app"],
             binarySourcePaths: ["/Applications/Fake.app/Contents/MacOS/fake-cli"]

--- a/CaskHubTests/Homebrew/Workflows/CaskAdoptionWorkflowTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/CaskAdoptionWorkflowTests.swift
@@ -6,6 +6,7 @@
 //
 
 @testable import CaskHub
+import Synchronization
 import XCTest
 
 @MainActor
@@ -97,20 +98,20 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
             installedAt: nil,
             appBundleNames: ["OneDrive.app"]
         )
+        let scanner = MutableInstalledSoftwareScanner()
         let service = makeMutationService(
             runner: runner,
-            scanner: FixedInstalledSoftwareScanner(snapshot: InstallationSnapshot(
-                installedCasks: [cask.token: installed]
-            )),
+            scanner: scanner,
             permissionProbe: { .granted }
         )
         seedExternalInstallation(of: cask, version: "26.129.0706", in: service)
-        let stableRevision = service.catalogStateRevision
+        var sequenceRevision: Int?
         var inspectedInstallStep = false
         runner.onRequest = { request in
+            if sequenceRevision == nil { sequenceRevision = service.catalogStateRevision }
             guard request.arguments.first == "install" else { return }
             inspectedInstallStep = true
-            XCTAssertEqual(service.catalogStateRevision, stableRevision)
+            XCTAssertEqual(service.catalogStateRevision, sequenceRevision)
             XCTAssertTrue(
                 service.localState(for: cask).isAdoptable,
                 "the Adopt row must remain backed by the last stable snapshot"
@@ -119,6 +120,9 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
                 service.operationStore.state(for: cask.token)?.progress?.action,
                 .adopting
             )
+            scanner.replace(with: InstallationSnapshot(
+                installedCasks: [cask.token: installed]
+            ))
         }
 
         await service.requestAdoption(cask)
@@ -128,7 +132,7 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
         try await service.confirmAdoption(request)
 
         XCTAssertTrue(inspectedInstallStep)
-        XCTAssertGreaterThan(service.catalogStateRevision, stableRevision)
+        XCTAssertGreaterThan(service.catalogStateRevision, sequenceRevision ?? 0)
         XCTAssertTrue(service.isInstalled(token: cask.token))
         XCTAssertFalse(service.localState(for: cask).isAdoptable)
         XCTAssertNil(service.operationStore.state(for: cask.token))
@@ -181,5 +185,171 @@ final class CaskAdoptionWorkflowTests: XCTestCase {
         XCTAssertEqual(request.plan.operation, expectedOperation)
         try await service.confirmAdoption(request)
         XCTAssertEqual(runner.requests.map(\.arguments), [expectedArguments])
+    }
+}
+
+extension CaskAdoptionWorkflowTests {
+    func test_adoption_permission_probe_receives_exact_detected_target_bundle() async throws {
+        let appsDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("adoption-permission-\(UUID().uuidString)")
+        let appURL = try makeApplicationBundle(
+            in: appsDirectory, named: "Target.app", bundleIdentifier: "com.example.target"
+        )
+        defer { try? FileManager.default.removeItem(at: appsDirectory) }
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("adoption-permission-target")
+        ) {
+            $0.applicationDirectories = [appsDirectory]
+        }
+        let probedTarget = Mutex<URL?>(nil)
+        service.permissionProbe = { target in
+            probedTarget.withLock { $0 = target }
+            return AppManagementPermission.Assessment(status: .granted, evidence: .target)
+        }
+        let cask = makeCask("target", appNames: ["Target.app"])
+        seedExternalInstallation(of: cask, version: "1.0", url: appURL, in: service)
+
+        await service.requestAdoption(cask)
+
+        XCTAssertEqual(probedTarget.withLock { $0 }, appURL)
+        XCTAssertNotNil(service.operationStore.state(for: cask.token)?.adoptionRequest)
+    }
+
+    func test_package_permission_probe_prefers_scanner_owned_bundle() async {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(runner: runner)
+        let cask = makeCask(
+            "package-owner",
+            packageIdentifiers: ["com.example.package-owner"],
+            packageAppNames: ["Catalog Name.app"]
+        )
+        let owner = makeDetectedApplication(
+            "Actual Package.app",
+            id: "com.example.actual-package",
+            version: cask.displayVersion
+        )
+        updateInstallationSnapshot(of: service) {
+            $0.externalPackageInstallations[cask.token] = ExternalPackageInstallation(
+                appBundleNames: [owner.bundleName]
+            )
+            $0.externalPackageApplicationOwners[cask.token] = owner
+        }
+        let probedTarget = Mutex<URL?>(nil)
+        service.permissionProbe = { target in
+            probedTarget.withLock { $0 = target }
+            return AppManagementPermission.Assessment(status: .granted, evidence: .target)
+        }
+
+        await service.requestAdoption(cask)
+
+        XCTAssertEqual(probedTarget.withLock { $0 }, owner.url)
+    }
+
+    func test_unprobeable_target_can_continue_after_returning_from_settings() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(runner: runner)
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(status: .unknown, evidence: nil)
+        }
+        let cask = makeCask("unprobeable", appNames: ["Unprobeable.app"])
+        seedExternalInstallation(of: cask, version: cask.displayVersion, in: service)
+
+        await service.requestAdoption(cask)
+        XCTAssertNotNil(service.operationStore.pendingPermissions[cask.token])
+
+        await service.resumePendingAdoptions()
+        let request = try XCTUnwrap(
+            service.operationStore.state(for: cask.token)?.adoptionRequest
+        )
+        try await service.confirmAdoption(request)
+
+        XCTAssertEqual(runner.requests.map(\.arguments), [[
+            "install", "--cask", cask.token, "--adopt"
+        ]])
+    }
+
+    func test_confirmation_replans_from_fresh_installation_snapshot() async throws {
+        let runner = StubBrewProcessRunner()
+        let cask = makeCask(
+            "replanned-package",
+            packageIdentifiers: ["com.example.replanned"],
+            packageAppNames: ["Replanned.app"]
+        )
+        let refreshedApplication = makeDetectedApplication(
+            "Replanned.app", version: "999.0"
+        )
+        let scanner = FixedInstalledSoftwareScanner(snapshot: InstallationSnapshot(
+            applications: ApplicationInstallationSnapshot(
+                externalPackageApplicationOwners: [cask.token: refreshedApplication],
+                detectedApplications: [refreshedApplication]
+            ),
+            externalPackageInstallations: [
+                cask.token: ExternalPackageInstallation(
+                    appBundleNames: [refreshedApplication.bundleName]
+                )
+            ]
+        ))
+        let service = makeMutationService(
+            runner: runner,
+            scanner: scanner,
+            permissionProbe: { .granted }
+        )
+        seedExternalInstallation(of: cask, version: cask.displayVersion, in: service)
+        await service.requestAdoption(cask)
+        let original = try XCTUnwrap(
+            service.operationStore.state(for: cask.token)?.adoptionRequest
+        )
+
+        try await service.confirmAdoption(original)
+
+        let updated = try XCTUnwrap(
+            service.operationStore.state(for: cask.token)?.adoptionRequest
+        )
+        XCTAssertNotEqual(updated, original)
+        XCTAssertEqual(updated.plan.operation, .downgradeAndAdopt)
+        XCTAssertEqual(updated.plan.execution, .replacePackage)
+        XCTAssertTrue(runner.requests.isEmpty)
+    }
+
+    func test_confirmation_stops_when_fresh_snapshot_no_longer_has_the_app() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(
+            runner: runner,
+            scanner: FixedInstalledSoftwareScanner(snapshot: .empty),
+            permissionProbe: { .granted }
+        )
+        let cask = makeCask("removed", appNames: ["Removed.app"])
+        seedExternalInstallation(of: cask, version: cask.displayVersion, in: service)
+        await service.requestAdoption(cask)
+        let request = try XCTUnwrap(
+            service.operationStore.state(for: cask.token)?.adoptionRequest
+        )
+
+        try await service.confirmAdoption(request)
+
+        XCTAssertNil(service.operationStore.state(for: cask.token))
+        XCTAssertTrue(runner.requests.isEmpty)
+    }
+
+    func test_replacement_recovery_still_handles_external_executable() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(runner: runner, permissionProbe: { .granted })
+        let cask = makeCask("binary-only", binaryNames: ["binary-only"])
+        updateInstallationSnapshot(of: service) {
+            $0.externalBinaryPaths[cask.token] = URL(fileURLWithPath: "/usr/local/bin/binary-only")
+        }
+
+        await service.requestReplacementAdoption(cask)
+        let request = try XCTUnwrap(
+            service.operationStore.state(for: cask.token)?.adoptionRequest
+        )
+        XCTAssertEqual(request.intent, .replacement)
+        XCTAssertEqual(request.plan.execution, .replaceApplication)
+
+        try await service.confirmAdoption(request)
+
+        XCTAssertEqual(runner.requests.map(\.arguments), [[
+            "install", "--cask", cask.token, "--force"
+        ]])
     }
 }

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -157,7 +157,10 @@ func updateInstallationSnapshot(
         snapshot: service.installationSnapshot
     )
     update(&fixture)
-    service.commitInstallationSnapshot(fixture.makeSnapshot())
+    let snapshot = fixture.makeSnapshot()
+    service.commitInstallationSnapshot(snapshot)
+    (service.softwareScanner as? MutableInstalledSoftwareScanner)?
+        .replace(with: snapshot)
 }
 
 @MainActor
@@ -423,6 +426,7 @@ final class SpyCrashReporterProvider: CrashReporterProvider {
     var startedWith: [SentryConsent] = []
     var consentChanges: [SentryConsent] = []
     var capturedErrors: [Error] = []
+    var capturedErrorTags: [[String: String]] = []
     var breadcrumbs: [(message: String, data: [String: String])] = []
     var tags: [String: String] = [:]
     var spans: [SpanRecord] = []
@@ -444,8 +448,9 @@ final class SpyCrashReporterProvider: CrashReporterProvider {
         consentChanges.append(consent)
     }
 
-    func capture(_ error: Error) {
+    func capture(_ error: Error, tags: [String: String]) {
         capturedErrors.append(error)
+        capturedErrorTags.append(tags)
     }
 
     func setTag(_ key: String, value: String) {

--- a/CaskHubTests/Support/TestFactories.swift
+++ b/CaskHubTests/Support/TestFactories.swift
@@ -7,6 +7,7 @@
 
 @testable import CaskHub
 import Foundation
+import Synchronization
 import SwiftUI
 
 internal nonisolated func makeDetectedApplication(
@@ -51,25 +52,54 @@ nonisolated struct FixedInstalledSoftwareScanner: InstalledSoftwareScanning {
     }
 }
 
+nonisolated final class MutableInstalledSoftwareScanner: InstalledSoftwareScanning, Sendable {
+    private let storedSnapshot: Mutex<InstallationSnapshot>
+
+    init(snapshot: InstallationSnapshot = .empty) {
+        storedSnapshot = Mutex(snapshot)
+    }
+
+    func replace(with snapshot: InstallationSnapshot) {
+        storedSnapshot.withLock { $0 = snapshot }
+    }
+
+    func scan(_ request: InstalledSoftwareScanRequest) async -> InstallationSnapshot {
+        storedSnapshot.withLock { $0 }
+    }
+
+    func reconcileCatalog(
+        _ request: InstalledSoftwareScanRequest,
+        with current: InstallationSnapshot
+    ) async -> InstallationSnapshot {
+        storedSnapshot.withLock { $0 }
+    }
+}
+
 @MainActor
 func makeMutationService(
     runner: StubBrewProcessRunner,
     scanner: (any InstalledSoftwareScanning)? = nil,
     permissionProbe: (@Sendable () -> AppManagementPermission.Status)? = nil
 ) -> LocalHomebrewService {
+    let softwareScanner = scanner ?? MutableInstalledSoftwareScanner()
     let service = LocalHomebrewService(
         defaults: makeScratchDefaults("mutation-runner-\(UUID().uuidString)")
     ) {
         $0.fileManager = NoFilesFileManager()
         $0.processRunner = runner
-        $0.softwareScanner = scanner
+        $0.softwareScanner = softwareScanner
         $0.brewBinaryProvider = {
             URL(fileURLWithPath: "/test/bin/brew")
         }
         $0.brewVersionProvider = { "test" }
     }
     if let permissionProbe {
-        service.permissionProbe = permissionProbe
+        service.permissionProbe = { _ in
+            AppManagementPermission.Assessment(
+                status: permissionProbe(),
+                evidence: .target
+            )
+        }
     }
     return service
 }
@@ -78,6 +108,7 @@ func makeMutationService(
 func seedExternalInstallation(
     of cask: Cask,
     version: String?,
+    url: URL? = nil,
     in service: LocalHomebrewService
 ) {
     let bundleName = (cask.packageAppNameCandidates + cask.appArtifactNames).first
@@ -85,7 +116,8 @@ func seedExternalInstallation(
     let application = makeDetectedApplication(
         bundleName,
         id: "com.example.\(cask.token)",
-        version: version
+        version: version,
+        url: url
     )
     updateInstallationSnapshot(of: service) {
         $0.detectedApplications.append(application)

--- a/CaskHubTests/Telemetry/AnalyticsTests.swift
+++ b/CaskHubTests/Telemetry/AnalyticsTests.swift
@@ -62,6 +62,10 @@ final class AnalyticsTests: XCTestCase {
     private var originalMetrics: SentryMetricsApiProtocol!
     private var originalAnalyticsDefaults: UserDefaults!
     private var originalCrashDefaults: UserDefaults!
+    private var crashSpy: SpyCrashReporterProvider!
+    private var originalCrashProvider: CrashReporterProvider!
+    private var originalCaptureCounts: [String: Int]!
+    private var originalCrashTestState = false
 
     override func setUp() {
         super.setUp()
@@ -70,8 +74,15 @@ final class AnalyticsTests: XCTestCase {
         originalMetrics = Analytics.metrics
         originalAnalyticsDefaults = Analytics.defaults
         originalCrashDefaults = CrashReporter.defaults
+        originalCrashProvider = CrashReporter.provider
+        originalCaptureCounts = CrashReporter.captureCounts
+        originalCrashTestState = CrashReporter.isRunningTests
+        crashSpy = SpyCrashReporterProvider()
         Analytics.provider = spy
         Analytics.metrics = spy
+        CrashReporter.provider = crashSpy
+        CrashReporter.captureCounts = [:]
+        CrashReporter.isRunningTests = false
         Analytics.defaults = makeScratchDefaults(
             "analytics-\(ProcessInfo.processInfo.processIdentifier)"
         )
@@ -86,12 +97,13 @@ final class AnalyticsTests: XCTestCase {
         Analytics.metrics = originalMetrics
         Analytics.defaults = originalAnalyticsDefaults
         CrashReporter.defaults = originalCrashDefaults
+        CrashReporter.provider = originalCrashProvider
+        CrashReporter.captureCounts = originalCaptureCounts
+        CrashReporter.isRunningTests = originalCrashTestState
         super.tearDown()
     }
 
-    private var lastSignal: (name: String, parameters: [String: String])? {
-        spy.signals.last
-    }
+    private var lastSignal: (name: String, parameters: [String: String])? { spy.signals.last }
 
     // MARK: - Opt-out state
 
@@ -199,29 +211,6 @@ final class AnalyticsTests: XCTestCase {
         ])
     }
 
-    @MainActor
-    func test_failed_service_mutation_forwards_its_classification() async {
-        let runner = StubBrewProcessRunner()
-        runner.queuedResults = [BrewProcessResult(
-            exitCode: 1,
-            output: "Error: Cask 'gimp' definition is invalid: invalid "
-                + "'command_wrapper' stanza: Unknown key: :executable"
-        )]
-        let service = LocalHomebrewService(
-            defaults: makeScratchDefaults("classified-analytics")
-        ) {
-            $0.fileManager = NoFilesFileManager()
-            $0.processRunner = runner
-            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
-            $0.brewVersionProvider = { "test" }
-        }
-
-        try? await service.install(token: "gimp")
-
-        XCTAssertEqual(lastSignal?.name, "Cask.actionFailed")
-        XCTAssertEqual(lastSignal?.parameters["failureClass"], "homebrew-runtime-incompatible")
-    }
-
     func test_cask_action_recovered_records_repair_postcondition() {
         Analytics.caskActionRecovered(.uninstalling, token: "zed", origin: .repair)
 
@@ -233,9 +222,18 @@ final class AnalyticsTests: XCTestCase {
         ])
     }
 
-    func test_cask_action_failed_ignores_app_launches() {
-        Analytics.caskActionFailed(.opening, token: "firefox")
-        XCTAssertTrue(spy.signals.isEmpty)
+    func test_cask_action_failed_tracks_missing_app_launches() {
+        Analytics.caskActionFailed(
+            .opening,
+            token: "firefox",
+            failureKind: .appBundleNotFound
+        )
+        XCTAssertEqual(lastSignal?.parameters, [
+            "action": "open",
+            "cask": "firefox",
+            "failureClass": "app-bundle-not-found",
+            "origin": "individual"
+        ])
     }
 
     func test_cask_action_events_ignore_queued_state() {
@@ -390,5 +388,213 @@ final class AnalyticsTests: XCTestCase {
         Analytics.send("Page.opened")
 
         XCTAssertTrue(crashSpy.breadcrumbs.isEmpty)
+    }
+}
+
+extension AnalyticsTests {
+    func test_homebrew_update_failure_has_its_own_action() {
+        Analytics.caskActionFailed(
+            .updatingHomebrew,
+            token: "gimp",
+            origin: .repair,
+            failureKind: .unknown
+        )
+
+        XCTAssertEqual(lastSignal?.name, "Cask.actionFailed")
+        XCTAssertEqual(lastSignal?.parameters, [
+            "action": "updateHomebrew",
+            "cask": "gimp",
+            "failureClass": "unknown",
+            "origin": "repair"
+        ])
+    }
+
+    @MainActor
+    func test_invariant_conflict_reports_context_and_failed_span() async {
+        let crashSpy = await runFailingService(
+            output: "Error: gimp: Cask 'gimp' conflicts with 'gimp-beta'."
+        )
+
+        XCTAssertEqual(lastSignal?.name, "Cask.actionFailed")
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "cask-conflict")
+        XCTAssertEqual(crashSpy.capturedErrors.count, 1)
+        XCTAssertEqual(crashSpy.capturedErrorTags, [[
+            "brew.action": "installing",
+            "brew.cask": "gimp",
+            "brew.origin": "individual"
+        ]])
+        XCTAssertNotNil(crashSpy.spans.last?.span.finishedError)
+    }
+
+    @MainActor
+    func test_external_network_failure_is_metric_only_with_failed_span() async {
+        let crashSpy = await runFailingService(
+            output: "curl: (6) Could not resolve host: example.com"
+        )
+
+        XCTAssertEqual(lastSignal?.name, "Cask.actionFailed")
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "network-failure")
+        XCTAssertTrue(crashSpy.capturedErrors.isEmpty)
+        XCTAssertNotNil(crashSpy.spans.last?.span.finishedError)
+    }
+
+    @MainActor
+    func test_external_homebrew_update_failure_remains_metric_only() async {
+        let crashSpy = await runFailingService(
+            output: "curl: (6) Could not resolve host: example.com",
+            operation: .updatingHomebrew
+        )
+
+        XCTAssertEqual(lastSignal?.parameters["action"], "updateHomebrew")
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "network-failure")
+        XCTAssertTrue(crashSpy.capturedErrors.isEmpty)
+        XCTAssertNotNil(crashSpy.spans.last?.span.finishedError)
+    }
+
+    @MainActor
+    func test_only_proven_askpass_cancellation_is_suppressed() async {
+        let cancelled = await runFailingService(
+            output: "sudo: no password was provided",
+            markAskpassCancelled: true
+        )
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "sudo-declined")
+        XCTAssertTrue(cancelled.capturedErrors.isEmpty)
+
+        let failedHelper = await runFailingService(
+            output: "sudo: no password was provided"
+        )
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "askpass-unavailable")
+        XCTAssertEqual(failedHelper.capturedErrors.count, 1)
+    }
+
+    @MainActor
+    func test_ambiguous_password_and_disk_image_failures_are_reported() async {
+        let wrongPassword = await runFailingService(output: "sudo: 3 incorrect password attempts")
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "sudo-wrong-password")
+        XCTAssertEqual(wrongPassword.capturedErrors.count, 1)
+        let diskImage = await runFailingService(output: "hdiutil: attach canceled")
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "dmg-mount-cancelled")
+        XCTAssertEqual(diskImage.capturedErrors.count, 1)
+    }
+
+    @MainActor
+    func test_askpass_disk_full_is_metric_only() async {
+        let crashSpy = await runFailingService(
+            output: "",
+            askpassError: .fileSystem(
+                stage: .script,
+                failureKind: .storageFull
+            )
+        )
+
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "storage-full")
+        XCTAssertTrue(crashSpy.capturedErrors.isEmpty)
+        XCTAssertNotNil(crashSpy.spans.last?.span.finishedError)
+    }
+
+    @MainActor
+    func test_permission_denial_after_adoption_gate_reports_invariant_context() async {
+        let crashSpy = await runFailingService(
+            output: "CaskHub does not have App Management permissions",
+            operation: .adopting
+        )
+
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "permission-denied")
+        XCTAssertEqual(crashSpy.capturedErrorTags, [[
+            "brew.action": "adopting",
+            "brew.adoption_execution": "adopt-application",
+            "brew.adoption_relationship": "same",
+            "brew.cask": "gimp",
+            "brew.origin": "individual",
+            "brew.permission_evidence": "target"
+        ]])
+    }
+
+    @MainActor
+    func test_arm_machine_with_intel_brew_runtime_reports_architecture_invariant() async throws {
+        try XCTSkipUnless(HomebrewLocator.isAppleSilicon)
+        let crashSpy = await runFailingService(output: """
+        This cask depends on hardware architecture being one of \
+        [{type: :arm, bits: 64}], but you are running {type: :intel, bits: 64}.
+        """)
+
+        XCTAssertEqual(
+            lastSignal?.parameters["failureClass"],
+            "brew-architecture-mismatch"
+        )
+        XCTAssertEqual(crashSpy.capturedErrors.count, 1)
+    }
+
+    @MainActor
+    func test_missing_app_open_reports_the_local_state_contradiction() {
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("missing-app-telemetry")
+        ) {
+            $0.softwareScanner = EmptyInstalledSoftwareScanner()
+        }
+
+        service.open(makeCask("ghost", appNames: ["Ghost.app"]))
+
+        XCTAssertEqual(lastSignal?.parameters["failureClass"], "app-bundle-not-found")
+        XCTAssertEqual(crashSpy.capturedErrorTags, [[
+            "brew.action": "opening",
+            "brew.cask": "ghost",
+            "brew.origin": "individual"
+        ]])
+    }
+
+    @MainActor
+    private func runFailingService(
+        output: String,
+        operation: CaskAction = .installing,
+        markAskpassCancelled: Bool = false,
+        askpassError: AskpassScriptError? = nil
+    ) async -> SpyCrashReporterProvider {
+        crashSpy.capturedErrors.removeAll()
+        crashSpy.capturedErrorTags.removeAll()
+        crashSpy.spans.removeAll()
+        CrashReporter.captureCounts = [:]
+
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(exitCode: 1, output: output)]
+        let askpass = FileManager.default.temporaryDirectory
+            .appendingPathComponent("caskhub-analytics-\(UUID().uuidString)")
+        let scanner = MutableInstalledSoftwareScanner()
+        if markAskpassCancelled {
+            runner.onRequest = { _ in
+                try Data().write(to: AskpassScriptManager.cancellationMarker(
+                    for: askpass
+                ))
+            }
+        }
+        let service = LocalHomebrewService(
+            defaults: makeScratchDefaults("failure-telemetry-\(UUID().uuidString)")
+        ) {
+            $0.fileManager = NoFilesFileManager()
+            $0.processRunner = runner
+            $0.softwareScanner = scanner
+            $0.askpassProvider = { _ in
+                if let askpassError { throw askpassError }
+                return askpass
+            }
+            $0.brewBinaryProvider = { URL(fileURLWithPath: "/test/bin/brew") }
+            $0.brewVersionProvider = { "test" }
+        }
+        if operation == .updatingHomebrew {
+            try? await service.updateHomebrew(for: "gimp")
+        } else if operation == .adopting {
+            let cask = makeCask("gimp", appNames: ["Gimp.app"])
+            seedExternalInstallation(of: cask, version: cask.displayVersion, in: service)
+            service.permissionProbe = { _ in
+                AppManagementPermission.Assessment(status: .granted, evidence: .target)
+            }
+            await service.requestAdoption(cask)
+            if let request = service.operationStore.state(for: cask.token)?.adoptionRequest {
+                try? await service.confirmAdoption(request)
+            }
+        } else {
+            try? await service.install(token: "gimp")
+        }
+        return crashSpy
     }
 }

--- a/CaskHubTests/Telemetry/AnalyticsTests.swift
+++ b/CaskHubTests/Telemetry/AnalyticsTests.swift
@@ -559,7 +559,6 @@ extension AnalyticsTests {
         runner.queuedResults = [BrewProcessResult(exitCode: 1, output: output)]
         let askpass = FileManager.default.temporaryDirectory
             .appendingPathComponent("caskhub-analytics-\(UUID().uuidString)")
-        let scanner = MutableInstalledSoftwareScanner()
         if markAskpassCancelled {
             runner.onRequest = { _ in
                 try Data().write(to: AskpassScriptManager.cancellationMarker(
@@ -567,12 +566,11 @@ extension AnalyticsTests {
                 ))
             }
         }
-        let service = LocalHomebrewService(
-            defaults: makeScratchDefaults("failure-telemetry-\(UUID().uuidString)")
-        ) {
+        let defaults = makeScratchDefaults("failure-telemetry-\(UUID().uuidString)")
+        let service = LocalHomebrewService(defaults: defaults) {
             $0.fileManager = NoFilesFileManager()
             $0.processRunner = runner
-            $0.softwareScanner = scanner
+            $0.softwareScanner = MutableInstalledSoftwareScanner()
             $0.askpassProvider = { _ in
                 if let askpassError { throw askpassError }
                 return askpass

--- a/CaskHubTests/Telemetry/AppHangReportingTests.swift
+++ b/CaskHubTests/Telemetry/AppHangReportingTests.swift
@@ -78,6 +78,7 @@ extension CrashReporterTests {
         XCTAssertTrue(options.enableCrashHandler)
         XCTAssertTrue(options.enableAutoSessionTracking)
         XCTAssertTrue(options.enableAppHangTracking)
+        XCTAssertFalse(options.enableCaptureFailedRequests)
         XCTAssertEqual(options.tracesSampleRate?.doubleValue, 1)
         XCTAssertNotNil(options.beforeSend)
     }

--- a/CaskHubTests/Telemetry/CrashReporterTests.swift
+++ b/CaskHubTests/Telemetry/CrashReporterTests.swift
@@ -157,9 +157,9 @@ final class CrashReporterTests: XCTestCase {
         XCTAssertTrue(spy.consentChanges.isEmpty)
     }
 
-    func test_environmental_errors_are_never_captured() {
+    func test_capture_does_not_guess_homebrew_operation_policy() {
         CrashReporter.capture(LocalHomebrewError.brewBinaryNotFound)
-        XCTAssertTrue(spy.capturedErrors.isEmpty)
+        XCTAssertEqual(spy.capturedErrors.count, 1)
     }
 
     func test_disk_full_and_truncated_payloads_are_never_captured() {
@@ -195,20 +195,11 @@ final class CrashReporterTests: XCTestCase {
         )
     }
 
-    func test_recoverable_brew_failures_are_never_captured() {
-        let architectureFailure = """
-        This cask depends on hardware architecture being one of \
-        [{type: :arm, bits: 64}], but you are running {type: :intel, bits: 64}.
-        """
+    func test_capture_does_not_apply_homebrew_operation_policy() {
         let failures = [
-            "It seems the existing App is different from the one being installed.",
-            "Error: zed: It seems there is already an App at "
-                + "'/opt/homebrew/Caskroom/zed/1.10.3/Zed.app'.",
-            "chmod: /Applications/Example.app/Contents/MacOS/example: Operation not permitted",
-            "SHA256 mismatch",
-            "Download failed: curl: (6) Could not resolve host: example.com",
-            "Error: zen-privacy: Cask 'zen-privacy' conflicts with 'zen'.",
-            architectureFailure
+            "sudo: no password was provided",
+            "sudo: 3 incorrect password attempts",
+            "hdiutil: attach canceled"
         ]
         for stderr in failures {
             CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
@@ -217,10 +208,10 @@ final class CrashReporterTests: XCTestCase {
                 stderr: stderr
             ))
         }
-        XCTAssertTrue(spy.capturedErrors.isEmpty)
+        XCTAssertEqual(spy.capturedErrors.count, 3)
     }
 
-    func test_conflicts_with_recovery_buttons_are_no_longer_captured() {
+    func test_non_user_brew_failures_reach_the_provider_when_requested() {
         CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
             args: ["install", "--cask", "x"],
             exitCode: 1,
@@ -231,15 +222,13 @@ final class CrashReporterTests: XCTestCase {
             exitCode: 1,
             stderr: "Error: It seems there is already an App at '/Applications/X.app'."
         ))
-        XCTAssertTrue(spy.capturedErrors.isEmpty)
-
         CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
             args: ["install", "--cask", "x"],
             exitCode: 1,
             stderr: "Error: x: Download failed on Cask 'x' with message: "
                 + "curl: (22) The requested URL returned error: 404"
         ))
-        XCTAssertEqual(spy.capturedErrors.count, 1, "classes without a recovery path still report")
+        XCTAssertEqual(spy.capturedErrors.count, 3)
     }
 
     // MARK: - Fingerprinting
@@ -420,7 +409,7 @@ final class CrashReporterTests: XCTestCase {
             SentryProvider.fingerprint(for: killed),
             ["brewCommandFailed", "install", "process-killed"]
         )
-        XCTAssertTrue(killed.shouldReport, "watch volume before deciding to suppress")
+        XCTAssertFalse(killed.isExplicitUserDecision)
     }
 
     private func classify(_ diagnostic: String, exitCode: Int32) -> String {
@@ -429,24 +418,6 @@ final class CrashReporterTests: XCTestCase {
             exitCode: exitCode,
             diagnostic: diagnostic
         ).rawValue
-    }
-
-    func test_wrong_sudo_password_is_not_reported() {
-        CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
-            args: ["install", "--cask", "arq"],
-            exitCode: 1,
-            stderr: "Sorry, try again.\nsudo: 3 incorrect password attempts"
-        ))
-        XCTAssertTrue(spy.capturedErrors.isEmpty)
-    }
-
-    func test_declined_sudo_prompt_is_not_reported() {
-        CrashReporter.capture(LocalHomebrewError.brewCommandFailed(
-            args: ["uninstall", "--cask", "wetype"],
-            exitCode: 1,
-            stderr: "sudo: no password was provided\nsudo: a password is required"
-        ))
-        XCTAssertTrue(spy.capturedErrors.isEmpty)
     }
 
     func test_other_errors_keep_default_grouping() {
@@ -528,17 +499,24 @@ final class CrashReporterTests: XCTestCase {
 }
 
 extension CrashReporterTests {
-    func test_unknown_brew_diagnostics_share_one_bounded_fingerprint_and_rate_limit() {
-        let first = LocalHomebrewError.brewCommandFailed(
-            args: ["install", "--cask", "one"],
-            exitCode: 1,
-            stderr: "Error: renderer crashed before launch"
-        )
-        let second = LocalHomebrewError.brewCommandFailed(
-            args: ["install", "--cask", "two"],
-            exitCode: 1,
-            stderr: "Error: helper returned an impossible state"
-        )
+    func test_unknown_brew_diagnostics_share_one_issue_and_use_bounded_rate_buckets() throws {
+        let failures = [
+            "renderer crashed before launch",
+            "helper returned an impossible state",
+            "catalog produced an invalid artifact",
+            "installer returned an undocumented response"
+        ].map {
+            LocalHomebrewError.brewCommandFailed(
+                args: ["install", "--cask", "example"],
+                exitCode: 1,
+                stderr: "Error: \($0)"
+            )
+        }
+        let first = failures[0]
+        let firstSignature = try XCTUnwrap(first.commandFailure?.rateLimitSignature)
+        let second = try XCTUnwrap(failures.first {
+            $0.commandFailure?.rateLimitSignature != firstSignature
+        })
         XCTAssertEqual(
             SentryProvider.fingerprint(for: first),
             SentryProvider.fingerprint(for: second)
@@ -549,7 +527,7 @@ extension CrashReporterTests {
             CrashReporter.capture(second)
         }
 
-        XCTAssertEqual(spy.capturedErrors.count, 5)
-        XCTAssertEqual(CrashReporter.captureCounts.count, 1)
+        XCTAssertEqual(spy.capturedErrors.count, 10)
+        XCTAssertEqual(CrashReporter.captureCounts.count, 2)
     }
 }

--- a/CaskHubTests/Views/ContentViewTests.swift
+++ b/CaskHubTests/Views/ContentViewTests.swift
@@ -92,6 +92,8 @@ final class ContentViewTests: XCTestCase {
 
         click(at: NSPoint(x: 20, y: 20), in: window)
 
+        XCTAssertEqual(probe.resignCount, 0)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
         XCTAssertEqual(probe.resignCount, 1)
     }
 
@@ -105,17 +107,19 @@ final class ContentViewTests: XCTestCase {
         window.contentView!.addSubview(fieldEditor)
 
         click(at: NSPoint(x: 100, y: 100), in: window)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
 
         XCTAssertEqual(probe.resignCount, 0)
     }
 
     @MainActor
-    func test_click_while_unfocused_is_ignored() {
+    func test_deferred_resign_rechecks_focus() {
         let probe = FocusProbe()
         let window = makeWindow(probe: probe)
-        probe.focused = false
 
         click(at: NSPoint(x: 20, y: 20), in: window)
+        probe.focused = false
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
 
         XCTAssertEqual(probe.resignCount, 0)
     }
@@ -128,6 +132,7 @@ final class ContentViewTests: XCTestCase {
         window.contentView = NSView()
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
         click(at: NSPoint(x: 20, y: 20), in: window)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
 
         XCTAssertEqual(probe.resignCount, 0)
     }


### PR DESCRIPTION
## Summary

Homebrew failures were grouped and suppressed by exception type without enough execution context. That mixed unrelated failures into the same Sentry issue and could hide app-owned failures behind rules intended for user or environment state.

This PR:

- classifies Homebrew failures by typed evidence and applies reporting policy at the mutation boundary;
- keeps proven user/external states metric-only while capturing app-owned, invariant, and ambiguous failures;
- sends bounded, privacy-safe Sentry fingerprints and tags without uploading free-form Homebrew diagnostics;
- distinguishes marker-proven Askpass cancellation from helper/setup failures and requires signal-proven process cancellation;
- serializes mutation and maintenance commands through one process-wide Homebrew FIFO;
- refreshes and replans adoption from a complete installation snapshot before confirmation;
- records target-specific App Management permission evidence and keeps adoption state published until completion.

The implementation preserves the cleanup from PR #192: no removed mutation wrapper, facade plumbing, or duplicate test factory was reintroduced.

Follow-up to #174.

## Verification

- `swiftlint lint --strict --no-cache --quiet`
- Full macOS `xcodebuild test` suite
- Signed Debug build and strict code-signature verification
- App launch smoke check
- Independent full-diff review against `develop`

## Checklist

- [x] Base branch is `develop` (not `master`)
- [x] Title uses a conventional prefix + Sentence-case subject (`fix: Handle empty search results`)
- [x] Tests added or updated (Codecov patch target: 80%)
- [x] SwiftLint build phase passes locally
- [x] No changes to `CaskHub/Resources/*.json` or `CHANGELOG.md`
- [x] Issue linked for non-trivial changes (see [CONTRIBUTING.md](https://github.com/alielsokary/CaskHub/blob/develop/CONTRIBUTING.md))
