### PR TITLE
docs: Update Website Badges

### DIFF
--- a/docs/assets/producthunt-badge.svg
+++ b/docs/assets/producthunt-badge.svg
@@ -5,20 +5,12 @@
       <g transform="translate(130.000000, 73.000000)">
         <rect stroke="#FF6154" stroke-width="1" fill="#FFFFFF" x="0.5" y="0.5" width="249" height="53" rx="10"></rect>
         <text font-family="Helvetica-Bold, Helvetica" font-size="9" font-weight="bold" fill="#FF6154">
-          <tspan x="53" y="20">FIND US ON</tspan>
+          <tspan x="53" y="20">FOLLOW US ON</tspan>
         </text>
-        <text font-family="Helvetica-Bold, Helvetica" font-size="21" font-weight="bold" fill="#FF6154">
+        <text font-family="Helvetica-Bold, Helvetica" font-size="16" font-weight="bold" fill="#FF6154">
           <tspan x="52" y="40">Product Hunt</tspan>
         </text>
-            <g transform="translate(201.000000, 13.000000)" fill="#FF6154">
-      <g>
-        <polygon points="26.0024997 10 15 10 20.5012498 0"></polygon>
-        <text font-family="Helvetica-Bold, Helvetica" font-size="13" font-weight="bold" line-spacing="20">
-          <tspan x="15.7" y="27">3</tspan>
-        </text>
-      </g>
-    </g>
-
+        false
         <g transform="translate(11.000000, 12.000000)"><path d="M31,15.5 C31,24.0603917 24.0603917,31 15.5,31 C6.93960833,31 0,24.0603917 0,15.5 C0,6.93960833 6.93960833,0 15.5,0 C24.0603917,0 31,6.93960833 31,15.5" fill="#FF6154"></path><path d="M17.4329412,15.9558824 L17.4329412,15.9560115 L13.0929412,15.9560115 L13.0929412,11.3060115 L17.4329412,11.3060115 L17.4329412,11.3058824 C18.7018806,11.3058824 19.7305882,12.3468365 19.7305882,13.6308824 C19.7305882,14.9149282 18.7018806,15.9558824 17.4329412,15.9558824 M17.4329412,8.20588235 L17.4329412,8.20601152 L10.0294118,8.20588235 L10.0294118,23.7058824 L13.0929412,23.7058824 L13.0929412,19.0560115 L17.4329412,19.0560115 L17.4329412,19.0558824 C20.3938424,19.0558824 22.7941176,16.6270324 22.7941176,13.6308824 C22.7941176,10.6347324 20.3938424,8.20588235 17.4329412,8.20588235" fill="#FFFFFF"></path></g>
       </g>
     </g>

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,6 +152,7 @@
   }
   .btn-ghost { border: 1px solid var(--line); color: var(--cream); background: rgba(244, 234, 213, .04); }
   .btn-ghost:hover { background: rgba(244, 234, 213, .09); color: var(--cream); transform: translateY(-2px); }
+  .btn .count { display: inline-flex; align-items: center; gap: 5px; margin-left: 2px; padding: 3px 10px; border-radius: 999px; background: rgba(244, 234, 213, .1); font-size: .88rem; color: var(--gold); }
   .hero .meta { margin-top: 22px; font-size: .9rem; color: var(--text-dim); font-weight: 600; }
   .hero .meta span { margin: 0 6px; }
   .hero .badges { margin-top: 18px; align-items: center; }
@@ -375,13 +376,17 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0 5-5m-5 5-5-5M4 21h16"/></svg>
         Download for macOS
       </a>
-      <a class="btn btn-ghost" href="https://github.com/alielsokary/CaskHub">View source</a>
+      <a class="btn btn-ghost" id="gh-star" href="https://github.com/alielsokary/CaskHub" aria-label="Star CaskHub on GitHub">
+        <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+        Star on GitHub
+        <span class="count"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span id="gh-stars">1.1k</span></span>
+      </a>
     </div>
     <p class="meta rise d6">100% free &amp; open source <span>·</span> MIT licensed <span>·</span> macOS 15.6+</p>
-    <!-- Product Hunt badge is fetched live (upvote count); the bundled SVG is only a fallback if the request fails -->
+    <!-- Product Hunt badge is fetched live; the bundled SVG is a fallback for blocked requests (Fanboy annoyance list blocks api.producthunt.com) -->
     <div class="cta-row badges rise d7">
       <a href="https://trendshift.io/repositories/87516?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-87516" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/87516" alt="alielsokary%2FCaskHub | Trendshift" width="250" height="55"/></a>
-      <a href="https://www.producthunt.com/products/caskhub?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-caskhub" target="_blank" rel="noopener noreferrer"><img alt="CaskHub - The Mac app store Homebrew never had | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1233154&amp;theme=light&amp;t=1788444308443" onerror="this.onerror=null;this.src='assets/producthunt-badge.svg'"></a>
+      <a href="https://www.producthunt.com/products/caskhub?utm_source=badge-follow&amp;utm_medium=badge&amp;utm_campaign=badge-caskhub" target="_blank" rel="noopener noreferrer"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1302237&amp;theme=light" onerror="this.onerror=null;this.src='assets/producthunt-badge.svg'" alt="CaskHub - The Mac app store Homebrew never had | Product Hunt" width="250" height="54"></a>
     </div>
     <video class="app-shot rise d7" autoplay muted loop playsinline poster="assets/app-screenshot.webp" width="2064" height="1272" aria-label="CaskHub's Browse tab scrolling through curated shelves, Most Popular and Recently Added casks, and categories">
       <source src="assets/app-demo.mp4" type="video/mp4">
@@ -549,6 +554,14 @@
     demo.removeAttribute("autoplay");
     demo.pause();
   }
+  fetch("https://api.github.com/repos/alielsokary/CaskHub")
+    .then(r => r.ok ? r.json() : Promise.reject(r.status))
+    .then(({ stargazers_count: n }) => {
+      document.getElementById("gh-stars").textContent =
+        new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(n).toLowerCase();
+      document.getElementById("gh-star").setAttribute("aria-label", `Star CaskHub on GitHub, ${n.toLocaleString("en")} stars`);
+    })
+    .catch(() => {});
   const copyBtn = document.getElementById("copy");
   copyBtn.addEventListener("click", async () => {
     await navigator.clipboard.writeText(document.getElementById("brew-cmd").textContent);

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,7 +152,8 @@
   }
   .btn-ghost { border: 1px solid var(--line); color: var(--cream); background: rgba(244, 234, 213, .04); }
   .btn-ghost:hover { background: rgba(244, 234, 213, .09); color: var(--cream); transform: translateY(-2px); }
-  .btn .count { display: inline-flex; align-items: center; gap: 5px; margin-left: 2px; padding: 3px 10px; border-radius: 999px; background: rgba(244, 234, 213, .1); font-size: .88rem; color: var(--gold); }
+  #gh-star { font-family: var(--body); font-weight: 600; font-size: .95rem; color: var(--text); gap: 8px; padding-inline: 20px; }
+  #gh-star:hover { color: var(--cream); }
   .hero .meta { margin-top: 22px; font-size: .9rem; color: var(--text-dim); font-weight: 600; }
   .hero .meta span { margin: 0 6px; }
   .hero .badges { margin-top: 18px; align-items: center; }
@@ -376,10 +377,10 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0 5-5m-5 5-5-5M4 21h16"/></svg>
         Download for macOS
       </a>
-      <a class="btn btn-ghost" id="gh-star" href="https://github.com/alielsokary/CaskHub" aria-label="Star CaskHub on GitHub">
-        <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
-        Star on GitHub
-        <span class="count"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span id="gh-stars">1.1k</span></span>
+      <a class="btn btn-ghost" id="gh-star" href="https://github.com/alielsokary/CaskHub" aria-label="CaskHub on GitHub">
+        <svg width="17" height="17" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+        GitHub
+        <span id="gh-stars">1.1k+</span>
       </a>
     </div>
     <p class="meta rise d6">100% free &amp; open source <span>·</span> MIT licensed <span>·</span> macOS 15.6+</p>
@@ -558,8 +559,8 @@
     .then(r => r.ok ? r.json() : Promise.reject(r.status))
     .then(({ stargazers_count: n }) => {
       document.getElementById("gh-stars").textContent =
-        new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(n).toLowerCase();
-      document.getElementById("gh-star").setAttribute("aria-label", `Star CaskHub on GitHub, ${n.toLocaleString("en")} stars`);
+        new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(n).toLowerCase() + "+";
+      document.getElementById("gh-star").setAttribute("aria-label", `CaskHub on GitHub, ${n.toLocaleString("en")} stars`);
     })
     .catch(() => {});
   const copyBtn = document.getElementById("copy");


### PR DESCRIPTION
## Summary
- Hero "View source" is now "Star on GitHub": GitHub mark, star pill with the live stargazer count fetched from the public GitHub API (compact format, e.g. 1.1k). Baked value stays if the request fails.
- Product Hunt badge switched to the follow badge. The bundled fallback SVG is now the follow badge too, which carries no count, so blocked visitors (Fanboy's Annoyance List blocks `api.producthunt.com/widgets`) no longer see a stale number.

Docs-only, branched from `master`; the freshness guard skips it and no release is involved.