### PR TITLE
feat: Add optional app data cleanup on uninstall

### DIFF
--- a/CaskHub/Resources/Localizable.xcstrings
+++ b/CaskHub/Resources/Localizable.xcstrings
@@ -185,6 +185,102 @@
         }
       }
     },
+    "alert.uninstall.zap" : {
+      "comment" : "Uninstall confirmation when app data cleanup is enabled",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This also removes preferences, caches, and support files listed by the cask, including any shared files. This will run:"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Також буде видалено налаштування, кеші та допоміжні файли, зазначені в Cask, зокрема спільні файли. Буде виконано:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这也会移除 Cask 中列出的偏好设置、缓存和支持文件，包括共享文件。将执行："
+          }
+        }
+      }
+    },
+    "settings.uninstall.description" : {
+      "comment" : "Settings footnote explaining Homebrew zap cleanup",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uses Homebrew’s --zap to remove preferences, caches, and support files listed by the cask."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Використовує параметр --zap у Homebrew для видалення налаштувань, кешів і допоміжних файлів, зазначених у Cask."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 Homebrew 的 --zap 移除 Cask 中列出的偏好设置、缓存和支持文件。"
+          }
+        }
+      }
+    },
+    "settings.uninstall.removeAppData" : {
+      "comment" : "Toggle for removing app data when uninstalling a cask",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove app data on uninstall"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видаляти дані програми під час її видалення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "卸载时移除应用数据"
+          }
+        }
+      }
+    },
+    "settings.uninstall.title" : {
+      "comment" : "General settings section for app uninstallation",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uninstall"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "卸载"
+          }
+        }
+      }
+    },
     "© 2026 Ali Elsokary. All rights reserved." : {
       "shouldTranslate" : false
     },

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Workflows.swift
@@ -42,14 +42,20 @@ extension LocalHomebrewService {
     }
 
     func uninstall(token: String) async throws {
-        // Brew rejects plain uninstall for caskfile-less zombies; --force works.
-        let force = installedCasks[token]?.isZombie == true
         try await runMutation(
             .uninstalling,
             token: token,
-            args: ["uninstall", "--cask", token] + (force ? ["--force"] : []),
+            args: uninstallArguments(token: token),
             origin: .individual
         )
+    }
+
+    func uninstallArguments(token: String) -> [String] {
+        // Brew rejects plain uninstall for caskfile-less zombies; --force works.
+        let force = installedCasks[token]?.isZombie == true
+        return ["uninstall", "--cask", token]
+            + (force ? ["--force"] : [])
+            + (zapOnUninstall ? ["--zap"] : [])
     }
 
     /// Clears a zombie Caskroom entry — the app is already gone, `--force`

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService.swift
@@ -66,6 +66,8 @@ final class LocalHomebrewService {
         didSet { catalogStateRevision &+= 1 }
     }
 
+    private(set) var zapOnUninstall: Bool
+
     /// Tokens the user excluded from Adopt Apps, mapped to when they ignored them.
     private(set) var adoptIgnoredDates: [String: Date] {
         didSet { catalogStateRevision &+= 1 }
@@ -75,6 +77,7 @@ final class LocalHomebrewService {
     private let defaults: UserDefaults
     let applicationDirectories: [URL]
 
+    private static let zapOnUninstallKey = "zapOnUninstall"
     private static let greedyKey = "greedyUpdates"
     private static let adoptIgnoredKey = "adoptIgnoredDates"
 
@@ -106,6 +109,7 @@ final class LocalHomebrewService {
             ?? HomebrewInstallationScanner()
         brewBinaryProvider = dependencies.brewBinaryProvider
         brewVersionProvider = dependencies.brewVersionProvider
+        zapOnUninstall = defaults.bool(forKey: Self.zapOnUninstallKey)
         greedyUpdates = defaults.bool(forKey: Self.greedyKey)
         adoptIgnoredDates = defaults.dictionary(forKey: Self.adoptIgnoredKey) as? [String: Date] ?? [:]
         customBrewPrefix = defaults.string(forKey: HomebrewLocator.customPrefixKey)
@@ -134,6 +138,11 @@ final class LocalHomebrewService {
         if let activationObserver {
             NotificationCenter.default.removeObserver(activationObserver)
         }
+    }
+
+    func setZapOnUninstall(_ enabled: Bool) {
+        zapOnUninstall = enabled
+        defaults.set(enabled, forKey: Self.zapOnUninstallKey)
     }
 
     func setGreedyUpdates(_ enabled: Bool) {

--- a/CaskHub/Views/Settings/SettingsView.swift
+++ b/CaskHub/Views/Settings/SettingsView.swift
@@ -121,6 +121,7 @@ struct AboutSettingsView: View {
 }
 
 struct GeneralSettingsView: View {
+    @Environment(LocalHomebrewService.self) private var localHomebrew
     @State private var settingsModel = GeneralSettingsModel()
     @AppStorage(SidebarView.showAdoptKey) private var showAdoptApps = true
 
@@ -140,6 +141,19 @@ struct GeneralSettingsView: View {
                 Text("Adopt Apps lists installed apps that Homebrew can start managing for you.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
+            }
+            Section {
+                Toggle(isOn: Binding(
+                    get: { localHomebrew.zapOnUninstall },
+                    set: { localHomebrew.setZapOnUninstall($0) }
+                )) {
+                    Text(.settingsUninstallRemoveAppData)
+                }
+                Text(.settingsUninstallDescription)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text(.settingsUninstallTitle)
             }
             Section("Permissions") {
                 LabeledContent("App Management") {

--- a/CaskHub/Views/Shared/CaskActionAlerts.swift
+++ b/CaskHub/Views/Shared/CaskActionAlerts.swift
@@ -150,7 +150,7 @@ private extension View {
                 isPresented.wrappedValue = false
                 return
             }
-            let alert = CaskActionAlertFactory.uninstallAlert(for: cask)
+            let alert = CaskActionAlertFactory.uninstallAlert(for: cask, service: service)
             alert.beginSheetModal(for: window) { response in
                 if response == .alertFirstButtonReturn {
                     service.send(.uninstall(token: cask.token))
@@ -214,12 +214,14 @@ private extension View {
 
 @MainActor
 enum CaskActionAlertFactory {
-    static func uninstallAlert(for cask: Cask) -> NSAlert {
+    static func uninstallAlert(for cask: Cask, service: LocalHomebrewService) -> NSAlert {
         let alert = NSAlert()
         alert.messageText = "Uninstall \(cask.displayName)?"
-        alert.informativeText = "This will run:"
+        alert.informativeText = service.zapOnUninstall
+            ? String(localized: .alertUninstallZap)
+            : "This will run:"
         let command = NSHostingView(
-            rootView: CommandBlock(command: "brew uninstall --cask \(cask.token)")
+            rootView: CommandBlock(command: (["brew"] + service.uninstallArguments(token: cask.token)).joined(separator: " "))
         )
         command.setFrameSize(command.fittingSize)
         alert.accessoryView = command

--- a/CaskHubTests/Homebrew/Coordination/MutationRecoveryTests.swift
+++ b/CaskHubTests/Homebrew/Coordination/MutationRecoveryTests.swift
@@ -463,3 +463,64 @@ final class MutationRecoveryTests: XCTestCase {
         }
     }
 }
+
+extension MutationRecoveryTests {
+    func test_uninstall_zap_preference_persists_and_controls_commands() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeService(runner: runner, scanner: FixedInstalledSoftwareScanner(snapshot: .empty))
+        XCTAssertFalse(service.zapOnUninstall)
+        try await service.uninstall(token: "zed")
+
+        service.setZapOnUninstall(true)
+        let restored = makeService(runner: runner, scanner: FixedInstalledSoftwareScanner(snapshot: .empty))
+        XCTAssertTrue(restored.zapOnUninstall)
+        try await restored.uninstall(token: "zed")
+
+        updateInstalledCask(LocalCaskInstallation(
+            token: "zed", installedVersion: "1.0", installedAt: nil,
+            appBundleNames: ["Zed.app"], isZombie: true
+        ), in: restored)
+        try await restored.uninstall(token: "zed")
+
+        restored.setZapOnUninstall(false)
+        let disabled = makeService(runner: runner, scanner: FixedInstalledSoftwareScanner(snapshot: .empty))
+        XCTAssertFalse(disabled.zapOnUninstall)
+        try await disabled.uninstall(token: "zed")
+
+        XCTAssertEqual(runner.requests.map(\.arguments), [
+            ["uninstall", "--cask", "zed"],
+            ["uninstall", "--cask", "zed", "--zap"],
+            ["uninstall", "--cask", "zed", "--force", "--zap"],
+            ["uninstall", "--cask", "zed"]
+        ])
+    }
+
+    func test_repair_and_replacement_preserve_data_when_zap_is_enabled() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeService(runner: runner, scanner: FixedInstalledSoftwareScanner(snapshot: .empty))
+        service.setZapOnUninstall(true)
+
+        try await service.repair(token: "zed")
+        try await service.repairReinstalling(token: "zed")
+        try await service.replacePackageForAdoption(token: "zed")
+
+        let uninstalls = runner.requests.filter { $0.arguments.first == "uninstall" }
+        XCTAssertEqual(uninstalls.count, 3)
+        XCTAssertTrue(uninstalls.allSatisfy { $0.arguments == ["uninstall", "--cask", "zed", "--force"] })
+    }
+
+    func test_zap_cleanup_failure_is_reported_even_after_app_removal() async {
+        let runner = StubBrewProcessRunner()
+        runner.queuedResults = [BrewProcessResult(exitCode: 1, output: "Error: zap cleanup failed")]
+        let service = makeService(runner: runner, scanner: FixedInstalledSoftwareScanner(snapshot: .empty))
+        service.setZapOnUninstall(true)
+
+        do {
+            try await service.uninstall(token: "zed")
+            XCTFail("cleanup failure must not be hidden when the app is already removed")
+        } catch {
+            XCTAssertNotNil(service.actionAlert(for: "zed"))
+            XCTAssertEqual(runner.requests.first?.arguments, ["uninstall", "--cask", "zed", "--zap"])
+        }
+    }
+}

--- a/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
+++ b/CaskHubTests/Homebrew/Presentation/CaskActionPresentationTests.swift
@@ -213,13 +213,19 @@ final class AdoptionViewRenderTests: XCTestCase {
 
     @MainActor
     func test_uninstall_alert_shows_copyable_command_with_destructive_button() {
-        let alert = CaskActionAlertFactory.uninstallAlert(for: makeCask("iina", name: "IINA"))
+        let service = LocalHomebrewService(defaults: makeScratchDefaults("uninstall-alert"))
+        let alert = CaskActionAlertFactory.uninstallAlert(for: makeCask("iina", name: "IINA"), service: service)
 
         XCTAssertEqual(alert.messageText, "Uninstall IINA?")
         XCTAssertEqual(alert.informativeText, "This will run:")
         XCTAssertNotNil(alert.accessoryView)
         XCTAssertEqual(alert.buttons.map(\.title), ["Uninstall", "Cancel"])
         XCTAssertTrue(alert.buttons[0].hasDestructiveAction)
+
+        service.setZapOnUninstall(true)
+        let zapAlert = CaskActionAlertFactory.uninstallAlert(for: makeCask("iina"), service: service)
+        XCTAssertTrue(zapAlert.informativeText.contains("preferences, caches, and support files"))
+        XCTAssertNotNil(zapAlert.accessoryView)
     }
 
     @MainActor

--- a/CaskHubTests/Views/SettingsViewTests.swift
+++ b/CaskHubTests/Views/SettingsViewTests.swift
@@ -209,7 +209,7 @@ final class SettingsViewTests: XCTestCase {
     func test_settings_tabs_render() {
         render(AppearanceSettingsView(), width: 460, height: 480)
         render(PrivacySettingsView(), width: 460, height: 480)
-        render(GeneralSettingsView(), width: 460, height: 480)
+        render(GeneralSettingsView().environment(LocalHomebrewService()), width: 460, height: 480)
         render(
             HomebrewSettingsView()
                 .environment(LocalHomebrewService()),


### PR DESCRIPTION
## Summary

Adds an opt-in **Remove app data on uninstall** setting in General, above Permissions. When enabled, uninstall runs Homebrew with `--zap` to remove preferences, caches, and support files listed by the cask. The preference persists across launches and defaults to off.

The uninstall confirmation displays the actual command and explains data removal. Repair and replacement workflows continue preserving app data. New settings and confirmation strings use generated symbols with English, Ukrainian, and Simplified Chinese translations.

## Validation

- Full suite: 471 tests passed for the zap implementation.
- Affected settings and alert tests passed again after moving the section and adding translations.
- Strict SwiftLint, signed Debug build, signature verification, and app-launch smoke check passed.
- Regression coverage includes preference persistence, regular and forced uninstall arguments, repair/replacement preservation, and cleanup failure reporting.

## Checklist

- [x] Base branch is `develop` (not `master`)
- [x] Title uses a conventional prefix + Sentence-case subject
- [x] Tests added or updated
- [x] SwiftLint build phase passes locally
- [x] No changes to `CaskHub/Resources/*.json` or `CHANGELOG.md`