### PR TITLE
fix: Match external apps by verified bundle identity

### DIFF
--- a/CaskHub/Models/Cask.swift
+++ b/CaskHub/Models/Cask.swift
@@ -180,6 +180,8 @@ nonisolated struct Cask: Decodable, Identifiable, Hashable, Sendable {
     let autoUpdates: Bool?
     let conflictsWith: CaskConflicts?
     var artifacts: [ArtifactStanza]?
+    /// Verified identities supplied by CaskFlow, scoped to this cask's app artifacts.
+    var catalogBundleIdentifiers: [String]?
 
     var id: String {
         token
@@ -206,11 +208,9 @@ nonisolated struct Cask: Decodable, Identifiable, Hashable, Sendable {
         artifacts?.flatMap(\.packageIdentifiers) ?? []
     }
 
-    /// Bundle IDs Homebrew asks to quit before uninstalling. Unlike pkgutil
-    /// receipts, these identify the application itself and can safely relate
-    /// App Store and direct-download variants of the same product family.
+    /// Bundle IDs declared by Homebrew or verified in the CaskFlow identity manifest.
     var applicationBundleIdentifiers: [String] {
-        artifacts?.flatMap(\.applicationBundleIdentifiers) ?? []
+        (artifacts?.flatMap(\.applicationBundleIdentifiers) ?? []) + (catalogBundleIdentifiers ?? [])
     }
 
     /// Application bundles installed indirectly by a package artifact.

--- a/CaskHub/Services/Catalog/CategoryService.swift
+++ b/CaskHub/Services/Catalog/CategoryService.swift
@@ -26,6 +26,11 @@ nonisolated struct TokenCategoryMapping: Codable, Hashable {
     let secondary: [CategoryID]
 }
 
+nonisolated struct CaskAppIdentity: Decodable, Hashable, Sendable {
+    let bundleName: String
+    let bundleIdentifier: String
+}
+
 nonisolated struct CaskCategoryData: Decodable {
     let version: Int
     let generatedDate: String
@@ -35,6 +40,9 @@ nonisolated struct CaskCategoryData: Decodable {
     /// Manifest of tokens with an icon on the CaskFlow icons branch, stamped
     /// into the release asset. Absent in pre-2026.07 data → nil.
     let iconTokens: [String]?
+    // Optional for releases predating app identity metadata.
+    var appIdentities: [String: [CaskAppIdentity]]?
+    var metadataUpdatedAt: String?
 }
 
 @MainActor
@@ -46,6 +54,8 @@ final class CategoryService {
     private(set) var generatedDate: String = ""
     private(set) var releaseTag: String?
     private(set) var iconTokens: Set<String>?
+    private(set) var appIdentities: [String: [CaskAppIdentity]] = [:]
+    private(set) var metadataUpdatedAt: String?
     private(set) var catalogStateRevision = 0
 
     var orderedCategories: [(id: CategoryID, definition: CategoryDefinition)] {
@@ -62,8 +72,8 @@ final class CategoryService {
 
     /// Off-main decode; never overwrites fresher remote data.
     func loadBundledCategoriesAsync() async {
-        guard let catalog = await Self.decodeBundledCategories(),
-              catalog.generatedDate > generatedDate
+        guard version == 0 else { return }
+        guard let catalog = await Self.decodeBundledCategories(), version == 0
         else { return }
         applyData(catalog)
     }
@@ -76,12 +86,30 @@ final class CategoryService {
     }
 
     func refreshFromRemote() async {
-        guard let remote = await CaskFlowReleases.fetch(CaskCategoryData.self, asset: "categories.json"),
-              remote.version == version,
-              remote.generatedDate > generatedDate
-        else { return }
+        await loadBundledCategoriesAsync()
+        guard let remote = await CaskFlowReleases.fetch(CaskCategoryData.self, asset: "categories.json") else { return }
+        applyRemoteData(remote)
+    }
 
+    func applyRemoteData(_ remote: CaskCategoryData) {
+        guard remote.version == version, remote.generatedDate >= generatedDate,
+              remote.generatedDate > generatedDate
+                || (remote.metadataUpdatedAt ?? "") > (metadataUpdatedAt ?? "") else { return }
         applyData(remote)
+    }
+
+    func addingAppIdentities(to casks: [Cask]) -> [Cask] {
+        casks.map { cask in
+            var enriched = cask
+            let names = Set(cask.appArtifactNames + cask.packageAppNameCandidates)
+            enriched.catalogBundleIdentifiers = (appIdentities[cask.token] ?? []).filter {
+                names.contains($0.bundleName)
+                    && $0.bundleIdentifier.range(
+                        of: #"^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$"#, options: .regularExpression
+                    ) != nil
+            }.map(\.bundleIdentifier)
+            return enriched
+        }
     }
 
     func applyData(_ catalog: CaskCategoryData) {
@@ -92,6 +120,8 @@ final class CategoryService {
         generatedDate = catalog.generatedDate
         releaseTag = catalog.releaseTag
         iconTokens = catalog.iconTokens.map(Set.init)
+        if let identities = catalog.appIdentities { appIdentities = identities }
+        if let updatedAt = catalog.metadataUpdatedAt { metadataUpdatedAt = updatedAt }
         catalogStateRevision &+= 1
     }
 

--- a/CaskHub/Services/Homebrew/Coordination/CaskLocalStateResolver.swift
+++ b/CaskHub/Services/Homebrew/Coordination/CaskLocalStateResolver.swift
@@ -26,12 +26,19 @@ struct CaskLocalStateResolver {
 
     func isAdoptableApplication(_ cask: Cask) -> Bool {
         guard !isInstalled(token: cask.token) else { return false }
-        if hasRegisteredApplicationCatalog {
+        if hasRegisteredApplicationCatalog || snapshot.externalApplicationOwners[cask.token] != nil {
             return snapshot.externalApplicationOwners[cask.token] != nil
         }
-        return cask.appArtifactNames.contains(
-            where: snapshot.externalAppNames.contains
-        )
+        return cask.appArtifactNames.lazy
+            .flatMap { snapshot.detectedApplicationsByBundleName[$0] ?? [] }
+            .contains { application in
+                guard !application.isMacAppStore,
+                      application.isDirectlyInApplicationDirectory,
+                      let identifier = application.bundleIdentifier else { return false }
+                return ApplicationIdentityMatcher.applicationBundleIdentifier(
+                    identifier, matchesAny: cask.applicationBundleIdentifiers
+                )
+            }
     }
 
     func isExternalPackageInstalled(_ cask: Cask) -> Bool {
@@ -52,7 +59,6 @@ struct CaskLocalStateResolver {
         .intersection(snapshot.macAppStoreAppNames)
         guard !matchingNames.isEmpty else { return false }
 
-        guard cask.hasPackageArtifact else { return true }
         return matchingNames.contains { appName in
             snapshot.macAppStoreBundleIdentifiers[appName]?.contains {
                 storeBundleIdentifier($0, matches: cask)
@@ -251,7 +257,6 @@ struct CaskLocalStateResolver {
             .flatMap { snapshot.detectedApplicationsByBundleName[$0] ?? [] }
             .first { application in
                 guard application.isMacAppStore else { return false }
-                guard cask.hasPackageArtifact else { return true }
                 guard let bundleIdentifier = application.bundleIdentifier else {
                     return false
                 }
@@ -269,7 +274,7 @@ struct CaskLocalStateResolver {
                 matchesAny: cask.applicationBundleIdentifiers
             )
         }
-        return ApplicationIdentityMatcher.bundleIdentifier(
+        return cask.hasPackageArtifact && ApplicationIdentityMatcher.bundleIdentifier(
             identifier,
             matchesPackageIdentifiers: cask.packageIdentifiers
         )

--- a/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Adoption.swift
+++ b/CaskHub/Services/Homebrew/Facade/LocalHomebrewService+Adoption.swift
@@ -214,6 +214,8 @@ extension LocalHomebrewService {
     ) -> CaskAdoptionRequest? {
         let state = localState(for: cask)
         let current = state.adoptionPlan
+        guard current != nil || state.installationSource == .externalExecutable
+            || state.installationSource == .homebrew else { return nil }
         let plan: CaskAdoptionPlan
         switch intent {
         case .planned:

--- a/CaskHub/Services/Homebrew/Infrastructure/ApplicationDiscovery.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/ApplicationDiscovery.swift
@@ -142,13 +142,12 @@ nonisolated struct ApplicationOwnershipResolver: Sendable {
         for application: DetectedApplication,
         candidates: [ApplicationCaskSignature]
     ) -> ApplicationCaskSignature? {
-        if candidates.count == 1 { return candidates[0] }
-        guard candidates.count > 1,
-              let identifier = application.bundleIdentifier?.lowercased()
-        else { return nil }
+        guard let identifier = application.bundleIdentifier else { return nil }
 
         let exactMatches = candidates.filter { signature in
-            signature.bundleIdentifiers.contains { $0.lowercased() == identifier }
+            ApplicationIdentityMatcher.applicationBundleIdentifier(
+                identifier, matchesAny: Array(signature.bundleIdentifiers)
+            )
         }
         return exactMatches.count == 1 ? exactMatches[0] : nil
     }
@@ -163,13 +162,8 @@ nonisolated enum ApplicationIdentityMatcher {
         _ identifier: String,
         matchesAny candidates: [String]
     ) -> Bool {
-        let actual = identifier.lowercased().split(separator: ".").map(String.init)
-        return candidates.contains { candidate in
-            let expected = candidate.lowercased().split(separator: ".").map(String.init)
-            if actual == expected { return true }
-            return zip(actual, expected).prefix { pair in
-                pair.0 == pair.1
-            }.count >= 3
+        !identifier.isEmpty && candidates.contains {
+            $0.caseInsensitiveCompare(identifier) == .orderedSame
         }
     }
 

--- a/CaskHub/Services/Homebrew/Infrastructure/InstallationIndexBuilder.swift
+++ b/CaskHub/Services/Homebrew/Infrastructure/InstallationIndexBuilder.swift
@@ -195,7 +195,6 @@ nonisolated struct InstallationIndexBuilder: Sendable {
         _ application: DetectedApplication,
         matches signature: MacAppStoreCaskSignature
     ) -> Bool {
-        guard signature.hasPackageArtifact else { return true }
         guard let bundleIdentifier = application.bundleIdentifier else { return false }
         if !signature.applicationBundleIdentifiers.isEmpty {
             return ApplicationIdentityMatcher.applicationBundleIdentifier(
@@ -203,7 +202,7 @@ nonisolated struct InstallationIndexBuilder: Sendable {
                 matchesAny: signature.applicationBundleIdentifiers
             )
         }
-        return ApplicationIdentityMatcher.bundleIdentifier(
+        return signature.hasPackageArtifact && ApplicationIdentityMatcher.bundleIdentifier(
             bundleIdentifier,
             matchesPackageIdentifiers: signature.packageIdentifiers
         )

--- a/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
+++ b/CaskHub/ViewModels/Catalog/CaskCatalogViewModel.swift
@@ -168,6 +168,11 @@ final class CaskCatalogViewModel {
         async let categories: Void = categoryService.refreshFromRemote()
         async let addedDates: Void = recentlyAdded.refreshFromRemote()
         _ = await (catalog, local, categories, addedDates)
+        let enriched = categoryService.addingAppIdentities(to: casks)
+        if enriched != casks {
+            casks = enriched
+            await localHomebrew.updatePackageCatalog(casks)
+        }
     }
 
     func refreshIfStale(maxAge: TimeInterval = 3600) async {
@@ -188,12 +193,13 @@ final class CaskCatalogViewModel {
             async let analyticsRequest = apiClient.fetchAnalytics(period: .days365)
 
             let allCasks = try await caskRequest
-            casks = allCasks.filter { cask in
+            await categoryService.loadBundledCategoriesAsync()
+            casks = categoryService.addingAppIdentities(to: allCasks.filter { cask in
                 !cask.deprecated
                     && !cask.disabled
                     && !cask.token.contains("@")
                     && !cask.token.hasPrefix("font-")
-            }
+            })
             await localHomebrew.updatePackageCatalog(casks)
 
             if let analytics = try? await analyticsRequest {

--- a/CaskHubTests/Catalog/CaskCatalogSortTests.swift
+++ b/CaskHubTests/Catalog/CaskCatalogSortTests.swift
@@ -322,3 +322,55 @@ final class CaskCatalogSortTests: XCTestCase {
         XCTAssertEqual(vm.categoryCounts["utilities"], 1)
     }
 }
+
+extension CaskCatalogSortTests {
+    @MainActor
+    func test_identity_only_metadata_update_and_revocation_do_not_require_new_category_date() throws {
+        let service = CategoryService()
+        let legacy = Data(#"{"version":2,"generatedDate":"2026-09-05","categories":{},"tokenToCategory":{}}"#.utf8)
+        var catalog = try JSONDecoder().decode(CaskCategoryData.self, from: legacy)
+        service.applyData(catalog)
+        catalog.appIdentities = ["mail": [CaskAppIdentity(bundleName: "Mail.app", bundleIdentifier: "org.example.mail")]]
+        catalog.metadataUpdatedAt = "2026-09-06T10:00:00.000000+00:00"
+        service.applyRemoteData(catalog)
+        XCTAssertEqual(service.appIdentities["mail"]?.first?.bundleIdentifier, "org.example.mail")
+        let cask = makeCask("mail", appNames: ["Mail.app"])
+        let enriched = service.addingAppIdentities(to: [cask])[0]
+        XCTAssertEqual(enriched.applicationBundleIdentifiers, ["org.example.mail"])
+        XCTAssertTrue(service.addingAppIdentities(to: [makeCask("mail", appNames: ["Different.app"])])[0]
+            .applicationBundleIdentifiers.isEmpty)
+        catalog.appIdentities = [:]
+        catalog.metadataUpdatedAt = "2026-09-06T11:00:00.000000+00:00"
+        service.applyRemoteData(catalog)
+        XCTAssertTrue(service.addingAppIdentities(to: [enriched])[0].applicationBundleIdentifiers.isEmpty)
+        catalog.appIdentities = ["mail": [CaskAppIdentity(bundleName: "Mail.app", bundleIdentifier: "org.example.stale")]]
+        catalog.metadataUpdatedAt = "2026-09-06T09:00:00.000000+00:00"
+        service.applyRemoteData(catalog)
+        XCTAssertTrue(service.appIdentities.isEmpty)
+    }
+
+    @MainActor
+    func test_catalog_fetch_registers_manifest_identity_with_the_real_app_scanner() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("manifest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try makeApplicationBundle(in: root, named: "Example.app", bundleIdentifier: "org.example.mail", macAppStoreReceipt: true)
+        let local = LocalHomebrewService(defaults: makeScratchDefaults("manifest-scanner")) {
+            $0.applicationDirectories = [root]
+        }
+        let categories = CategoryService()
+        let data = Data(#"""
+        {"version":2,"generatedDate":"2026-09-05","categories":{},"tokenToCategory":{},
+         "appIdentities":{"example":[{"bundleName":"Example.app","bundleIdentifier":"org.example.mail"}]}}
+        """#.utf8)
+        categories.applyData(try JSONDecoder().decode(CaskCategoryData.self, from: data))
+        let api = MockBrewAPIClient()
+        api.casks = [makeCask("example", appNames: ["Example.app"])]
+        let vm = makeViewModel(api: api, categories: categories, localHomebrew: local)
+
+        await vm.fetchCasks()
+
+        XCTAssertEqual(vm.casks.first?.applicationBundleIdentifiers, ["org.example.mail"])
+        XCTAssertEqual(local.localState(for: vm.casks[0]).installationSource, .macAppStore)
+        XCTAssertFalse(local.localState(for: vm.casks[0]).isAdoptable)
+    }
+}

--- a/CaskHubTests/Homebrew/Detection/ExternalApplicationOwnershipTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ExternalApplicationOwnershipTests.swift
@@ -92,7 +92,7 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
         XCTAssertTrue(owners.isEmpty)
     }
 
-    func test_unique_app_name_remains_adoptable_without_bundle_identifier_metadata() {
+    func test_unique_app_name_without_bundle_identifier_metadata_is_not_adoptable() {
         let application = makeDetectedApplication("Unique.app", id: "com.example.unique")
         let signature = ApplicationCaskSignature(
             token: "unique",
@@ -106,7 +106,7 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
             installedCasks: [:]
         )
 
-        XCTAssertEqual(owners["unique"], application)
+        XCTAssertTrue(owners.isEmpty)
     }
 
     func test_store_resolution_indexes_direct_and_bundle_family_matches() {
@@ -131,13 +131,14 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
             storeSignature(
                 token: "canva",
                 bundleName: "Canva.app",
-                hasPackage: false
+                hasPackage: false,
+                applicationIdentifiers: ["com.canva.CanvaDesktop"]
             ),
             storeSignature(
                 token: "tailscale-app",
                 bundleName: "Tailscale.app",
                 hasPackage: true,
-                applicationIdentifiers: ["io.tailscale.ipn.macsys"],
+                applicationIdentifiers: ["io.tailscale.ipn.macsys", "io.tailscale.ipn.macos"],
                 packageIdentifiers: ["com.tailscale.ipn.macsys"]
             ),
             storeSignature(
@@ -318,7 +319,8 @@ final class ExternalApplicationOwnershipTests: XCTestCase {
             storeSignature(
                 token: cask.token,
                 bundleName: cask.appArtifactNames[0],
-                hasPackage: false
+                hasPackage: false,
+                applicationIdentifiers: ["com.example.store\(cask.token.dropFirst(6))"]
             )
         }
         updateInstallationSnapshot(of: service) {

--- a/CaskHubTests/Homebrew/Detection/ExternalInstallationTests.swift
+++ b/CaskHubTests/Homebrew/Detection/ExternalInstallationTests.swift
@@ -14,8 +14,12 @@ final class ExternalInstallationTests: XCTestCase {
         let service = LocalHomebrewService()
         updateInstallationSnapshot(of: service) {
             $0.macAppStoreAppNames = ["Canva.app"]
+            $0.macAppStoreBundleIdentifiers = ["Canva.app": ["com.canva.CanvaDesktop"]]
         }
-        let canva = makeCask("canva", appNames: ["Canva.app"])
+        let canva = makeCask(
+            "canva", appNames: ["Canva.app"],
+            applicationBundleIdentifiers: ["com.canva.CanvaDesktop"]
+        )
         let state = service.localState(for: canva)
 
         XCTAssertEqual(state.installationSource, .macAppStore)
@@ -181,7 +185,10 @@ final class ExternalInstallationTests: XCTestCase {
                 scan.macAppStoreBundleIdentifiers
             $0.detectedApplications = scan.applications
         }
-        let cask = makeCask("whatsapp", name: "WhatsApp", appNames: ["WhatsApp.app"])
+        let cask = makeCask(
+            "whatsapp", name: "WhatsApp", appNames: ["WhatsApp.app"],
+            applicationBundleIdentifiers: ["net.whatsapp.WhatsApp"]
+        )
         let state = service.localState(for: cask)
 
         XCTAssertEqual(state.installationSource, .macAppStore)

--- a/CaskHubTests/Homebrew/Detection/InstallationSnapshotTests.swift
+++ b/CaskHubTests/Homebrew/Detection/InstallationSnapshotTests.swift
@@ -219,10 +219,8 @@ final class ApplicationIdentityCollisionTests: XCTestCase {
                 ("Motion.app", "com.apple.motionapp"),
                 ("Verified.app", "com.example.verified")
             ] {
-                try makeApplicationBundle(
-                    in: root, named: name, bundleIdentifier: identifier,
-                    macAppStoreReceipt: hasReceipt
-                )
+                try makeApplicationBundle(in: root, named: name,
+                                          bundleIdentifier: identifier, macAppStoreReceipt: hasReceipt)
             }
             let classicCollision = makeCask("spark-app", appNames: ["Spark.app"])
             let motionCollision = makeCask("motion", appNames: ["Motion.app"])

--- a/CaskHubTests/Homebrew/Detection/InstallationSnapshotTests.swift
+++ b/CaskHubTests/Homebrew/Detection/InstallationSnapshotTests.swift
@@ -156,7 +156,7 @@ final class InstallationSnapshotTests: XCTestCase {
 
 extension ExternalInstallationTests {
     @MainActor
-    func test_store_tailscale_matches_package_cask_by_application_bundle_family() throws {
+    func test_store_tailscale_matches_package_cask_by_manifest_identity() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("store-tailscale-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
@@ -189,17 +189,150 @@ extension ExternalInstallationTests {
             packageIdentifiers: ["com.tailscale.ipn.macsys"],
             applicationBundleIdentifiers: ["io.tailscale.ipn.macsys"]
         )
-        let state = service.localState(for: tailscale)
+        let categories = try makeIdentityCategoryService()
+        let verified = categories.addingAppIdentities(to: [tailscale])[0]
+        let state = service.localState(for: verified)
 
         XCTAssertEqual(state.installationSource, .macAppStore)
         XCTAssertTrue(state.isPresent)
         XCTAssertFalse(state.isAdoptable)
         XCTAssertTrue(state.canOpen)
 
-        service.openExternalApp(cask: tailscale)
+        service.openExternalApp(cask: verified)
         XCTAssertEqual(
             launcher.lastOpenedURL?.standardizedFileURL,
             tailscaleApp.standardizedFileURL
         )
+    }
+}
+
+@MainActor
+final class ApplicationIdentityCollisionTests: XCTestCase {
+    func test_catalog_scan_rejects_spark_classic_and_apple_motion_collisions() async throws {
+        let categories = try makeIdentityCategoryService()
+        for hasReceipt in [true, false] {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent("identity-\(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: root) }
+            for (name, identifier) in [
+                ("Spark.app", "com.readdle.smartemail-Mac"),
+                ("Spark Desktop.app", "com.readdle.SparkDesktop.appstore"),
+                ("Motion.app", "com.apple.motionapp"),
+                ("Verified.app", "com.example.verified")
+            ] {
+                try makeApplicationBundle(
+                    in: root, named: name, bundleIdentifier: identifier,
+                    macAppStoreReceipt: hasReceipt
+                )
+            }
+            let classicCollision = makeCask("spark-app", appNames: ["Spark.app"])
+            let motionCollision = makeCask("motion", appNames: ["Motion.app"])
+            let mail = categories.addingAppIdentities(to: [makeCask("readdle-spark", appNames: ["Spark Desktop.app"])])[0]
+            let verified = makeCask("verified", appNames: ["Verified.app"], applicationBundleIdentifiers: ["com.example.verified"])
+            let service = LocalHomebrewService(defaults: makeScratchDefaults("identity-collisions")) {
+                $0.applicationDirectories = [root]
+            }
+            let scan = ApplicationDiscovery().scan(fileManager: .default, directories: [root])
+            updateInstallationSnapshot(of: service) {
+                $0.detectedApplications = scan.applications
+                $0.externalAppNames = scan.adoptableNames
+                $0.macAppStoreAppNames = scan.macAppStoreNames
+                $0.macAppStoreBundleIdentifiers = scan.macAppStoreBundleIdentifiers
+            }
+            // The unregistered fallback must enforce the same identity rules.
+            for cask in [classicCollision, motionCollision] {
+                XCTAssertFalse(service.localState(for: cask).isPresent)
+                XCTAssertFalse(service.localState(for: cask).isAdoptable)
+            }
+            await service.updatePackageCatalog([classicCollision, motionCollision, mail, verified])
+            for cask in [classicCollision, motionCollision] {
+                let state = service.localState(for: cask)
+                XCTAssertFalse(state.isPresent)
+                XCTAssertFalse(state.canOpen)
+                XCTAssertNil(state.adoptionPlan)
+                await service.requestReplacementAdoption(cask)
+                XCTAssertNil(service.operationStore.state(for: cask.token))
+            }
+            for cask in [mail, verified] {
+                let state = service.localState(for: cask)
+                XCTAssertEqual(state.installationSource, hasReceipt ? .macAppStore : .externalApplication)
+                XCTAssertTrue(state.canOpen)
+                XCTAssertEqual(state.isAdoptable, !hasReceipt)
+            }
+        }
+    }
+
+    func test_element_rejects_kushview_package_and_accepts_matrix() async throws {
+        let categories = try makeIdentityCategoryService()
+        let matrix = categories.addingAppIdentities(to: [makeCask("element", appNames: ["Element.app"])])[0]
+        XCTAssertEqual(matrix.applicationBundleIdentifiers, ["im.riot.app"])
+        let registration = InstallationCatalogBuilder().build([matrix])
+        XCTAssertTrue(registration.packageSignatures.isEmpty)
+        // Observed from Kushview's 1.1.1 installer, not Homebrew metadata.
+        let receipts = Set(["ElementApp", "ElementVST2", "ElementVST3", "ElementAU", "ElementLV2", "ElementCLAP"]
+            .map { "net.kushview.pkg." + $0 })
+        for (identifier, expectedPresent) in [("net.kushview.Element", false), ("im.riot.app", true)] {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent("element-\(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: root) }
+            try makeApplicationBundle(in: root, named: "Element.app", bundleIdentifier: identifier)
+            let scan = ApplicationDiscovery().scan(fileManager: .default, directories: [root])
+            XCTAssertEqual(scan.applications.count, 1)
+            let packages = PackageReceiptResolver().resolve(
+                signatures: registration.packageSignatures, installedReceipts: receipts,
+                packageFileLists: ["net.kushview.pkg.ElementApp": "Applications/Element.app"],
+                availableAppNames: scan.adoptableNames
+            )
+            XCTAssertTrue(packages.isEmpty)
+            let service = LocalHomebrewService(defaults: makeScratchDefaults("element-collision")) {
+                $0.applicationDirectories = [root]
+            }
+            updateInstallationSnapshot(of: service) {
+                $0.detectedApplications = scan.applications
+                $0.externalAppNames = scan.adoptableNames
+                $0.externalPackageInstallations = packages
+            }
+            XCTAssertEqual(service.localState(for: matrix).isAdoptable, expectedPresent)
+            await service.updatePackageCatalog([matrix])
+            let state = service.localState(for: matrix)
+            XCTAssertEqual(state.isPresent, expectedPresent)
+            XCTAssertEqual(state.isAdoptable, expectedPresent)
+            XCTAssertEqual(state.canOpen, expectedPresent)
+            XCTAssertEqual(state.adoptionPlan != nil, expectedPresent)
+            if !expectedPresent {
+                await service.requestReplacementAdoption(matrix)
+                XCTAssertNil(service.operationStore.state(for: matrix.token))
+            }
+        }
+    }
+
+    func test_known_conflicting_identifier_cannot_claim_unique_filename() {
+        let application = makeDetectedApplication("Motion.app", id: "com.apple.motionapp")
+        let expectedIdentifier = "com.electron.motion"
+        XCTAssertTrue(ApplicationOwnershipResolver().resolve(
+            signatures: [ApplicationCaskSignature(
+                token: "motion", appBundleNames: ["Motion.app"],
+                bundleIdentifiers: [expectedIdentifier]
+            )],
+            applications: [application], installedCasks: [:]
+        ).isEmpty)
+        let storeApp = makeDetectedApplication(
+            "Motion.app", id: "com.apple.motionapp", isMacAppStore: true
+        )
+        XCTAssertTrue(InstallationIndexBuilder().resolveMacAppStoreApplications(
+            signatures: [MacAppStoreCaskSignature(
+                token: "motion", bundleNames: ["Motion.app"], hasPackageArtifact: false,
+                applicationBundleIdentifiers: [expectedIdentifier], packageIdentifiers: []
+            )],
+            applications: [storeApp], installedCasks: [:]
+        ).isEmpty)
+    }
+
+    func test_bundle_identifier_prefix_is_not_identity() {
+        XCTAssertFalse(ApplicationIdentityMatcher.applicationBundleIdentifier(
+            "com.vendor.suite.unrelated", matchesAny: ["com.vendor.suite.app"]
+        ))
+        XCTAssertFalse(ApplicationIdentityMatcher.applicationBundleIdentifier("", matchesAny: [""]))
+        XCTAssertTrue(ApplicationIdentityMatcher.applicationBundleIdentifier(
+            "com.vendor.App", matchesAny: ["com.vendor.app"]
+        ))
     }
 }

--- a/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
+++ b/CaskHubTests/Homebrew/Integration/CaskHubTests.swift
@@ -79,10 +79,10 @@ final class CaskHubTests: XCTestCase {
     func test_adoptable_requires_on_disk_app_and_no_brew_install() {
         let service = LocalHomebrewService()
         updateInstallationSnapshot(of: service) {
-            $0.externalAppNames = ["Google Chrome.app"]
+            $0.detectedApplications = [makeDetectedApplication("Google Chrome.app", id: "com.google.Chrome")]
         }
 
-        let chrome = makeCask("google-chrome", appNames: ["Google Chrome.app"])
+        let chrome = makeCask("google-chrome", appNames: ["Google Chrome.app"], applicationBundleIdentifiers: ["com.google.Chrome"])
         XCTAssertTrue(service.localState(for: chrome).isAdoptable)
 
         updateInstalledCask(installation("google-chrome", version: "1.0"), in: service)
@@ -134,9 +134,7 @@ final class CaskHubTests: XCTestCase {
         XCTAssertEqual(service.localState(for: managed).uninstallAvailability, .available)
 
         let adoptable = makeCask("adoptable", appNames: ["Adoptable.app"])
-        updateInstallationSnapshot(of: service) {
-            $0.externalAppNames = ["Adoptable.app"]
-        }
+        seedExternalInstallation(of: adoptable, version: "1.0", in: service)
         let adoptHint = String(
             localized: "Adopt this app first so CaskHub can manage/uninstall it."
         )
@@ -145,9 +143,10 @@ final class CaskHubTests: XCTestCase {
             adoptHint
         )
 
-        let store = makeCask("store", appNames: ["Store.app"])
+        let store = makeCask("store", appNames: ["Store.app"], applicationBundleIdentifiers: ["com.example.store"])
         updateInstallationSnapshot(of: service) {
             $0.macAppStoreAppNames = ["Store.app"]
+            $0.macAppStoreBundleIdentifiers = ["Store.app": ["com.example.store"]]
         }
         let storeHint = String(
             localized: """
@@ -506,11 +505,11 @@ final class CaskHubTests: XCTestCase {
     func test_adopt_sidebar_filter_lists_only_adoptable_casks() async {
         let homebrew = LocalHomebrewService()
         updateInstallationSnapshot(of: homebrew) {
-            $0.externalAppNames = ["Google Chrome.app"]
+            $0.detectedApplications = [makeDetectedApplication("Google Chrome.app", id: "com.google.Chrome")]
         }
         let (vm, _) = await makeSUT(
             casks: [
-                makeCask("google-chrome", appNames: ["Google Chrome.app"]),
+                makeCask("google-chrome", appNames: ["Google Chrome.app"], applicationBundleIdentifiers: ["com.google.Chrome"]),
                 makeCask("slack", appNames: ["Slack.app"])
             ],
             localHomebrew: homebrew

--- a/CaskHubTests/Homebrew/Workflows/CaskAdoptionWorkflowTests.swift
+++ b/CaskHubTests/Homebrew/Workflows/CaskAdoptionWorkflowTests.swift
@@ -352,4 +352,34 @@ extension CaskAdoptionWorkflowTests {
             "install", "--cask", cask.token, "--force"
         ]])
     }
+    func test_homebrew_package_replacement_recovery_preserves_package_execution() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(runner: runner, permissionProbe: { .granted })
+        let cask = makeCask("managed", packageIdentifiers: ["com.example.managed"])
+        updateInstalledCask(installation(cask.token, version: "1.0"), in: service)
+
+        await service.requestReplacementAdoption(cask)
+
+        let request = try XCTUnwrap(service.operationStore.state(for: cask.token)?.adoptionRequest)
+        XCTAssertEqual(request.plan.execution, .replacePackage)
+        XCTAssertTrue(runner.requests.isEmpty)
+    }
+
+    func test_replacement_confirmation_stops_when_identity_is_no_longer_resolved() async throws {
+        let runner = StubBrewProcessRunner()
+        let service = makeMutationService(
+            runner: runner, scanner: FixedInstalledSoftwareScanner(snapshot: .empty),
+            permissionProbe: { .granted }
+        )
+        let cask = makeCask("changed", appNames: ["Changed.app"])
+        seedExternalInstallation(of: cask, version: "1.0", in: service)
+        await service.requestReplacementAdoption(cask)
+        let request = try XCTUnwrap(service.operationStore.state(for: cask.token)?.adoptionRequest)
+
+        try await service.confirmAdoption(request)
+
+        XCTAssertTrue(runner.requests.isEmpty)
+        XCTAssertNil(service.operationStore.state(for: cask.token))
+    }
+
 }

--- a/CaskHubTests/Support/SharedTestHelpers.swift
+++ b/CaskHubTests/Support/SharedTestHelpers.swift
@@ -73,7 +73,8 @@ func makeCask(
     if packageIdentifiers != nil || packageAppNames != nil
         || applicationBundleIdentifiers != nil {
         artifacts.append(ArtifactStanza(
-            keys: ["pkg", "uninstall"],
+            keys: packageIdentifiers != nil || packageAppNames != nil
+                ? ["pkg", "uninstall"] : ["uninstall"],
             adoptionSourcePaths: [],
             packageIdentifiers: packageIdentifiers ?? [],
             deletedAppNames: packageAppNames ?? [],
@@ -466,4 +467,18 @@ final class SpyCrashReporterProvider: CrashReporterProvider {
         spans.append(SpanRecord(name: name, operation: operation, span: span))
         return span
     }
+}
+
+@MainActor
+func makeIdentityCategoryService() throws -> CategoryService {
+    let data = Data(#"""
+    {"version":2,"generatedDate":"2026-09-06","categories":{},"tokenToCategory":{},
+     "appIdentities":{
+       "readdle-spark":[{"bundleName":"Spark Desktop.app","bundleIdentifier":"com.readdle.SparkDesktop.appstore"}],
+       "tailscale-app":[{"bundleName":"Tailscale.app","bundleIdentifier":"io.tailscale.ipn.macos"}],
+       "element":[{"bundleName":"Element.app","bundleIdentifier":"im.riot.app"}]}}
+    """#.utf8)
+    let service = CategoryService()
+    service.applyData(try JSONDecoder().decode(CaskCategoryData.self, from: data))
+    return service
 }


### PR DESCRIPTION
## Summary

Kushview Element and the Matrix client both install as `Element.app`. Filename-only matching offered the unrelated Matrix cask for adoption. Require an exact application bundle identifier for external and Mac App Store matches, and reject adoption requests whose app identity no longer resolves.

Load optional verified identities from CaskFlow metadata, validate them against the cask's declared app names, and re-register the catalog when remote identity metadata arrives. Preserve existing Homebrew and package recovery behavior.

Closes #175. Related: #218 and #219.

Companion data PR: https://github.com/alielsokary/CaskFlow/pull/141. Publish that metadata and sync the generated bundled resources during release preparation. This feature PR deliberately leaves generated JSON unchanged; tests use explicit verified identity fixtures. Until metadata is available, external apps without known bundle identifiers remain unassigned, which can reduce the displayed installed/adoptable count.

## Verification

- Full signed macOS test suite: 479 passed, 0 failures or skips. Strict SwiftLint and codesign verification passed on the final commits.
- `git diff --check origin/develop...HEAD` passed.
- Real-app checks with the verified metadata: old build offered Kushview as Matrix; fixed build rejected Kushview, recognized Matrix, and successfully adopted Matrix into Homebrew while Kushview's package receipts remained installed. Spark Mail was correctly identified as the App Store variant.
- Apple Motion collision uses a regression fixture; the paid app was not purchased.
- Three focused commits cover metadata loading, exact matching, and adoption validation, all authored and committed using Ali Elsokary's configured identity.

## Checklist

- [x] Base branch is `develop` (not `master`)
- [x] Title uses a conventional prefix + Sentence-case subject
- [x] Tests added or updated
- [x] SwiftLint build phase passes locally
- [x] No changes to `CaskHub/Resources/*.json` or `CHANGELOG.md`
- [x] Issue linked for non-trivial changes
