### PR TITLE
feat(icons): Refresh changed icons from the independent CaskFlow manifest

### DIFF
--- a/CaskHub.xcodeproj/project.pbxproj
+++ b/CaskHub.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		A29100000000000000000107 /* HomebrewOutputDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000106 /* HomebrewOutputDiagnosticsTests.swift */; };
 		A29100000000000000000207 /* CatalogScrollSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000206 /* CatalogScrollSupport.swift */; };
 		A29100000000000000000307 /* BrewOutputAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29100000000000000000306 /* BrewOutputAggregator.swift */; };
+		CE0920260000000000000001 /* IconRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0920260000000000000002 /* IconRefreshTests.swift */; };
 		ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */; };
 		ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */; };
 		B08000000000000000000002 /* CaskHubCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08000000000000000000001 /* CaskHubCommands.swift */; };
@@ -240,6 +241,7 @@
 		A29100000000000000000106 /* HomebrewOutputDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewOutputDiagnosticsTests.swift; sourceTree = "<group>"; };
 		A29100000000000000000206 /* CatalogScrollSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogScrollSupport.swift; sourceTree = "<group>"; };
 		A29100000000000000000306 /* BrewOutputAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewOutputAggregator.swift; sourceTree = "<group>"; };
+		CE0920260000000000000002 /* IconRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconRefreshTests.swift; sourceTree = "<group>"; };
 		ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewTests.swift; sourceTree = "<group>"; };
 		ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewTests.swift; sourceTree = "<group>"; };
 		B08000000000000000000001 /* CaskHubCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskHubCommands.swift; sourceTree = "<group>"; };
@@ -780,6 +782,7 @@
 				ABCA0F0600ABCA0F0600ABCA /* ContentViewTests.swift */,
 				B09200000000000000000001 /* HelpViewTests.swift */,
 				AA1000000000000000000010 /* MaintenanceViewTests.swift */,
+				CE0920260000000000000002 /* IconRefreshTests.swift */,
 				ABCA0F0400ABCA0F0400ABCA /* SettingsViewTests.swift */,
 				B0C000000000000000000004 /* ShelfSetupViewTests.swift */,
 				A26000000000000000000003 /* UpdateSettingsViewTests.swift */,
@@ -1144,6 +1147,7 @@
 				41DFD4B430028F9F00608C7A /* CaskHubTests.swift in Sources */,
 				ABCA0F0500ABCA0F0500ABCA /* ContentViewTests.swift in Sources */,
 				B09200000000000000000002 /* HelpViewTests.swift in Sources */,
+				CE0920260000000000000001 /* IconRefreshTests.swift in Sources */,
 				ABCA0F0300ABCA0F0300ABCA /* SettingsViewTests.swift in Sources */,
 				B0C000000000000000000005 /* ShelfSetupViewTests.swift in Sources */,
 				AA100000000000000000000D /* MaintenanceParsingTests.swift in Sources */,

--- a/CaskHub/Services/Images/IconDiskCache.swift
+++ b/CaskHub/Services/Images/IconDiskCache.swift
@@ -41,7 +41,7 @@ actor IconDiskCache {
         generation expectedGeneration: UInt64,
         fromCaskFlow: Bool
     ) throws -> Bool {
-        guard generation == expectedGeneration else { return false }
+        guard !Task.isCancelled, generation == expectedGeneration else { return false }
         try ensureDirectory()
         try writeAtomically(data, to: path(token: token, fileExtension: "png"))
         try? FileManager.default.removeItem(at: path(token: token, fileExtension: "miss"))

--- a/CaskHub/Services/Images/ImageCacheService.swift
+++ b/CaskHub/Services/Images/ImageCacheService.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import CryptoKit
 import Foundation
 import Observation
 
@@ -13,6 +14,7 @@ import Observation
 @Observable
 final class ImageCacheService {
     private let memoryCache = NSCache<NSString, NSImage>()
+    private var memoryHashes: [String: String] = [:]
     private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
     private var upgradeInFlight: Set<String> = []
     private let session: URLSession
@@ -22,6 +24,14 @@ final class ImageCacheService {
     /// categories.json — absent tokens are guaranteed 404s, never requested.
     /// nil = manifest unknown (old category data) → fall back to probing.
     var knownIconTokens: () -> Set<String>? = { nil }
+    private var iconHashes: [String: String]?
+    private var lastManifestAttempt: Date?
+    private var isRefreshingManifest = false
+    private(set) var iconRefreshRevision: UInt64 = 0
+
+    func iconHash(for token: String) -> String? {
+        iconHashes?[token]
+    }
 
     private static let missRetryInterval: TimeInterval = 24 * 60 * 60
     // The manifest vouches the icon exists, so a recorded miss is publication
@@ -45,6 +55,10 @@ final class ImageCacheService {
     func image(for cask: Cask) async -> NSImage? {
         let token = cask.token
 
+        if let hash = iconHash(for: token) {
+            return await hashedImage(for: cask, hash: hash)
+        }
+
         if let cached = memoryCache.object(forKey: token as NSString) {
             return cached
         }
@@ -57,12 +71,15 @@ final class ImageCacheService {
         if let data = await diskCache.loadData(token: token),
            let diskImage = NSImage(data: data),
            diskImage.isValid {
+            guard !Task.isCancelled, await diskCache.isCurrent(generation) else { return nil }
+            if iconHash(for: token) != nil { return await image(for: cask) }
             memoryCache.setObject(diskImage, forKey: token as NSString)
+            memoryHashes.removeValue(forKey: token)
             await maybeUpgradeFallbackIcon(token: token, generation: generation)
             return diskImage
         }
 
-        let inManifest = knownIconTokens()?.contains(token) ?? true
+        let inManifest = iconHashes.map { $0[token] != nil } ?? knownIconTokens()?.contains(token) ?? true
         if cask.isCLI, !inManifest {
             return nil
         }
@@ -99,6 +116,7 @@ final class ImageCacheService {
         inFlightTasks.removeAll()
         upgradeInFlight.removeAll()
         memoryCache.removeAllObjects()
+        memoryHashes.removeAll()
         do {
             try await diskCache.clear()
         } catch {
@@ -174,18 +192,23 @@ final class ImageCacheService {
         image: NSImage,
         token: String,
         generation: UInt64,
-        fromCaskFlow: Bool = false
+        fromCaskFlow: Bool = false,
+        expectedHash: String? = nil
     ) async {
-        guard await diskCache.isCurrent(generation) else { return }
-        memoryCache.setObject(image, forKey: token as NSString)
+        guard await diskCache.isCurrent(generation), iconHash(for: token) == expectedHash else { return }
         guard let pngData = await Self.pngData(for: image) else { return }
+        guard !Task.isCancelled, iconHash(for: token) == expectedHash else { return }
         do {
-            try await diskCache.store(
+            guard try await diskCache.store(
                 pngData,
                 token: token,
                 generation: generation,
                 fromCaskFlow: fromCaskFlow
-            )
+            ) else { return }
+            guard !Task.isCancelled, await diskCache.isCurrent(generation),
+                  iconHash(for: token) == expectedHash else { return }
+            memoryCache.setObject(image, forKey: token as NSString)
+            memoryHashes.removeValue(forKey: token)
         } catch {
             CrashReporter.capture(error)
         }
@@ -216,12 +239,17 @@ final class ImageCacheService {
             token: token,
             retryInterval: Self.missRetryInterval
         ),
-            !upgradeInFlight.contains(token)
+            !upgradeInFlight.contains(token), iconHash(for: token) == nil
         else {
             return
         }
         upgradeInFlight.insert(token)
-        Task {
+        let key = "\(token):fallback"
+        inFlightTasks[key] = Task {
+            defer {
+                upgradeInFlight.remove(token)
+                inFlightTasks.removeValue(forKey: key)
+            }
             for url in CaskIconURL.caskFlowIconURLs(for: token) {
                 let (image, _) = await downloadImage(from: url)
                 if let image {
@@ -231,12 +259,11 @@ final class ImageCacheService {
                         generation: generation,
                         fromCaskFlow: true
                     )
-                    upgradeInFlight.remove(token)
-                    return
+                    return image
                 }
             }
             try? await diskCache.touchFallback(token: token, generation: generation)
-            upgradeInFlight.remove(token)
+            return nil
         }
     }
 
@@ -250,5 +277,126 @@ final class ImageCacheService {
             }
             return pngData
         }.value
+    }
+}
+
+extension ImageCacheService {
+    private func hashedImage(for cask: Cask, hash: String) async -> NSImage? {
+        let token = cask.token
+        if memoryHashes[token] == hash,
+           let image = memoryCache.object(forKey: token as NSString) { return image }
+        let generation = await diskCache.currentGeneration()
+        let key = "\(token):\(hash):\(generation)"
+        guard iconHash(for: token) == hash else { return await image(for: cask) }
+        for (otherKey, task) in inFlightTasks where otherKey != key
+            && (otherKey == token || otherKey.hasPrefix("\(token):")) {
+            task.cancel()
+        }
+        if let task = inFlightTasks[key] { return await task.value }
+        let task = Task {
+            await refreshHashedImage(for: cask, hash: hash, generation: generation)
+        }
+        inFlightTasks[key] = task
+        let image = await task.value
+        inFlightTasks.removeValue(forKey: key)
+        return image
+    }
+
+    private func refreshHashedImage(for cask: Cask, hash: String, generation: UInt64) async -> NSImage? {
+        let token = cask.token
+        var previous = memoryCache.object(forKey: token as NSString)
+        if let data = await diskCache.loadData(token: token),
+           let image = NSImage(data: data), image.isValid {
+            previous = image
+            if Self.gitBlobHash(data) == hash {
+                guard !Task.isCancelled, await diskCache.isCurrent(generation),
+                      iconHash(for: token) == hash else { return previous }
+                memoryCache.setObject(image, forKey: token as NSString)
+                memoryHashes[token] = hash
+                return image
+            }
+        }
+        if let image = await downloadHashedImage(token: token, hash: hash, generation: generation) { return image }
+        guard !Task.isCancelled, iconHash(for: token) == hash else { return previous }
+        if previous == nil, !cask.isCLI, let url = CaskIconURL.appFairIconURL(for: token) {
+            let (image, _) = await downloadImage(from: url)
+            if let image {
+                await cache(image: image, token: token, generation: generation, expectedHash: hash)
+                return image
+            }
+        }
+        return previous
+    }
+
+    private func downloadHashedImage(token: String, hash: String, generation: UInt64) async -> NSImage? {
+        for url in CaskIconURL.caskFlowIconURLs(for: token) {
+            guard !Task.isCancelled else { return nil }
+            // Mutable endpoints may lag. Only matching bytes may replace the cache.
+            let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 15)
+            guard let (data, response) = try? await session.data(for: request),
+                  (response as? HTTPURLResponse)?.statusCode == 200,
+                  Self.gitBlobHash(data) == hash,
+                  let image = NSImage(data: data), image.isValid else { continue }
+            guard !Task.isCancelled, await diskCache.isCurrent(generation),
+                  iconHash(for: token) == hash else { return nil }
+            do {
+                guard try await diskCache.store(
+                    data, token: token, generation: generation, fromCaskFlow: true
+                ) else { return nil }
+            } catch {
+                CrashReporter.capture(error)
+                return nil
+            }
+            guard !Task.isCancelled, await diskCache.isCurrent(generation),
+                  iconHash(for: token) == hash else { return nil }
+            memoryCache.setObject(image, forKey: token as NSString)
+            memoryHashes[token] = hash
+            return image
+        }
+        return nil
+    }
+
+    nonisolated static func gitBlobHash(_ data: Data) -> String {
+        var digest = Insecure.SHA1()
+        digest.update(data: Data("blob \(data.count)\0".utf8))
+        digest.update(data: data)
+        return digest.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+extension ImageCacheService {
+    /// Independent of category releases. Failed attempts retain the last manifest.
+    func refreshIconManifest(force: Bool = false) async {
+        guard !isRefreshingManifest,
+              force || lastManifestAttempt.map({ Date().timeIntervalSince($0) >= 15 * 60 }) ?? true else { return }
+        isRefreshingManifest = true
+        lastManifestAttempt = Date()
+        defer {
+            isRefreshingManifest = false
+            // Retry visible stale icons even when the manifest itself is unchanged.
+            iconRefreshRevision &+= 1
+        }
+        let url = URL(string: "https://raw.githubusercontent.com/alielsokary/CaskFlow/icons/icons.json")!
+        let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 15)
+        guard let (data, response) = try? await session.data(for: request),
+              !Task.isCancelled, (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+        applyIconManifest(data)
+    }
+
+    @discardableResult
+    func applyIconManifest(_ data: Data) -> Bool {
+        guard let manifest = try? JSONDecoder().decode(IconManifest.self, from: data),
+              manifest.version == 1,
+              manifest.hashes.allSatisfy({ token, hash in
+                  token.range(of: #"^[a-z0-9][a-z0-9+@._-]*$"#, options: .regularExpression) != nil
+                      && hash.range(of: #"^[0-9a-f]{40}$"#, options: .regularExpression) != nil
+              }) else { return false }
+        iconHashes = manifest.hashes
+        return true
+    }
+
+    private nonisolated struct IconManifest: Decodable {
+        let version: Int
+        let hashes: [String: String]
     }
 }

--- a/CaskHub/Views/ContentView.swift
+++ b/CaskHub/Views/ContentView.swift
@@ -13,6 +13,7 @@ enum ViewMode: String {
 
 struct ContentView: View {
     @Bindable var viewModel: CaskCatalogViewModel
+    @Environment(ImageCacheService.self) private var imageCache
     @Environment(CategoryService.self) private var categoryService
     @Environment(LocalHomebrewService.self) private var localHomebrew
     @Environment(MaintenanceViewModel.self) private var maintenance
@@ -102,14 +103,20 @@ struct ContentView: View {
         .windowToolbarFullScreenVisibility(.onHover)
         .tint(Color.chTerracotta)
         .task {
+            async let icons: Void = imageCache.refreshIconManifest()
             await viewModel.load()
+            await icons
         }
         .onReceive(
             NotificationCenter.default.publisher(
                 for: NSApplication.didBecomeActiveNotification
             )
         ) { _ in
-            Task { await viewModel.refreshIfStale() }
+            Task {
+                async let icons: Void = imageCache.refreshIconManifest()
+                await viewModel.refreshIfStale()
+                await icons
+            }
         }
         .onChange(of: viewModel.selectedSidebar) { _, newValue in
             Analytics.pageOpened(newValue)

--- a/CaskHub/Views/Maintenance/MaintenanceView.swift
+++ b/CaskHub/Views/Maintenance/MaintenanceView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MaintenanceView: View {
+    @Environment(ImageCacheService.self) private var imageCache
+    @State private var isSyncingIcons = false
     let model: MaintenanceViewModel
     @State private var expandedChecks: Set<String> = []
 
@@ -190,6 +192,7 @@ extension MaintenanceView {
                     Task { await model.updateHomebrew() }
                 }
                 .disabled(model.brewVersion == nil || model.hasActiveOperations)
+                .disabled(isSyncingIcons)
             case .running:
                 WorkingPill(title: String(localized: .maintenanceWorking))
             case .done:
@@ -227,21 +230,24 @@ extension MaintenanceView {
             metaColor: syncMeta.color
         ) {
             switch model.syncState {
-            case .idle where model.collectionFreshness == .current:
-                StatusPill(title: String(localized: .maintenanceUpToDate))
-            case .idle:
+            case .idle, .done:
                 PillButton(
                     title: String(localized: .maintenanceWidgetSyncButton),
                     background: .chActionInstallBg,
                     border: .chActionInstallBorder,
                     foreground: .chActionInstallFg
                 ) {
-                    Task { await model.syncCollection() }
+                    isSyncingIcons = true
+                    Task {
+                        async let icons: Void = imageCache.refreshIconManifest(force: true)
+                        await model.syncCollection()
+                        await icons
+                        isSyncingIcons = false
+                    }
                 }
+                .disabled(isSyncingIcons)
             case .running:
                 WorkingPill(title: String(localized: .maintenanceWidgetSyncRunning))
-            case .done:
-                StatusPill(title: String(localized: .maintenanceWidgetSyncDone))
             }
         }
     }
@@ -346,6 +352,7 @@ struct StatusPill: View {
         catalog: catalog,
         clearImageCache: {}
     ))
+    .environment(ImageCacheService())
     .frame(width: 1100, height: 700)
     .background(WindowBackdrop())
 }

--- a/CaskHub/Views/Shared/CaskIconView.swift
+++ b/CaskHub/Views/Shared/CaskIconView.swift
@@ -51,9 +51,11 @@ struct CaskIconView: View {
             }
         }
         .animation(.easeIn(duration: 0.2), value: loadedImage != nil)
-        .task(id: cask.token) {
+        .task(id: [cask.token, imageCache.iconHash(for: cask.token) ?? "", String(imageCache.iconRefreshRevision)]) {
             didResolve = false
-            loadedImage = await imageCache.image(for: cask)
+            let image = await imageCache.image(for: cask)
+            guard !Task.isCancelled else { return }
+            loadedImage = image
             didResolve = true
         }
     }

--- a/CaskHubTests/Views/IconRefreshTests.swift
+++ b/CaskHubTests/Views/IconRefreshTests.swift
@@ -1,0 +1,289 @@
+//
+//  IconRefreshTests.swift
+//  CaskHubTests
+//
+//  Created by Ali Elsokary on 09/09/2026.
+//  Copyright © 2026 BuildingLink. All rights reserved.
+
+@testable import CaskHub
+import Observation
+import SwiftUI
+import Synchronization
+import XCTest
+
+private final class IconRefreshProtocol: URLProtocol {
+    typealias Handler = @Sendable (URLRequest) async -> Data?
+    static let handler = Mutex<Handler>({ _ in nil })
+    static let requests = Mutex<[URLRequest]>([])
+    private var responseTask: Task<Void, Never>?
+
+    override static func canInit(with _: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        Self.requests.withLock { $0.append(request) }
+        let respond = Self.handler.withLock { $0 }
+        responseTask = Task {
+            guard let data = await respond(request) else {
+                client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+                return
+            }
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+    override func stopLoading() { responseTask?.cancel() }
+}
+
+private actor IconResponseGate {
+    private var continuation: CheckedContinuation<Data?, Never>?
+
+    func wait(started: XCTestExpectation) async -> Data? {
+        await withCheckedContinuation {
+            continuation = $0
+            started.fulfill()
+        }
+    }
+
+    func release(_ data: Data) {
+        continuation?.resume(returning: data)
+        continuation = nil
+    }
+}
+
+@MainActor
+final class IconRefreshTests: XCTestCase {
+    private func png(red: Bool) -> Data {
+        let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: 2, pixelsHigh: 2,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+        )!
+        let pixels = bitmap.bitmapData!
+        for pixel in 0..<4 {
+            pixels[pixel * 4] = red ? 255 : 0
+            pixels[pixel * 4 + 1] = red ? 0 : 255
+            pixels[pixel * 4 + 2] = 0
+            pixels[pixel * 4 + 3] = 255
+        }
+        return bitmap.representation(using: .png, properties: [:])!
+    }
+
+    private func cache(_ directory: URL) -> ImageCacheService {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [IconRefreshProtocol.self]
+        let cache = ImageCacheService(session: URLSession(configuration: config), diskCache: IconDiskCache(directory: directory))
+        return cache
+    }
+
+    private func metadata(hash: String?) throws -> Data {
+        try JSONSerialization.data(withJSONObject: ["version": 1, "hashes": hash.map { ["antinote": $0] } ?? [:]])
+    }
+
+    private func directory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("icon-refresh-\(UUID().uuidString)")
+    }
+
+    func test_git_blob_hash_uses_git_header() {
+        XCTAssertEqual(ImageCacheService.gitBlobHash(Data("hello".utf8)), "b6fc4c620b67d95f953a5c1c1230aaab5db5a1b0")
+    }
+
+    func test_metadata_refresh_replaces_only_changed_icons_and_survives_restart() async throws {
+        let directory = directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let old = png(red: true), fresh = png(red: false)
+        let oldHash = ImageCacheService.gitBlobHash(old), freshHash = ImageCacheService.gitBlobHash(fresh)
+        XCTAssertNotEqual(oldHash, freshHash)
+        let images = cache(directory)
+        images.applyIconManifest(try metadata(hash: oldHash))
+        let disk = IconDiskCache(directory: directory)
+        try await disk.store(old, token: "antinote", generation: 0, fromCaskFlow: true)
+        IconRefreshProtocol.requests.withLock { $0 = [] }
+        IconRefreshProtocol.handler.withLock { $0 = { _ in fresh } }
+        _ = await images.image(for: Cask.preview(token: "antinote"))
+        XCTAssertTrue(IconRefreshProtocol.requests.withLock { $0.isEmpty })
+
+        let observed = expectation(description: "hash observation invalidates view task")
+        withObservationTracking {
+            _ = images.iconHash(for: "antinote")
+        } onChange: { observed.fulfill() }
+        images.applyIconManifest(try metadata(hash: freshHash))
+        await fulfillment(of: [observed], timeout: 2)
+        let image = await images.image(for: Cask.preview(token: "antinote"))
+        XCTAssertNotNil(image)
+        let stored = await disk.loadData(token: "antinote")
+        XCTAssertEqual(stored, fresh)
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.count }, 1)
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.first?.cachePolicy }, .reloadIgnoringLocalCacheData)
+        XCTAssertNil(IconRefreshProtocol.requests.withLock { $0.first?.url?.query })
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.first?.url?.path },
+                       "/gh/alielsokary/CaskFlow@icons/antinote.png")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.appendingPathComponent("icon-hashes.json").path))
+        let reloadedDisk = IconDiskCache(directory: directory)
+        let reloadedBytes = await reloadedDisk.loadData(token: "antinote")
+        let reloadedData = try XCTUnwrap(reloadedBytes)
+        XCTAssertEqual(ImageCacheService.gitBlobHash(reloadedData), freshHash)
+        _ = await images.image(for: Cask.preview(token: "antinote"))
+        let restarted = cache(directory)
+        restarted.applyIconManifest(try metadata(hash: freshHash))
+        _ = await restarted.image(for: Cask.preview(token: "antinote"))
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.count }, 1)
+    }
+
+    func test_legacy_icon_refreshes_once_and_stale_cdn_bytes_use_raw_fallback() async throws {
+        let directory = directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let old = png(red: true), fresh = png(red: false)
+        let hash = ImageCacheService.gitBlobHash(fresh)
+        let images = cache(directory)
+        images.applyIconManifest(try metadata(hash: hash))
+        let disk = IconDiskCache(directory: directory)
+        try await disk.store(old, token: "antinote", generation: 0, fromCaskFlow: true)
+        IconRefreshProtocol.requests.withLock { $0 = [] }
+        IconRefreshProtocol.handler.withLock { $0 = { request in
+            request.url?.host() == "cdn.jsdelivr.net" ? old : fresh
+        } }
+        _ = await images.image(for: Cask.preview(token: "antinote"))
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.compactMap { $0.url?.host() } },
+                       ["cdn.jsdelivr.net", "raw.githubusercontent.com"])
+        let saved = await disk.loadData(token: "antinote")
+        XCTAssertEqual(saved, fresh)
+        _ = await images.image(for: Cask.preview(token: "antinote"))
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.count }, 2)
+    }
+
+    func test_failed_or_stale_download_preserves_old_icon_and_retries() async throws {
+        let directory = directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let old = png(red: true), fresh = png(red: false)
+        let oldHash = ImageCacheService.gitBlobHash(old)
+        let images = cache(directory)
+        images.applyIconManifest(try metadata(hash: ImageCacheService.gitBlobHash(fresh)))
+        let disk = IconDiskCache(directory: directory)
+        try await disk.store(old, token: "antinote", generation: 0, fromCaskFlow: true)
+        for response in [nil, old] as [Data?] {
+            IconRefreshProtocol.handler.withLock { $0 = { _ in response } }
+            let image = await images.image(for: Cask.preview(token: "antinote"))
+            XCTAssertNotNil(image)
+            let saved = await disk.loadData(token: "antinote")
+            XCTAssertEqual(saved, old)
+            XCTAssertEqual(ImageCacheService.gitBlobHash(try XCTUnwrap(saved)), oldHash)
+        }
+        IconRefreshProtocol.handler.withLock { $0 = { _ in fresh } }
+        _ = await images.image(for: Cask.preview(token: "antinote"))
+        let saved = await disk.loadData(token: "antinote")
+        XCTAssertEqual(saved, fresh)
+    }
+
+    func test_late_old_download_cannot_overwrite_new_revision() async throws {
+        let directory = directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let old = png(red: true), fresh = png(red: false)
+        let oldHash = ImageCacheService.gitBlobHash(old), freshHash = ImageCacheService.gitBlobHash(fresh)
+        let images = cache(directory)
+        images.applyIconManifest(try metadata(hash: oldHash))
+        let gate = IconResponseGate()
+        let started = expectation(description: "old download suspended")
+        let first = Mutex(true)
+        IconRefreshProtocol.handler.withLock { $0 = { _ in
+            if first.withLock({ value in defer { value = false }; return value }) {
+                return await gate.wait(started: started)
+            }
+            return fresh
+        } }
+        let oldTask = Task { await images.image(for: Cask.preview(token: "antinote")) }
+        await fulfillment(of: [started], timeout: 3)
+        images.applyIconManifest(try metadata(hash: freshHash))
+        _ = await images.image(for: Cask.preview(token: "antinote"))
+        await gate.release(old)
+        _ = await oldTask.value
+        let disk = IconDiskCache(directory: directory)
+        let data = await disk.loadData(token: "antinote")
+        XCTAssertEqual(data, fresh)
+        XCTAssertEqual(ImageCacheService.gitBlobHash(try XCTUnwrap(data)), freshHash)
+    }
+
+    func test_visible_icon_retries_mismatch_on_independent_manifest_refresh() async throws {
+        let directory = directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let old = png(red: true), fresh = png(red: false)
+        let images = cache(directory)
+        let oldHash = ImageCacheService.gitBlobHash(old)
+        images.applyIconManifest(try metadata(hash: oldHash))
+        let disk = IconDiskCache(directory: directory)
+        try await disk.store(old, token: "antinote", generation: 0, fromCaskFlow: true)
+        IconRefreshProtocol.handler.withLock { $0 = { _ in fresh } }
+        let host = NSHostingView(rootView: CaskIconView(cask: Cask.preview(token: "antinote"))
+            .environment(images))
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 60, height: 60),
+                              styleMask: .borderless, backing: .buffered, defer: false)
+        window.contentView = host
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+        await waitForColor(in: host, red: true)
+        let manifest = try metadata(hash: ImageCacheService.gitBlobHash(fresh))
+        let pngRequests = Mutex(0)
+        let attempted = expectation(description: "both mutable image endpoints returned stale bytes")
+        IconRefreshProtocol.handler.withLock { $0 = { request in
+            if request.url?.lastPathComponent == "icons.json" { return manifest }
+            if pngRequests.withLock({ $0 += 1; return $0 }) == 2 { attempted.fulfill() }
+            return old
+        } }
+        await images.refreshIconManifest(force: true)
+        await fulfillment(of: [attempted], timeout: 5)
+        XCTAssertTrue(containsColor(in: host, red: true))
+        IconRefreshProtocol.handler.withLock { $0 = { request in
+            request.url?.lastPathComponent == "icons.json" ? manifest : fresh
+        } }
+        // The hash stays the same; manual refresh must retry the failed image.
+        await images.refreshIconManifest(force: true)
+        await waitForColor(in: host, red: false)
+    }
+
+    private func waitForColor(in view: NSView, red: Bool) async {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while ContinuousClock.now < deadline {
+            if containsColor(in: view, red: red) { return }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("Expected the visible icon to become \(red ? "red" : "green")")
+    }
+
+    private func containsColor(in view: NSView, red: Bool) -> Bool {
+        view.layoutSubtreeIfNeeded()
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return false }
+        view.cacheDisplay(in: view.bounds, to: bitmap)
+        for row in 0..<bitmap.pixelsHigh {
+            for column in 0..<bitmap.pixelsWide {
+                guard let color = bitmap.colorAt(x: column, y: row)?.usingColorSpace(.deviceRGB) else { continue }
+                if red ? (color.redComponent > 0.8 && color.greenComponent < 0.2)
+                    : (color.greenComponent > 0.8 && color.redComponent < 0.2) { return true }
+            }
+        }
+        return false
+    }
+
+    func test_manifest_refresh_is_independent_throttled_and_preserves_good_data_on_failure() async throws {
+        let directory = directory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let images = cache(directory)
+        let hash = ImageCacheService.gitBlobHash(png(red: false))
+        let manifest = try metadata(hash: hash)
+        IconRefreshProtocol.requests.withLock { $0 = [] }
+        IconRefreshProtocol.handler.withLock { $0 = { _ in manifest } }
+        await images.refreshIconManifest()
+        await images.refreshIconManifest()
+        XCTAssertEqual(images.iconHash(for: "antinote"), hash)
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.count }, 1)
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.first?.url?.path },
+                       "/alielsokary/CaskFlow/icons/icons.json")
+        for data in [nil, Data("{}".utf8), Data(#"{"version":2,"hashes":{}}"#.utf8),
+                     try metadata(hash: "invalid")] as [Data?] {
+            IconRefreshProtocol.handler.withLock { $0 = { _ in data } }
+            await images.refreshIconManifest(force: true)
+            XCTAssertEqual(images.iconHash(for: "antinote"), hash)
+        }
+        XCTAssertEqual(IconRefreshProtocol.requests.withLock { $0.count }, 5)
+    }
+}

--- a/CaskHubTests/Views/MaintenanceViewTests.swift
+++ b/CaskHubTests/Views/MaintenanceViewTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class MaintenanceViewTests: XCTestCase {
     @MainActor
     func test_page_renders_before_first_checkup() {
-        render(MaintenanceView(model: makeMaintenanceModel()))
+        render(MaintenanceView(model: makeMaintenanceModel()).environment(ImageCacheService()))
     }
 
     @MainActor
@@ -33,7 +33,7 @@ final class MaintenanceViewTests: XCTestCase {
         let model = makeMaintenanceModel(probe: probe)
         await model.runCheckup()
 
-        render(MaintenanceView(model: model))
+        render(MaintenanceView(model: model).environment(ImageCacheService()))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Refresh changed cached icons using CaskFlow's independent `icons.json`, with no hash fields in category metadata and no new service. For example, a cached old Antinote icon is replaced when its advertised hash changes, while matching icons are reused.

The existing image service checks the manifest at startup, on foreground activation with a 15-minute throttle, and through Health > Sync now. Sync now remains available when categories are current. Downloads keep the existing mutable image URLs, verify the original PNG bytes, and retain the previous icon on errors or mismatches. A later image load or refresh retries stale icons, even when the manifest hash is unchanged.

The cached PNG itself identifies its persisted version; no separate hash file is needed. Cancellation and cache-generation checks prevent late requests from replacing newer icons. An unavailable or unsupported manifest preserves legacy behavior or the last valid in-memory manifest.

## Verification

Companion publisher PR: https://github.com/alielsokary/CaskFlow/pull/149

- Full suite: 489 tests passed, including disk reuse after restart, stale CDN fallback, mismatch retry, late-response protection, manifest throttling, and hosted UI replacement.
- Strict SwiftLint passed; signed build and fresh app launch passed.
- Proxyman confirmed startup and manual requests to `icons.json` independently of category freshness. Temporary response rules were removed.
- Rebased onto current `develop` without conflicts; intervening changes only affect the README and website assets.

## Checklist

- [x] Base branch is `develop` (not `master`)
- [x] Title uses a conventional prefix + Sentence-case subject
- [x] Tests added or updated
- [x] SwiftLint passes locally
- [x] No changes to `CaskHub/Resources/*.json` or `CHANGELOG.md`

Direction was requested and approved by the repository maintainer; no separate issue was opened.
